### PR TITLE
Add claim-check flow plus recursion limit tweaks

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -8,8 +8,11 @@ from typing import Any, Literal
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import RetryPolicy
 
-from opentulpa.agent.lc_messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from opentulpa.agent.lc_messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.models import AgentState
+from opentulpa.agent.utils import (
+    content_to_text as _content_to_text,
+)
 from opentulpa.agent.utils import (
     extract_relative_delay_minutes as _extract_relative_delay_minutes,
 )
@@ -401,14 +404,105 @@ def build_runtime_graph(runtime: Any):
             update["last_tool_error"] = "tool execution failed"
         return update
 
-    def route_after_agent(state: AgentState) -> Literal["validate_tools", END]:
+    def _latest_turn_messages(messages: list[AnyMessage]) -> list[AnyMessage]:
+        if not messages:
+            return []
+        start = 0
+        for idx in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[idx], HumanMessage):
+                start = idx
+                break
+        return messages[start:]
+
+    def _collect_recent_tool_outputs(turn_messages: list[AnyMessage]) -> list[str]:
+        if not turn_messages:
+            return []
+        outputs: list[str] = []
+        for msg in turn_messages:
+            if isinstance(msg, ToolMessage):
+                text = _content_to_text(getattr(msg, "content", "")).strip()
+                if text:
+                    outputs.append(text)
+        return outputs
+
+    def _serialize_turn_window(turn_messages: list[AnyMessage]) -> str:
+        parts: list[str] = []
+        for msg in turn_messages:
+            if isinstance(msg, HumanMessage):
+                role = "user"
+            elif isinstance(msg, AIMessage):
+                role = "assistant"
+            elif isinstance(msg, ToolMessage):
+                role = "tool"
+            else:
+                continue
+            text = _content_to_text(getattr(msg, "content", "")).strip()
+            if not text:
+                continue
+            chunk = f"[{role}] {text}"
+            parts.append(chunk)
+        return "\n".join(parts)
+
+    async def claim_check_node(state: AgentState) -> dict[str, Any]:
         messages = state.get("messages", [])
         if not messages:
-            return END
+            return {"claim_check_needs_retry": False}
+        last = messages[-1]
+        if not isinstance(last, AIMessage) or last.tool_calls:
+            return {"claim_check_needs_retry": False}
+
+        retry_count = int(state.get("claim_check_retry_count", 0))
+        if retry_count >= 1:
+            return {"claim_check_needs_retry": False}
+
+        assistant_text = _content_to_text(getattr(last, "content", "")).strip()
+        if not assistant_text:
+            return {"claim_check_needs_retry": False}
+
+        turn_messages = _latest_turn_messages(messages)
+        if not turn_messages:
+            return {"claim_check_needs_retry": False}
+        user_text = _content_to_text(getattr(turn_messages[0], "content", "")).strip()
+        recent_tool_outputs = _collect_recent_tool_outputs(turn_messages)
+        turn_window = _serialize_turn_window(turn_messages)
+        verdict = await runtime.verify_completion_claim(
+            user_text=user_text,
+            assistant_text=assistant_text,
+            recent_tool_outputs=recent_tool_outputs,
+            turn_window=turn_window,
+        )
+        mismatch = bool(verdict.get("mismatch", False))
+        if not mismatch:
+            return {
+                "claim_check_needs_retry": False,
+                "claim_check_retry_count": 0,
+            }
+
+        reason = str(verdict.get("reason", "")).strip()[:180]
+        repair = str(verdict.get("repair_instruction", "")).strip()[:220]
+        note = (
+            "SELF_CHECK_FAILED: Your last reply likely claimed an immediate action was done "
+            "without confirmed tool evidence in this turn. "
+            "Do not repeat the claim. Either execute the required tool now or state pending status clearly."
+        )
+        if reason:
+            note += f" Reason={reason}."
+        if repair:
+            note += f" Fix={repair}."
+        return {
+            "messages": [SystemMessage(content=note)],
+            "claim_check_needs_retry": True,
+            "claim_check_retry_count": retry_count + 1,
+        }
+
+    def route_after_agent(state: AgentState) -> Literal["validate_tools", "claim_check"]:
+        messages = state.get("messages", [])
+        if not messages:
+            return "claim_check"
         last = messages[-1]
         if isinstance(last, AIMessage) and last.tool_calls:
             return "validate_tools"
-        return END
+        return "claim_check"
 
     async def guardrail_precheck_node(state: AgentState) -> dict[str, Any]:
         messages = state.get("messages", [])
@@ -541,12 +635,22 @@ def build_runtime_graph(runtime: Any):
             approval_id = str(result.get("approval_id", "")).strip()
             summary = str(result.get("summary", f"execute {call_name}")).strip()
             reason = str(result.get("reason", "approval_required")).strip()
+            delivery_mode = str(result.get("delivery_mode", "")).strip()
             if approval_id:
-                content = (
-                    "APPROVAL_PENDING: This action is blocked until user approval. "
-                    f"approval_id={approval_id}; summary={summary}; reason={reason}. "
-                    "After approval, call guardrail_execute_approved_action with this approval_id."
-                )
+                if delivery_mode:
+                    content = (
+                        "APPROVAL_PENDING: This action is blocked until user approval. "
+                        f"approval_id={approval_id}; summary={summary}; reason={reason}. "
+                        "After approval, call guardrail_execute_approved_action with this approval_id."
+                    )
+                else:
+                    content = (
+                        "APPROVAL_PENDING: This action is blocked until user approval, but no push prompt "
+                        "was delivered automatically. "
+                        f"approval_id={approval_id}; summary={summary}; reason={reason}. "
+                        f"Ask the user to approve manually with /approve {approval_id} (or deny with /deny {approval_id}). "
+                        "After approval, call guardrail_execute_approved_action with this approval_id."
+                    )
             else:
                 if reason.startswith("already_executed_recent_"):
                     content = (
@@ -587,6 +691,11 @@ def build_runtime_graph(runtime: Any):
             return "tools"
         return "agent"
 
+    def route_after_claim_check(state: AgentState) -> Literal["agent", END]:
+        if bool(state.get("claim_check_needs_retry", False)):
+            return "agent"
+        return END
+
     builder = StateGraph(AgentState)
     builder.add_node("agent", agent_node, retry_policy=RetryPolicy(max_attempts=3))
     builder.add_node(
@@ -600,11 +709,13 @@ def build_runtime_graph(runtime: Any):
         retry_policy=RetryPolicy(max_attempts=2),
     )
     builder.add_node("tools", tools_node, retry_policy=RetryPolicy(max_attempts=2))
+    builder.add_node("claim_check", claim_check_node, retry_policy=RetryPolicy(max_attempts=2))
     builder.add_edge(START, "agent")
-    builder.add_conditional_edges("agent", route_after_agent, ["validate_tools", END])
+    builder.add_conditional_edges("agent", route_after_agent, ["validate_tools", "claim_check"])
     builder.add_conditional_edges(
         "validate_tools", route_after_validate, ["guardrail_precheck", "agent"]
     )
     builder.add_conditional_edges("guardrail_precheck", route_after_guardrail, ["tools", "agent"])
     builder.add_edge("tools", "agent")
+    builder.add_conditional_edges("claim_check", route_after_claim_check, ["agent", END])
     return builder.compile(checkpointer=runtime._checkpointer)

--- a/src/opentulpa/agent/models.py
+++ b/src/opentulpa/agent/models.py
@@ -24,3 +24,5 @@ class AgentState(TypedDict, total=False):
     action_notes_by_action: dict[str, str]
     tool_error_count: int
     last_tool_error: str
+    claim_check_needs_retry: bool
+    claim_check_retry_count: int

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -914,7 +914,7 @@ class OpenTulpaLangGraphRuntime:
                 user_text=merged_text,
             )
             effective_recursion_limit = (
-                max(5, min(int(recursion_limit_override), 64))
+                max(5, min(int(recursion_limit_override), 200))
                 if recursion_limit_override is not None
                 else self.recursion_limit
             )
@@ -928,6 +928,8 @@ class OpenTulpaLangGraphRuntime:
                     "customer_id": customer_id,
                     "thread_id": thread_id,
                     "tool_error_count": 0,
+                    "claim_check_retry_count": 0,
+                    "claim_check_needs_retry": False,
                     **skill_state,
                 },
                 config=config,
@@ -1042,6 +1044,8 @@ class OpenTulpaLangGraphRuntime:
                     "customer_id": customer_id,
                     "thread_id": thread_id,
                     "tool_error_count": 0,
+                    "claim_check_retry_count": 0,
+                    "claim_check_needs_retry": False,
                     **skill_state,
                 },
                 config=config,
@@ -1093,6 +1097,8 @@ class OpenTulpaLangGraphRuntime:
                         "customer_id": customer_id,
                         "thread_id": thread_id,
                         "tool_error_count": 0,
+                        "claim_check_retry_count": 0,
+                        "claim_check_needs_retry": False,
                         **skill_state,
                     },
                     config=config,
@@ -1177,6 +1183,93 @@ class OpenTulpaLangGraphRuntime:
         except Exception as exc:
             return {"notify_user": False, "reason": f"classifier_error:{exc}"}
 
+    async def verify_completion_claim(
+        self,
+        *,
+        user_text: str,
+        assistant_text: str,
+        recent_tool_outputs: list[str],
+        turn_window: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Verify that immediate-action completion claims are supported by tool evidence.
+
+        This check is intentionally conservative: on uncertainty it should not force a retry.
+        """
+        safe_assistant = str(assistant_text or "").strip()
+        if not safe_assistant:
+            return {
+                "ok": True,
+                "applies": False,
+                "mismatch": False,
+                "confidence": 0.0,
+                "reason": "empty_assistant_text",
+                "repair_instruction": "",
+            }
+        safe_user = str(user_text or "").strip()
+        safe_turn_window = str(turn_window or "").strip()
+        safe_tools: list[str] = []
+        for raw in (recent_tool_outputs or []):
+            text = " ".join(str(raw or "").split()).strip()
+            if text:
+                safe_tools.append(text)
+
+        try:
+            response = await self._guardrail_classifier_model.ainvoke(
+                [
+                    SystemMessage(
+                        content=(
+                            "You verify assistant execution claims against tool evidence.\n"
+                            "Return strict JSON only with keys:\n"
+                            "ok (bool), applies (bool), mismatch (bool), confidence (0..1), "
+                            "reason (string <= 180 chars), repair_instruction (string <= 220 chars).\n"
+                            "Decision policy (conservative, non-aggressive):\n"
+                            "- applies=true only if assistant explicitly claims something was already done/launched/sent/posted/scheduled now.\n"
+                            "- If assistant is future-tense, conditional, or says approval is pending, set applies=false and mismatch=false.\n"
+                            "- mismatch=true only when there is a clear immediate completion claim without matching success evidence in tool outputs.\n"
+                            "- If evidence is ambiguous/partial, prefer mismatch=false.\n"
+                            "- If tool outputs show approval pending, denial, or tool error while assistant claims success now, mismatch=true.\n"
+                            "- repair_instruction should tell the agent to either run the missing tool now or restate status honestly.\n"
+                            "No markdown. No extra keys."
+                        )
+                    ),
+                    HumanMessage(
+                        content=(
+                            f"user_message={safe_user}\n"
+                            f"assistant_message={safe_assistant}\n"
+                            f"turn_window={safe_turn_window}\n"
+                            f"recent_tool_outputs={json.dumps(safe_tools, ensure_ascii=False)}"
+                        )
+                    ),
+                ]
+            )
+            raw = response.content if hasattr(response, "content") else str(response)
+            raw_text = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
+            parsed = self._extract_json_object(raw_text) or {}
+            applies = bool(parsed.get("applies", False))
+            mismatch = bool(parsed.get("mismatch", False)) if applies else False
+            try:
+                confidence = float(parsed.get("confidence", 0.0))
+            except Exception:
+                confidence = 0.0
+            return {
+                "ok": bool(parsed.get("ok", True)),
+                "applies": applies,
+                "mismatch": mismatch,
+                "confidence": max(0.0, min(confidence, 1.0)),
+                "reason": str(parsed.get("reason", "")).strip()[:180],
+                "repair_instruction": str(parsed.get("repair_instruction", "")).strip()[:220],
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "applies": False,
+                "mismatch": False,
+                "confidence": 0.0,
+                "reason": f"classifier_error:{exc}",
+                "repair_instruction": "",
+            }
+
     async def classify_guardrail_intent(
         self,
         *,
@@ -1240,6 +1333,11 @@ class OpenTulpaLangGraphRuntime:
                             "default to gate=allow, impact_type=read, recipient_scope=self.\n"
                             "- Internal system management (routine_delete, automation_delete, routine_list, "
                             "uploaded_file_search/get/analyze, local context/memory reads) should be allow.\n"
+                            "- For routine_create:\n"
+                            "  * If the routine can cause external side effects (posting/sending/mutating external services), "
+                            "set gate=require_approval.\n"
+                            "  * If the routine is internal-only (research, summarization, reminders/check-ins to the same user), "
+                            "set gate=allow.\n"
                             "- Use require_approval only for actions that can affect external systems/accounts/users "
                             "(posting, sending, purchasing, mutating external services) or when uncertainty is high.\n"
                             "- If uncertain between allow vs require_approval, prefer require_approval only when "

--- a/src/opentulpa/api/routes/telegram_webhook.py
+++ b/src/opentulpa/api/routes/telegram_webhook.py
@@ -122,13 +122,12 @@ async def _execute_approved_action_and_summarize(
                     f"failure_result={payload_preview}\n\n"
                     "Instructions:\n"
                     "1) Retry/fix on your own using tools.\n"
-                    "2) Work within a maximum of 10 internal tool steps.\n"
-                    "3) If resolved, report final success + deliverable.\n"
-                    "4) If not resolved within step budget, report what you tried and ask user whether to continue.\n"
+                    "2) If resolved, report final success + deliverable.\n"
+                    "3) If still unresolved after substantial attempts, report what you tried and ask user whether to continue.\n"
                     "Do not leak internal JSON or system internals."
                 ),
                 include_pending_context=False,
-                recursion_limit_override=10,
+                recursion_limit_override=48,
             )
             recovered = str(recovery_text or "").strip()
             if recovered:

--- a/src/opentulpa/approvals/broker.py
+++ b/src/opentulpa/approvals/broker.py
@@ -145,11 +145,11 @@ class ApprovalBroker:
             action_args_json=args_json,
         )
         if duplicate is not None:
-            delivery_mode = await self._deliver_challenge(duplicate)
             decision.approval_id = duplicate.id
             decision.status = duplicate.status
             decision.expires_at = duplicate.expires_at
-            decision.delivery_mode = delivery_mode
+            # Reuse existing pending approval without sending duplicate prompts.
+            decision.delivery_mode = "existing_pending"
             return self._evaluator.as_dict(decision)
 
         # Reuse recent non-pending decisions for exact same action intent.
@@ -189,11 +189,11 @@ class ApprovalBroker:
             )
             if recent_browser is not None:
                 if recent_browser.status == "pending":
-                    delivery_mode = await self._deliver_challenge(recent_browser)
                     decision.approval_id = recent_browser.id
                     decision.status = recent_browser.status
                     decision.expires_at = recent_browser.expires_at
-                    decision.delivery_mode = delivery_mode
+                    # Reuse existing pending approval without sending duplicate prompts.
+                    decision.delivery_mode = "existing_pending"
                     return self._evaluator.as_dict(decision)
                 if recent_browser.status == "approved":
                     decision.gate = "allow"

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
         description="SQLite path for LangGraph thread checkpoints.",
     )
     agent_recursion_limit: int = Field(
-        default=30,
+        default=80,
         ge=5,
         le=200,
         description="Maximum LangGraph steps per turn.",

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -403,7 +403,7 @@ async def relay_event_via_main_agent(
                 customer_id=customer_id,
                 text=instruction,
                 include_pending_context=False,
-                recursion_limit_override=12 if proactive_heartbeat else None,
+                recursion_limit_override=36 if proactive_heartbeat else None,
             )
             safe = str(text or "").strip()
             if not safe:

--- a/tests/test_approval_broker.py
+++ b/tests/test_approval_broker.py
@@ -187,7 +187,8 @@ async def test_external_action_requires_approval_and_reuses_pending(
     assert first["gate"] == "require_approval"
     assert second["gate"] == "require_approval"
     assert first["approval_id"] == second["approval_id"]
-    assert len(adapter.sent) == 2
+    assert len(adapter.sent) == 1
+    assert second.get("delivery_mode") == "existing_pending"
 
 
 @pytest.mark.asyncio

--- a/tests/test_completion_claim_check.py
+++ b/tests/test_completion_claim_check.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeModel:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    async def ainvoke(self, _messages: object) -> _FakeResponse:
+        return _FakeResponse(self._content)
+
+
+class _FailingModel:
+    async def ainvoke(self, _messages: object) -> _FakeResponse:
+        raise RuntimeError("model_down")
+
+
+def _mk_runtime_with_model(model: object) -> OpenTulpaLangGraphRuntime:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._guardrail_classifier_model = model
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_verify_completion_claim_flags_mismatch_when_supported() -> None:
+    runtime = _mk_runtime_with_model(
+        _FakeModel(
+            (
+                '{"ok": true, "applies": true, "mismatch": true, "confidence": 0.91, '
+                '"reason": "claimed_sent_without_tool_success", '
+                '"repair_instruction": "run the missing tool first"}'
+            )
+        )
+    )
+
+    result = await runtime.verify_completion_claim(
+        user_text="send that file now",
+        assistant_text="I sent the file.",
+        recent_tool_outputs=[],
+    )
+
+    assert result["mismatch"] is True
+    assert result["applies"] is True
+    assert result["confidence"] == pytest.approx(0.91)
+
+
+@pytest.mark.asyncio
+async def test_verify_completion_claim_is_conservative_when_not_applicable() -> None:
+    runtime = _mk_runtime_with_model(
+        _FakeModel(
+            (
+                '{"ok": true, "applies": false, "mismatch": true, "confidence": 0.8, '
+                '"reason": "future_tense", "repair_instruction": "none"}'
+            )
+        )
+    )
+
+    result = await runtime.verify_completion_claim(
+        user_text="set a schedule",
+        assistant_text="I will run this at 16:00.",
+        recent_tool_outputs=[],
+    )
+
+    assert result["applies"] is False
+    assert result["mismatch"] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_completion_claim_fails_open_on_classifier_error() -> None:
+    runtime = _mk_runtime_with_model(_FailingModel())
+
+    result = await runtime.verify_completion_claim(
+        user_text="post now",
+        assistant_text="Done, posted.",
+        recent_tool_outputs=[],
+    )
+
+    assert result["ok"] is False
+    assert result["mismatch"] is False
+    assert "classifier_error" in result["reason"]

--- a/tests/test_telegram_approval_recovery.py
+++ b/tests/test_telegram_approval_recovery.py
@@ -74,4 +74,4 @@ async def test_failed_approved_action_uses_autonomous_recovery_message() -> None
     assert "auth link" in out.lower()
     ainvoke_calls = [c for c in runtime.calls if c.get("kind") == "ainvoke"]
     assert len(ainvoke_calls) == 1
-    assert ainvoke_calls[0].get("recursion_limit_override") == 10
+    assert ainvoke_calls[0].get("recursion_limit_override") == 48


### PR DESCRIPTION
Summary
- add a completion claim guardrail node that verifies assistant statements against recent tool evidence and retries when mismatch detected
- reuse existing pending approvals without re-delivery, enhance recursion/config limits, and beef up verification tooling with tests
- extend runtime state tracking for the new guardrail and serialize contexts for classifier inputs

Testing
- Not run (not requested)