### PR TITLE
Trace LLM calls and compact recent tool context

### DIFF
--- a/scripts/inspect_llm_call_traces.py
+++ b/scripts/inspect_llm_call_traces.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _list_records(records: list[dict[str, Any]], *, limit: int) -> str:
+    lines: list[str] = []
+    for record in records[-max(1, int(limit)) :]:
+        lines.append(
+            " | ".join(
+                [
+                    str(record.get("ts", "")),
+                    str(record.get("trace_id", "")) or "-",
+                    str(record.get("call_site", "")) or "-",
+                    str(record.get("model_name", "")) or "-",
+                    f"prompt={record.get('native_tokens_prompt') or '-'}",
+                    f"completion={record.get('native_tokens_completion') or '-'}",
+                ]
+            )
+        )
+    return "\n".join(lines).strip()
+
+
+def _decompose_record(record: dict[str, Any]) -> str:
+    lines = [
+        f"ts: {record.get('ts', '')}",
+        f"trace_id: {record.get('trace_id', '')}",
+        f"call_site: {record.get('call_site', '')}",
+        f"model_name: {record.get('model_name', '')}",
+        f"thread_id: {record.get('thread_id', '')}",
+        f"customer_id: {record.get('customer_id', '')}",
+        f"turn_mode: {record.get('turn_mode', '')}",
+        f"prompt_mode: {record.get('prompt_mode', '')}",
+        f"stable_prefix_count: {record.get('stable_prefix_count', 0)}",
+        f"prompt_sections: {', '.join(record.get('prompt_sections') or [])}",
+        f"prompt_overhead_tokens: {record.get('prompt_overhead_tokens', '')}",
+        f"history_message_count: {record.get('history_message_count', '')}",
+        f"raw_chat_history_count: {record.get('raw_chat_history_count', '')}",
+        f"raw_tool_history_count: {record.get('raw_tool_history_count', '')}",
+        f"optional_context_messages: {record.get('optional_context_messages', '')}",
+        f"native_tokens_prompt: {record.get('native_tokens_prompt', '')}",
+        f"native_tokens_completion: {record.get('native_tokens_completion', '')}",
+        "",
+        "Prompt messages:",
+    ]
+    for idx, message in enumerate(record.get("prompt_messages") or []):
+        if not isinstance(message, dict):
+            continue
+        lines.append(
+            f"{idx:02d}. role={message.get('role', '')} "
+            f"type={message.get('type', '')} "
+            f"approx_tokens={message.get('approx_tokens', '')}"
+        )
+        text = str(message.get("text", "") or "")
+        if text:
+            lines.append(text)
+        else:
+            lines.append(json.dumps(message.get("content"), ensure_ascii=False))
+        lines.append("")
+    lines.extend(
+        [
+            "Response text:",
+            str(record.get("response_text", "") or ""),
+        ]
+    )
+    response_tool_calls = record.get("response_tool_calls")
+    if response_tool_calls:
+        lines.extend(
+            [
+                "",
+                "Response tool calls:",
+                json.dumps(response_tool_calls, ensure_ascii=False, indent=2),
+            ]
+        )
+    error = str(record.get("error", "") or "").strip()
+    if error:
+        lines.extend(["", f"Error: {error}"])
+    return "\n".join(lines).strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect local OpenTulpa LLM call traces.")
+    parser.add_argument(
+        "--path",
+        default=".opentulpa/logs/llm_call_traces.jsonl",
+        help="Path to the local LLM call trace JSONL file.",
+    )
+    parser.add_argument("--limit", type=int, default=10, help="How many recent records to list.")
+    parser.add_argument("--trace-id", default="", help="Trace id to inspect in full.")
+    parser.add_argument("--latest", action="store_true", help="Show the latest record in full.")
+    args = parser.parse_args()
+
+    path = Path(args.path).resolve()
+    records = _load_records(path)
+    if not records:
+        print(f"No records found at {path}")
+        return 1
+    if args.trace_id:
+        for record in reversed(records):
+            if str(record.get("trace_id", "")).strip() == str(args.trace_id).strip():
+                print(_decompose_record(record))
+                return 0
+        print(f"Trace id not found: {args.trace_id}")
+        return 1
+    if args.latest:
+        print(_decompose_record(records[-1]))
+        return 0
+    print(_list_records(records, limit=args.limit))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/opentulpa/agent/context_compaction.py
+++ b/src/opentulpa/agent/context_compaction.py
@@ -179,7 +179,13 @@ async def compress_rollup(runtime: Any, existing_rollup: str, additional_text: s
         ]
         ainvoke_model = getattr(runtime, "ainvoke_model", None)
         if callable(ainvoke_model):
-            response = await ainvoke_model(runtime._model, messages)
+            response = await ainvoke_model(
+                runtime._model,
+                messages,
+                call_context={
+                    "call_site": "context_compaction",
+                },
+            )
         else:
             response = await runtime._model.ainvoke(messages)
         running = _sanitize_rollup_text(_content_to_text(getattr(response, "content", "")).strip() or running)

--- a/src/opentulpa/agent/context_engineer.py
+++ b/src/opentulpa/agent/context_engineer.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from typing import Any
 
 from opentulpa.agent.lc_messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from opentulpa.agent.tool_parser import compact_tool_call_record as _compact_tool_call_record
+from opentulpa.agent.tool_parser import compact_tool_payload as _compact_tool_payload
 from opentulpa.agent.utils import (
     approx_tokens as _approx_tokens,
 )
@@ -90,6 +91,26 @@ class ContextEngineer:
                 ids.append(call_id)
         return ids
 
+    @staticmethod
+    def _latest_tool_call_ids(messages: list[AnyMessage], *, limit: int = 5) -> set[str]:
+        latest_ids: list[str] = []
+        seen: set[str] = set()
+        max_items = max(1, int(limit))
+        for message in reversed(messages):
+            if isinstance(message, ToolMessage):
+                call_id = str(getattr(message, "tool_call_id", "") or "").strip()
+                if call_id and call_id not in seen:
+                    seen.add(call_id)
+                    latest_ids.append(call_id)
+            elif isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
+                for call_id in reversed(ContextEngineer._tool_call_ids(message)):
+                    if call_id and call_id not in seen:
+                        seen.add(call_id)
+                        latest_ids.append(call_id)
+            if len(latest_ids) >= max_items:
+                break
+        return set(latest_ids[:max_items])
+
     def _protected_suffix_indices(self, messages: list[AnyMessage]) -> set[int]:
         protected: set[int] = set()
         idx = len(messages) - 1
@@ -117,48 +138,22 @@ class ContextEngineer:
             break
         return protected
 
-    @staticmethod
-    def _summarize_jsonish_text(text: str, *, limit: int) -> str:
-        raw = str(text or "").strip()
-        if not raw:
-            return ""
-        parsed: Any = None
-        if raw.startswith("{") or raw.startswith("["):
-            try:
-                parsed = json.loads(raw)
-            except Exception:
-                parsed = None
-        if isinstance(parsed, dict):
-            high_signal: dict[str, Any] = {}
-            for key in (
-                "status",
-                "error",
-                "message",
-                "result",
-                "tool_name",
-                "approval_id",
-                "workflow_id",
-                "routine_id",
-            ):
-                value = parsed.get(key)
-                if value not in (None, "", [], {}):
-                    high_signal[key] = value
-            if not high_signal:
-                keys = [str(key) for key in list(parsed.keys())[:10]]
-                high_signal = {"keys": keys}
-            raw = json.dumps(high_signal, ensure_ascii=False)
-        elif isinstance(parsed, list):
-            raw = json.dumps({"items": len(parsed)}, ensure_ascii=False)
-        max_chars = max(120, int(limit))
-        if len(raw) <= max_chars:
-            return raw
-        return raw[: max_chars - 3].rstrip() + "..."
-
-    def _summarize_stale_messages(self, messages: list[AnyMessage]) -> str:
+    def _summarize_stale_messages(
+        self,
+        messages: list[AnyMessage],
+        *,
+        latest_tool_call_ids: set[str] | None = None,
+    ) -> str:
         if not messages:
             return ""
         parts: list[str] = []
         tool_calls_by_id: dict[str, dict[str, Any]] = {}
+        latest_tool_call_ids = set(latest_tool_call_ids or ())
+        result_ids = {
+            str(getattr(message, "tool_call_id", "") or "").strip()
+            for message in messages
+            if isinstance(message, ToolMessage) and str(getattr(message, "tool_call_id", "") or "").strip()
+        }
         for message in messages:
             if isinstance(message, HumanMessage):
                 text = trim_text_to_token_budget(_content_to_text(getattr(message, "content", "")), token_budget=80)
@@ -177,11 +172,21 @@ class ContextEngineer:
                         args = call.get("args")
                         tool_calls_by_id[call_id] = {
                             "name": str(call.get("name", "") or "").strip() or "tool",
-                            "args": self._summarize_jsonish_text(
-                                json.dumps(args, ensure_ascii=False) if isinstance(args, (dict, list)) else str(args or ""),
-                                limit=220,
+                            "args": _compact_tool_payload(
+                                args,
+                                value_char_limit=None if call_id in latest_tool_call_ids else 100,
                             ),
                         }
+                        if call_id in latest_tool_call_ids and call_id not in result_ids:
+                            parts.append(
+                                _compact_tool_call_record(
+                                    tool_name=tool_calls_by_id[call_id]["name"],
+                                    args=tool_calls_by_id[call_id]["args"],
+                                    result="",
+                                    args_value_char_limit=None,
+                                    result_value_char_limit=None,
+                                )
+                            )
                     names = ", ".join(
                         sorted({tool_calls_by_id[call_id]["name"] for call_id in tool_calls_by_id if call_id})
                     )
@@ -196,16 +201,13 @@ class ContextEngineer:
                 tool_call_id = str(getattr(message, "tool_call_id", "") or "").strip()
                 call = tool_calls_by_id.get(tool_call_id, {})
                 tool_name = str(call.get("name", "") or "").strip() or "tool"
-                args_text = str(call.get("args", "") or "").strip()
-                result_text = self._summarize_jsonish_text(
-                    _content_to_text(getattr(message, "content", "")),
-                    limit=260,
+                line = _compact_tool_call_record(
+                    tool_name=tool_name,
+                    args=call.get("args", ""),
+                    result=_content_to_text(getattr(message, "content", "")),
+                    args_value_char_limit=None,
+                    result_value_char_limit=None if tool_call_id in latest_tool_call_ids else 100,
                 )
-                line = f"Tool {tool_name}"
-                if args_text:
-                    line += f" args={args_text}"
-                if result_text:
-                    line += f" -> {result_text}"
                 parts.append(line)
         joined = "\n".join(parts).strip()
         return trim_text_to_token_budget(joined, token_budget=self.stale_summary_token_budget)
@@ -260,7 +262,11 @@ class ContextEngineer:
             if not matching_tool_indices.issubset(keep_indices):
                 keep_indices.discard(idx)
         stale_messages = [msg for idx, msg in enumerate(messages) if idx not in keep_indices]
-        summary_text = self._summarize_stale_messages(stale_messages)
+        latest_tool_call_ids = self._latest_tool_call_ids(messages, limit=5)
+        summary_text = self._summarize_stale_messages(
+            stale_messages,
+            latest_tool_call_ids=latest_tool_call_ids,
+        )
         summary_tokens = min(self.stale_summary_token_budget, max(0, budget // 4))
         summary_text = trim_text_to_token_budget(summary_text, token_budget=summary_tokens) if summary_text else ""
         raw_budget = max(200, budget - (_approx_tokens(summary_text) if summary_text else 0))

--- a/src/opentulpa/agent/file_analysis.py
+++ b/src/opentulpa/agent/file_analysis.py
@@ -35,7 +35,11 @@ _VIDEO_FALLBACK_DURATION_SECONDS = 120
 async def _ainvoke_runtime_model(runtime: Any, messages: list[Any]) -> Any:
     ainvoke_model = getattr(runtime, "ainvoke_model", None)
     if callable(ainvoke_model):
-        return await ainvoke_model(runtime._model, messages)
+        return await ainvoke_model(
+            runtime._model,
+            messages,
+            call_context={"call_site": "file_analysis"},
+        )
     return await runtime._model.ainvoke(messages)
 
 
@@ -61,7 +65,12 @@ async def _ainvoke_selected_runtime_model(
         raise RuntimeError("runtime model unavailable")
     ainvoke_model = getattr(runtime, "ainvoke_model", None)
     if callable(ainvoke_model):
-        return await ainvoke_model(model, messages, model_name=model_name)
+        return await ainvoke_model(
+            model,
+            messages,
+            model_name=model_name,
+            call_context={"call_site": "file_analysis"},
+        )
     return await model.ainvoke(messages)
 
 

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -990,6 +990,22 @@ def build_runtime_graph(runtime: Any):
         assert model_with_tools is not None
         ainvoke_fn = getattr(runtime, "ainvoke_model", None)
         if callable(ainvoke_fn):
+            call_context = {
+                "call_site": "graph_agent",
+                "trace_id": state.get("agent_trace_id"),
+                "thread_id": thread_id,
+                "customer_id": customer_id,
+                "turn_mode": turn_mode,
+                "prompt_mode": prompt_mode,
+                "prompt_sections": prompt_section_names,
+                "stable_prefix_count": stable_prompt_count,
+                "prompt_overhead_tokens": prompt_overhead_tokens,
+                "history_message_count": len(bounded_messages),
+                "raw_chat_history_count": history_working_set.raw_chat_count,
+                "raw_tool_history_count": history_working_set.raw_tool_count,
+                "protected_history_count": history_working_set.protected_count,
+                "optional_context_messages": max(0, len(prompt_messages) - len(prompt_messages_base)),
+            }
             model_messages: list[AnyMessage]
             if memory_grounding_message is not None:
                 latest_turn = _latest_turn_messages(bounded_messages)
@@ -1016,6 +1032,7 @@ def build_runtime_graph(runtime: Any):
                 model_with_tools,
                 model_messages,
                 stable_prefix_count=stable_prompt_count,
+                call_context=call_context,
             )
         else:
             model_messages = (

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -120,6 +120,17 @@ _MEMORY_GROUNDING_KIND_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
 _LLM_CALL_TRACE_LIMIT = 100
 
 
+def _redact_inline_trace_string(value: str) -> str:
+    raw = str(value)
+    if not raw.lower().startswith("data:"):
+        return raw
+    if ";base64," in raw:
+        prefix, _, _ = raw.partition(";base64,")
+        return f"{prefix};base64,[redacted]"
+    prefix, _, _ = raw.partition(",")
+    return f"{prefix},[redacted]"
+
+
 def _prompt_cache_control_payload(*, ttl_1h: bool) -> dict[str, Any]:
     cc: dict[str, Any] = {"type": "ephemeral"}
     if ttl_1h:
@@ -218,19 +229,28 @@ def _provider_prompt_cache_invoke_extras(
 
 
 def _json_safe(value: Any) -> Any:
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if value is None or isinstance(value, (int, float, bool)):
         return value
+    if isinstance(value, str):
+        return _redact_inline_trace_string(value)
     if isinstance(value, Path):
         return str(value)
     if isinstance(value, dict):
-        return {str(k): _json_safe(v) for k, v in value.items()}
+        safe = {str(k): _json_safe(v) for k, v in value.items()}
+        if str(safe.get("type", "") or "").strip().lower() == "input_audio":
+            input_audio = safe.get("input_audio")
+            if isinstance(input_audio, dict) and str(input_audio.get("data", "") or "").strip():
+                safe_input_audio = dict(input_audio)
+                safe_input_audio["data"] = "[redacted]"
+                safe["input_audio"] = safe_input_audio
+        return safe
     if isinstance(value, (list, tuple, set)):
         return [_json_safe(item) for item in value]
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
         with suppress(Exception):
             return _json_safe(model_dump())
-    return str(value)
+    return _redact_inline_trace_string(str(value))
 
 
 def _message_role(message: Any) -> str:
@@ -247,12 +267,14 @@ def _message_role(message: Any) -> str:
 
 def _serialize_message(message: Any) -> dict[str, Any]:
     content = getattr(message, "content", "")
+    safe_content = _json_safe(content)
+    safe_text = _content_to_text(safe_content)
     payload: dict[str, Any] = {
         "role": _message_role(message),
         "type": type(message).__name__,
-        "content": _json_safe(content),
-        "text": _content_to_text(content),
-        "approx_tokens": _approx_tokens(_content_to_text(content)),
+        "content": safe_content,
+        "text": safe_text,
+        "approx_tokens": _approx_tokens(safe_text),
     }
     tool_call_id = str(getattr(message, "tool_call_id", "") or "").strip()
     if tool_call_id:
@@ -976,7 +998,8 @@ class OpenTulpaLangGraphRuntime:
         self._llm_call_trace_path = self._behavior_log_path.parent / "llm_call_traces.jsonl"
         self._llm_call_trace_lock = threading.Lock()
         self._llm_call_trace_limit = _LLM_CALL_TRACE_LIMIT
-        self._behavior_log_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._behavior_log_enabled:
+            self._behavior_log_path.parent.mkdir(parents=True, exist_ok=True)
         self._browser_use_headless = bool(browser_use_headless)
         self._browser_use_model_override = str(browser_use_model_override or "").strip()
         self._browser_use_max_concurrent_tasks = max(1, int(browser_use_max_concurrent_tasks))
@@ -1351,6 +1374,8 @@ class OpenTulpaLangGraphRuntime:
         error: str | None,
         call_context: dict[str, Any] | None = None,
     ) -> None:
+        if not bool(getattr(self, "_behavior_log_enabled", True)):
+            return
         normalized_context = self._normalize_llm_call_context(call_context)
         usage_fields = (
             self.extract_response_usage_fields(response)
@@ -1358,6 +1383,7 @@ class OpenTulpaLangGraphRuntime:
             else {}
         )
         response_content = getattr(response, "content", response) if response is not None else ""
+        safe_response_content = _json_safe(response_content)
         record: dict[str, Any] = {
             "ts": datetime.now(UTC).isoformat(),
             "model_name": str(model_name or "").strip(),
@@ -1366,8 +1392,8 @@ class OpenTulpaLangGraphRuntime:
             "prompt_message_count": len(prepared_messages),
             "response_type": type(response).__name__ if response is not None else "",
             "response_message": _serialize_message(response) if response is not None else None,
-            "response_text": _content_to_text(response_content).strip() if response is not None else "",
-            "response_content": _json_safe(response_content),
+            "response_text": _content_to_text(safe_response_content).strip() if response is not None else "",
+            "response_content": safe_response_content,
             "response_tool_calls": _json_safe(getattr(response, "tool_calls", None)),
             "error": str(error or "").strip() or None,
             **usage_fields,

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -117,6 +117,8 @@ _MEMORY_GROUNDING_KIND_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("fallback_thread_context", ("thread_context_rollup",)),
 )
 
+_LLM_CALL_TRACE_LIMIT = 100
+
 
 def _prompt_cache_control_payload(*, ttl_1h: bool) -> dict[str, Any]:
     cc: dict[str, Any] = {"type": "ephemeral"}
@@ -213,6 +215,61 @@ def _provider_prompt_cache_invoke_extras(
     if profile.get("strategy") != "top_level":
         return {}
     return {"extra_body": {"cache_control": dict(profile.get("cache_control") or {})}}
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        with suppress(Exception):
+            return _json_safe(model_dump())
+    return str(value)
+
+
+def _message_role(message: Any) -> str:
+    if isinstance(message, HumanMessage):
+        return "user"
+    if isinstance(message, AIMessage):
+        return "assistant"
+    if isinstance(message, SystemMessage):
+        return "system"
+    if isinstance(message, ToolMessage):
+        return "tool"
+    return "unknown"
+
+
+def _serialize_message(message: Any) -> dict[str, Any]:
+    content = getattr(message, "content", "")
+    payload: dict[str, Any] = {
+        "role": _message_role(message),
+        "type": type(message).__name__,
+        "content": _json_safe(content),
+        "text": _content_to_text(content),
+        "approx_tokens": _approx_tokens(_content_to_text(content)),
+    }
+    tool_call_id = str(getattr(message, "tool_call_id", "") or "").strip()
+    if tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    tool_calls = getattr(message, "tool_calls", None)
+    if tool_calls:
+        payload["tool_calls"] = _json_safe(tool_calls)
+    name = str(getattr(message, "name", "") or "").strip()
+    if name:
+        payload["name"] = name
+    additional_kwargs = getattr(message, "additional_kwargs", None)
+    if additional_kwargs:
+        payload["additional_kwargs"] = _json_safe(additional_kwargs)
+    response_metadata = getattr(message, "response_metadata", None)
+    if response_metadata:
+        payload["response_metadata"] = _json_safe(response_metadata)
+    return payload
 
 
 def _message_content_with_cache_breakpoint(
@@ -916,8 +973,10 @@ class OpenTulpaLangGraphRuntime:
         raw_behavior_path = str(behavior_log_path or "").strip() or ".opentulpa/logs/agent_behavior.jsonl"
         self._behavior_log_path = Path(raw_behavior_path).resolve()
         self._behavior_log_lock = threading.Lock()
-        if self._behavior_log_enabled:
-            self._behavior_log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._llm_call_trace_path = self._behavior_log_path.parent / "llm_call_traces.jsonl"
+        self._llm_call_trace_lock = threading.Lock()
+        self._llm_call_trace_limit = _LLM_CALL_TRACE_LIMIT
+        self._behavior_log_path.parent.mkdir(parents=True, exist_ok=True)
         self._browser_use_headless = bool(browser_use_headless)
         self._browser_use_model_override = str(browser_use_model_override or "").strip()
         self._browser_use_max_concurrent_tasks = max(1, int(browser_use_max_concurrent_tasks))
@@ -1115,6 +1174,7 @@ class OpenTulpaLangGraphRuntime:
         *,
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        call_context: dict[str, Any] | None = None,
     ) -> Any:
         resolved_model_name = self._resolve_model_name_for_runtime_call(model, explicit_name=model_name)
         prepared_messages = self.prepare_messages_for_prompt_cache(
@@ -1123,9 +1183,26 @@ class OpenTulpaLangGraphRuntime:
             stable_prefix_count=stable_prefix_count,
         )
         invoke_extras = self.model_invoke_extras(model_name=resolved_model_name)
-        if _supports_ainvoke_kwargs(model, invoke_extras):
-            return await model.ainvoke(prepared_messages, **invoke_extras)
-        return await model.ainvoke(prepared_messages)
+        response: Any | None = None
+        error_text: str | None = None
+        try:
+            if _supports_ainvoke_kwargs(model, invoke_extras):
+                response = await model.ainvoke(prepared_messages, **invoke_extras)
+            else:
+                response = await model.ainvoke(prepared_messages)
+            return response
+        except Exception as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            self._record_llm_call_trace(
+                model_name=resolved_model_name,
+                prepared_messages=prepared_messages,
+                stable_prefix_count=stable_prefix_count,
+                response=response,
+                error=error_text,
+                call_context=call_context,
+            )
 
     @staticmethod
     def _looks_like_provisional_reply(text: str) -> bool:
@@ -1216,6 +1293,89 @@ class OpenTulpaLangGraphRuntime:
         with suppress(Exception), lock, path.open("a", encoding="utf-8") as f:
             f.write(serialized + "\n")
 
+    @staticmethod
+    def _normalize_llm_call_context(call_context: dict[str, Any] | None) -> dict[str, Any]:
+        normalized = dict(call_context) if isinstance(call_context, dict) else {}
+        prompt_sections = normalized.get("prompt_sections")
+        if isinstance(prompt_sections, str):
+            normalized["prompt_sections"] = [
+                part.strip() for part in prompt_sections.split(",") if part.strip()
+            ]
+        elif isinstance(prompt_sections, list):
+            normalized["prompt_sections"] = [
+                str(part).strip() for part in prompt_sections if str(part).strip()
+            ]
+        normalized["call_site"] = str(
+            normalized.get("call_site") or "runtime_model_invoke"
+        ).strip()
+        return normalized
+
+    def _write_llm_call_trace(self, payload: dict[str, Any]) -> None:
+        path = getattr(self, "_llm_call_trace_path", None)
+        lock = getattr(self, "_llm_call_trace_lock", None)
+        limit = max(1, int(getattr(self, "_llm_call_trace_limit", _LLM_CALL_TRACE_LIMIT)))
+        if not isinstance(path, Path):
+            return
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+
+        def _commit() -> None:
+            existing: list[str] = []
+            with suppress(Exception):
+                existing = [
+                    line.rstrip("\n")
+                    for line in path.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+            kept = existing[-max(0, limit - 1) :]
+            kept.append(serialized)
+            with path.open("w", encoding="utf-8") as f:
+                if kept:
+                    f.write("\n".join(kept) + "\n")
+
+        with suppress(Exception):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        if lock is None:
+            with suppress(Exception):
+                _commit()
+            return
+        with suppress(Exception), lock:
+            _commit()
+
+    def _record_llm_call_trace(
+        self,
+        *,
+        model_name: str,
+        prepared_messages: list[Any],
+        stable_prefix_count: int,
+        response: Any | None,
+        error: str | None,
+        call_context: dict[str, Any] | None = None,
+    ) -> None:
+        normalized_context = self._normalize_llm_call_context(call_context)
+        usage_fields = (
+            self.extract_response_usage_fields(response)
+            if response is not None
+            else {}
+        )
+        response_content = getattr(response, "content", response) if response is not None else ""
+        record: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(),
+            "model_name": str(model_name or "").strip(),
+            "stable_prefix_count": int(stable_prefix_count),
+            "prompt_messages": [_serialize_message(message) for message in prepared_messages],
+            "prompt_message_count": len(prepared_messages),
+            "response_type": type(response).__name__ if response is not None else "",
+            "response_message": _serialize_message(response) if response is not None else None,
+            "response_text": _content_to_text(response_content).strip() if response is not None else "",
+            "response_content": _json_safe(response_content),
+            "response_tool_calls": _json_safe(getattr(response, "tool_calls", None)),
+            "error": str(error or "").strip() or None,
+            **usage_fields,
+        }
+        for key, value in normalized_context.items():
+            record[str(key)] = _json_safe(value)
+        self._write_llm_call_trace(record)
+
     def _truncate_user_visible_reply(self, text: str) -> tuple[str, bool]:
         raw = str(text or "").strip()
         if not raw:
@@ -1278,6 +1438,7 @@ class OpenTulpaLangGraphRuntime:
                 list(messages),
                 model_name=resolved_model_name,
                 stable_prefix_count=stable_prefix_count,
+                call_context={"call_site": "structured_model_fallback"},
             )
             raw = _content_to_text(getattr(response, "content", response)).strip()
             if raw:

--- a/src/opentulpa/agent/tool_parser.py
+++ b/src/opentulpa/agent/tool_parser.py
@@ -1,0 +1,103 @@
+"""Compact reusable tool payload parsing and serialization helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _truncate_value(value: str, *, char_limit: int | None) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    if char_limit is None or char_limit <= 0 or len(text) <= char_limit:
+        return text
+    return text[: max(1, int(char_limit) - 3)].rstrip() + "..."
+
+
+def _coerce_jsonish_payload(payload: Any) -> Any:
+    if not isinstance(payload, str):
+        return payload
+    raw = str(payload or "").strip()
+    if not raw or raw[0] not in "{[":
+        return payload
+    try:
+        return json.loads(raw)
+    except Exception:
+        return payload
+
+
+def _flatten_pairs(
+    value: Any,
+    *,
+    prefix: str,
+    out: list[tuple[str, str]],
+    value_char_limit: int | None,
+) -> None:
+    if value in (None, "", [], {}):
+        return
+    if isinstance(value, dict):
+        for key in sorted(value.keys(), key=lambda item: str(item)):
+            child = value.get(key)
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            _flatten_pairs(
+                child,
+                prefix=child_prefix,
+                out=out,
+                value_char_limit=value_char_limit,
+            )
+        return
+    if isinstance(value, list):
+        for idx, child in enumerate(value):
+            child_prefix = f"{prefix}[{idx}]" if prefix else f"[{idx}]"
+            _flatten_pairs(
+                child,
+                prefix=child_prefix,
+                out=out,
+                value_char_limit=value_char_limit,
+            )
+        return
+    normalized = _truncate_value(str(value), char_limit=value_char_limit)
+    if not normalized:
+        return
+    out.append((prefix or "value", normalized))
+
+
+def compact_tool_payload(
+    payload: Any,
+    *,
+    value_char_limit: int | None = 100,
+    pair_delimiter: str = " | ",
+) -> str:
+    """Flatten JSON-ish tool payloads into a compact stable key=value format."""
+    parsed = _coerce_jsonish_payload(payload)
+    if isinstance(parsed, (dict, list)):
+        pairs: list[tuple[str, str]] = []
+        _flatten_pairs(
+            parsed,
+            prefix="",
+            out=pairs,
+            value_char_limit=value_char_limit,
+        )
+        if not pairs:
+            return ""
+        return pair_delimiter.join(f"{key}={value}" for key, value in pairs)
+    return _truncate_value(str(parsed), char_limit=value_char_limit)
+
+
+def compact_tool_call_record(
+    *,
+    tool_name: str,
+    args: Any,
+    result: Any,
+    args_value_char_limit: int | None = 100,
+    result_value_char_limit: int | None = 100,
+) -> str:
+    """Format a tool call/result pair in a compact reusable single-line representation."""
+    safe_name = str(tool_name or "").strip() or "tool"
+    parts = [f"tool={safe_name}"]
+    compact_args = compact_tool_payload(args, value_char_limit=args_value_char_limit)
+    if compact_args:
+        parts.append(f"args[{compact_args}]")
+    compact_result = compact_tool_payload(result, value_char_limit=result_value_char_limit)
+    if compact_result:
+        parts.append(f"result[{compact_result}]")
+    return " | ".join(parts)

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -315,6 +315,8 @@ def create_app(
             await task_runner.shutdown()
         if wake_queue_service:
             await wake_queue_service.shutdown()
+        if telegram_client and hasattr(telegram_client, "aclose"):
+            await telegram_client.aclose()
         if runtime and hasattr(runtime, "shutdown"):
             await runtime.shutdown()
 

--- a/src/opentulpa/interfaces/telegram/attachments.py
+++ b/src/opentulpa/interfaces/telegram/attachments.py
@@ -137,100 +137,105 @@ async def ingest_attachments(
 ) -> list[dict[str, Any]]:
     ingested: list[dict[str, Any]] = []
     client = TelegramClient(bot_token)
-    for attachment in attachments:
-        downloaded = await client.download_file(file_id=attachment.file_id)
-        if not downloaded:
-            continue
-        raw_bytes = downloaded.get("raw_bytes")
-        if not isinstance(raw_bytes, (bytes, bytearray)) or not raw_bytes:
-            continue
-        file_path_name = str(downloaded.get("file_path", "")).split("/")[-1].strip()
-        record = file_vault.ingest_file(
-            customer_id=customer_id,
-            chat_id=chat_id,
-            kind=attachment.kind,
-            telegram_file_id=attachment.file_id,
-            original_filename=attachment.filename or file_path_name or f"{attachment.kind}.bin",
-            mime_type=attachment.mime_type or str(downloaded.get("mime_type", "")).strip() or None,
-            caption=caption,
-            raw_bytes=bytes(raw_bytes),
-        )
-        local_path = _mirror_uploaded_file(
-            customer_id=customer_id,
-            file_id=str(record.get("id", "")).strip(),
-            filename=str(record.get("original_filename", "")).strip() or "file.bin",
-            raw_bytes=bytes(raw_bytes),
-        )
-        if local_path:
-            record = {**record, "local_path": local_path}
-        if (
-            attachment.kind == "voice"
-            and agent_runtime is not None
-            and hasattr(agent_runtime, "transcribe_audio_blob")
-        ):
-            with suppress(Exception):
-                transcript = await agent_runtime.transcribe_audio_blob(
-                    filename=attachment.filename or file_path_name or f"{attachment.kind}.ogg",
-                    mime_type=attachment.mime_type
-                    or str(downloaded.get("mime_type", "")).strip()
-                    or None,
-                    kind=attachment.kind,
-                    raw_bytes=bytes(raw_bytes),
-                )
-                if transcript:
-                    record = {**record, "voice_transcript": str(transcript).strip()[:4000]}
-        if agent_runtime is not None and hasattr(agent_runtime, "summarize_uploaded_blob"):
-            if attachment.kind == "voice":
-                ingested.append(record)
-                if memory is not None:
-                    with suppress(Exception):
-                        memory.add_text(
-                            (
-                                "Voice note stored for this user. "
-                                f"name={record.get('original_filename')} "
-                                f"vault_path={record.get('stored_path')} "
-                                f"local_path={record.get('local_path', '')} "
-                                f"transcript={str(record.get('voice_transcript', ''))[:1200]}"
-                            ),
-                            user_id=customer_id,
-                            metadata={
-                                "kind": "media_fact",
-                                "file_id": record.get("id"),
-                                "file_kind": record.get("kind"),
-                            },
-                        )
+    try:
+        for attachment in attachments:
+            downloaded = await client.download_file(file_id=attachment.file_id)
+            if not downloaded:
                 continue
+            raw_bytes = downloaded.get("raw_bytes")
+            if not isinstance(raw_bytes, (bytes, bytearray)) or not raw_bytes:
+                continue
+            file_path_name = str(downloaded.get("file_path", "")).split("/")[-1].strip()
+            record = file_vault.ingest_file(
+                customer_id=customer_id,
+                chat_id=chat_id,
+                kind=attachment.kind,
+                telegram_file_id=attachment.file_id,
+                original_filename=attachment.filename or file_path_name or f"{attachment.kind}.bin",
+                mime_type=attachment.mime_type or str(downloaded.get("mime_type", "")).strip() or None,
+                caption=caption,
+                raw_bytes=bytes(raw_bytes),
+            )
+            local_path = _mirror_uploaded_file(
+                customer_id=customer_id,
+                file_id=str(record.get("id", "")).strip(),
+                filename=str(record.get("original_filename", "")).strip() or "file.bin",
+                raw_bytes=bytes(raw_bytes),
+            )
+            if local_path:
+                record = {**record, "local_path": local_path}
+            if (
+                attachment.kind == "voice"
+                and agent_runtime is not None
+                and hasattr(agent_runtime, "transcribe_audio_blob")
+            ):
+                with suppress(Exception):
+                    transcript = await agent_runtime.transcribe_audio_blob(
+                        filename=attachment.filename or file_path_name or f"{attachment.kind}.ogg",
+                        mime_type=attachment.mime_type
+                        or str(downloaded.get("mime_type", "")).strip()
+                        or None,
+                        kind=attachment.kind,
+                        raw_bytes=bytes(raw_bytes),
+                    )
+                    if transcript:
+                        record = {**record, "voice_transcript": str(transcript).strip()[:4000]}
+            if agent_runtime is not None and hasattr(agent_runtime, "summarize_uploaded_blob"):
+                if attachment.kind == "voice":
+                    ingested.append(record)
+                    if memory is not None:
+                        with suppress(Exception):
+                            memory.add_text(
+                                (
+                                    "Voice note stored for this user. "
+                                    f"name={record.get('original_filename')} "
+                                    f"vault_path={record.get('stored_path')} "
+                                    f"local_path={record.get('local_path', '')} "
+                                    f"transcript={str(record.get('voice_transcript', ''))[:1200]}"
+                                ),
+                                user_id=customer_id,
+                                metadata={
+                                    "kind": "media_fact",
+                                    "file_id": record.get("id"),
+                                    "file_kind": record.get("kind"),
+                                },
+                            )
+                    continue
+                with suppress(Exception):
+                    ai_summary = await agent_runtime.summarize_uploaded_blob(
+                        filename=str(record.get("original_filename", "")).strip() or None,
+                        mime_type=str(record.get("mime_type", "")).strip() or None,
+                        kind=str(record.get("kind", "")).strip() or None,
+                        raw_bytes=bytes(raw_bytes),
+                        caption=caption,
+                    )
+                    if ai_summary:
+                        updated = file_vault.set_ai_summary(customer_id, str(record.get("id", "")), ai_summary)
+                        if isinstance(updated, dict):
+                            record = updated
+            ingested.append(record)
+            if memory is not None:
+                with suppress(Exception):
+                    record_kind = str(record.get("kind", "")).strip().lower()
+                    memory_kind = "media_fact" if record_kind in {"photo", "video", "video_note", "audio", "voice"} else "file_fact"
+                    memory.add_text(
+                        (
+                            "User file stored in vault. "
+                            f"name={record.get('original_filename')} "
+                            f"kind={record.get('kind')} "
+                            f"vault_path={record.get('stored_path')} "
+                            f"local_path={record.get('local_path', '')} "
+                            f"summary={record.get('summary', '')[:1200]}"
+                        ),
+                        user_id=customer_id,
+                        metadata={
+                            "kind": memory_kind,
+                            "file_id": record.get("id"),
+                            "file_kind": record.get("kind"),
+                        },
+                    )
+    finally:
+        if hasattr(client, "aclose"):
             with suppress(Exception):
-                ai_summary = await agent_runtime.summarize_uploaded_blob(
-                    filename=str(record.get("original_filename", "")).strip() or None,
-                    mime_type=str(record.get("mime_type", "")).strip() or None,
-                    kind=str(record.get("kind", "")).strip() or None,
-                    raw_bytes=bytes(raw_bytes),
-                    caption=caption,
-                )
-                if ai_summary:
-                    updated = file_vault.set_ai_summary(customer_id, str(record.get("id", "")), ai_summary)
-                    if isinstance(updated, dict):
-                        record = updated
-        ingested.append(record)
-        if memory is not None:
-            with suppress(Exception):
-                record_kind = str(record.get("kind", "")).strip().lower()
-                memory_kind = "media_fact" if record_kind in {"photo", "video", "video_note", "audio", "voice"} else "file_fact"
-                memory.add_text(
-                    (
-                        "User file stored in vault. "
-                        f"name={record.get('original_filename')} "
-                        f"kind={record.get('kind')} "
-                        f"vault_path={record.get('stored_path')} "
-                        f"local_path={record.get('local_path', '')} "
-                        f"summary={record.get('summary', '')[:1200]}"
-                    ),
-                    user_id=customer_id,
-                    metadata={
-                        "kind": memory_kind,
-                        "file_id": record.get("id"),
-                        "file_kind": record.get("kind"),
-                    },
-                )
+                await client.aclose()
     return ingested

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -164,15 +164,23 @@ async def _send_debug_logs_file(*, chat_id: int, bot_token: str | None) -> str |
     raw_bytes = read_debug_log_bytes()
     if raw_bytes is None:
         return "Debug log file is not available yet."
-    sent = await TelegramClient(str(bot_token)).send_file(
-        chat_id=chat_id,
-        filename="app.log",
-        raw_bytes=raw_bytes,
-        kind="document",
-        mime_type="text/plain",
-        caption="OpenTulpa debug log dump",
-        parse_mode="HTML",
-    )
+    client = TelegramClient(str(bot_token))
+    try:
+        sent = await client.send_file(
+            chat_id=chat_id,
+            filename="app.log",
+            raw_bytes=raw_bytes,
+            kind="document",
+            mime_type="text/plain",
+            caption="OpenTulpa debug log dump",
+            parse_mode="HTML",
+        )
+    finally:
+        if hasattr(client, "aclose"):
+            try:
+                await client.aclose()
+            except Exception:
+                pass
     if not sent:
         return "I couldn't send the debug log file right now."
     return None
@@ -315,9 +323,10 @@ async def handle_telegram_text(
     ingested_files: list[dict[str, Any]] = []
     if attachments and bot_token and file_vault is not None:
         typing_stop = asyncio.Event()
+        typing_client = TelegramClient(str(bot_token))
         typing_task = asyncio.create_task(
             _emit_typing_until_done(
-                client=TelegramClient(str(bot_token)),
+                client=typing_client,
                 chat_id=ctx.chat_id,
                 stop_event=typing_stop,
             )
@@ -339,6 +348,11 @@ async def handle_telegram_text(
                 await typing_task
             except Exception:
                 pass
+            if hasattr(typing_client, "aclose"):
+                try:
+                    await typing_client.aclose()
+                except Exception:
+                    pass
 
     if attachments and not ctx.text and not ingested_files:
         if agent_runtime is None:

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -49,16 +49,32 @@ class TelegramClient:
 
     def __init__(self, bot_token: str) -> None:
         self.bot_token = str(bot_token or "").strip()
+        self._client: Any | None = None
+
+    def _http_client(self) -> Any:
+        if self._client is None:
+            self._client = httpx.AsyncClient()
+        return self._client
+
+    async def aclose(self) -> None:
+        client = self._client
+        self._client = None
+        if client is None:
+            return
+        close = getattr(client, "aclose", None)
+        if callable(close):
+            with suppress(Exception):
+                await close()
 
     async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any] | None:
         url = f"https://api.telegram.org/bot{self.bot_token}/{method}"
         retryable_http = {408, 429, 500, 502, 503, 504}
         timeout = httpx.Timeout(20.0, connect=8.0, read=15.0)
         max_attempts = 3
+        client = self._http_client()
         for attempt in range(max_attempts):
             try:
-                async with httpx.AsyncClient() as client:
-                    r = await client.post(url, json=payload, timeout=timeout)
+                r = await client.post(url, json=payload, timeout=timeout)
             except (httpx.TimeoutException, httpx.TransportError) as exc:
                 if attempt < max_attempts - 1:
                     await asyncio.sleep(0.4 * (2**attempt))
@@ -243,8 +259,8 @@ class TelegramClient:
         guessed_mime, _ = mimetypes.guess_type(file_path)
         url = f"https://api.telegram.org/file/bot{self.bot_token}/{file_path}"
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(url, timeout=45.0)
+            client = self._http_client()
+            resp = await client.get(url, timeout=45.0)
         except Exception:
             return None
         if not resp.is_success:
@@ -285,8 +301,8 @@ class TelegramClient:
         files = {media_field: (safe_name, raw_bytes, mime_type or "application/octet-stream")}
         url = f"https://api.telegram.org/bot{self.bot_token}/{method}"
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.post(url, data=payload, files=files, timeout=60.0)
+            client = self._http_client()
+            resp = await client.post(url, data=payload, files=files, timeout=60.0)
         except Exception:
             return False
         if not resp.is_success:

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -306,6 +306,9 @@ async def stream_langgraph_reply_to_telegram(
             typing_stop.set()
         with suppress(Exception):
             await typing_task
+        if hasattr(client, "aclose"):
+            with suppress(Exception):
+                await client.aclose()
         raise
     if next_chunk_task is not None and not next_chunk_task.done():
         next_chunk_task.cancel()
@@ -347,6 +350,9 @@ async def stream_langgraph_reply_to_telegram(
         suppressed,
         len(str(final_reply or "")),
     )
+    if hasattr(client, "aclose"):
+        with suppress(Exception):
+            await client.aclose()
     return final_reply, suppressed
 
 

--- a/tests/test_context_engineer.py
+++ b/tests/test_context_engineer.py
@@ -49,6 +49,9 @@ def test_context_engineer_summarizes_stale_tool_arguments_and_errors() -> None:
     assert "composio_tool_execute" in result.summary_text
     assert "slot" in result.summary_text
     assert "slot conflict" in result.summary_text
+    assert "tool=composio_tool_execute" in result.summary_text
+    assert "args[" in result.summary_text
+    assert "result[" in result.summary_text
 
 
 def test_context_engineer_preserves_active_tool_dependency_suffix() -> None:
@@ -74,6 +77,49 @@ def test_context_engineer_preserves_active_tool_dependency_suffix() -> None:
     assert result.protected_count == 2
     assert any(isinstance(msg, AIMessage) and bool(getattr(msg, "tool_calls", [])) for msg in result.raw_messages)
     assert any(isinstance(msg, ToolMessage) and getattr(msg, "tool_call_id", "") == "call_live" for msg in result.raw_messages)
+
+
+def test_context_engineer_latest_five_stale_tool_calls_keep_full_content() -> None:
+    engineer = ContextEngineer(raw_chat_limit=1, raw_tool_limit=1, stale_summary_token_budget=5000)
+    long_value = "x" * 140
+    messages = [HumanMessage(content="old context"), AIMessage(content="older answer")]
+    for idx in range(6):
+        call_id = f"call_{idx}"
+        messages.append(
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": call_id,
+                        "name": "composio_tool_execute",
+                        "args": {
+                            "tool_slug": "googlesheets",
+                            "payload": f"args-{idx}-{long_value}",
+                        },
+                    }
+                ],
+            )
+        )
+        messages.append(
+            ToolMessage(
+                content=f'{{"status":"ok","result":"result-{idx}-{long_value}"}}',
+                tool_call_id=call_id,
+            )
+        )
+    messages.append(HumanMessage(content="latest"))
+    messages.append(AIMessage(content="latest answer"))
+
+    result = engineer.build_history_working_set(messages, token_budget=4000)
+    preserved_text = result.summary_text + "\n" + "\n".join(
+        f"{getattr(msg, 'content', '')} {getattr(msg, 'tool_calls', '')}"
+        for msg in result.raw_messages
+    )
+
+    assert f"args-0-{long_value}" not in preserved_text
+    assert f"result-0-{long_value}" not in preserved_text
+    for idx in range(1, 6):
+        assert f"args-{idx}-{long_value}" in preserved_text
+        assert f"result-{idx}-{long_value}" in preserved_text
 
 
 def test_context_engineer_optional_context_rules() -> None:

--- a/tests/test_llm_call_tracing.py
+++ b/tests/test_llm_call_tracing.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
+from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
+
+
+class _TraceResponse:
+    def __init__(self) -> None:
+        self.content = "All good."
+        self.tool_calls = [{"id": "call_1", "name": "memory_search", "args": {"query": "pricing"}}]
+        self.usage = {
+            "prompt_tokens": 1234,
+            "completion_tokens": 56,
+            "total_tokens": 1290,
+        }
+
+
+class _TraceModel:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def ainvoke(self, messages: object, **kwargs: object) -> _TraceResponse:
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return _TraceResponse()
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_model_writes_full_llm_call_trace(tmp_path: Path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+        prompt_caching_enabled=True,
+    )
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+    model = _TraceModel()
+
+    await runtime.ainvoke_model(
+        model,
+        [
+            SystemMessage(content="Stable system prompt"),
+            HumanMessage(content="What do you remember about pricing?"),
+        ],
+        model_name="google/gemini-3-flash-preview",
+        stable_prefix_count=1,
+        call_context={
+            "call_site": "graph_agent",
+            "trace_id": "turn_trace_test",
+            "thread_id": "chat_test",
+            "customer_id": "telegram_test",
+            "turn_mode": "interactive",
+            "prompt_mode": "literal_chat",
+            "prompt_sections": ["stable_core_policy", "style_card"],
+            "prompt_overhead_tokens": 1900,
+            "history_message_count": 2,
+            "raw_chat_history_count": 1,
+            "raw_tool_history_count": 0,
+            "optional_context_messages": 1,
+        },
+    )
+
+    records = [
+        json.loads(line)
+        for line in runtime._llm_call_trace_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record["trace_id"] == "turn_trace_test"
+    assert record["call_site"] == "graph_agent"
+    assert record["model_name"] == "google/gemini-3-flash-preview"
+    assert record["stable_prefix_count"] == 1
+    assert record["prompt_sections"] == ["stable_core_policy", "style_card"]
+    assert record["native_tokens_prompt"] == 1234
+    assert record["native_tokens_completion"] == 56
+    assert record["response_text"] == "All good."
+    assert record["response_tool_calls"][0]["name"] == "memory_search"
+    assert len(record["prompt_messages"]) == 2
+    assert record["prompt_messages"][0]["role"] == "system"
+    assert record["prompt_messages"][1]["role"] == "user"
+
+
+def test_llm_call_trace_keeps_latest_100_records(tmp_path: Path) -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+    runtime._llm_call_trace_lock = None
+    runtime._llm_call_trace_limit = 100
+
+    for idx in range(105):
+        runtime._write_llm_call_trace(  # type: ignore[attr-defined]
+            {
+                "ts": f"2026-04-10T00:00:{idx:02d}Z",
+                "trace_id": f"turn_{idx}",
+                "call_site": "graph_agent",
+                "prompt_messages": [],
+                "response_text": "",
+            }
+        )
+
+    records = [
+        json.loads(line)
+        for line in runtime._llm_call_trace_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 100
+    assert records[0]["trace_id"] == "turn_5"
+    assert records[-1]["trace_id"] == "turn_104"
+
+
+def test_llm_call_trace_inspector_shows_decomposition(tmp_path: Path) -> None:
+    trace_path = tmp_path / "llm_call_traces.jsonl"
+    trace_path.write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-10T00:00:00Z",
+                "trace_id": "turn_show",
+                "call_site": "graph_agent",
+                "model_name": "z-ai/glm-5.1",
+                "thread_id": "chat_test",
+                "customer_id": "telegram_test",
+                "turn_mode": "interactive",
+                "prompt_mode": "literal_chat",
+                "stable_prefix_count": 1,
+                "prompt_sections": ["stable_core_policy", "style_card"],
+                "prompt_overhead_tokens": 1900,
+                "history_message_count": 2,
+                "raw_chat_history_count": 1,
+                "raw_tool_history_count": 0,
+                "optional_context_messages": 1,
+                "native_tokens_prompt": 1234,
+                "native_tokens_completion": 56,
+                "prompt_messages": [
+                    {"role": "system", "type": "SystemMessage", "approx_tokens": 10, "text": "Stable system prompt"},
+                    {"role": "user", "type": "HumanMessage", "approx_tokens": 7, "text": "What do you remember?"},
+                ],
+                "response_text": "All good.",
+                "response_tool_calls": [],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/inspect_llm_call_traces.py",
+            "--path",
+            str(trace_path),
+            "--trace-id",
+            "turn_show",
+        ],
+        cwd=str(Path(__file__).resolve().parent.parent),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "trace_id: turn_show" in result.stdout
+    assert "Prompt messages:" in result.stdout
+    assert "00. role=system" in result.stdout
+    assert "Response text:" in result.stdout

--- a/tests/test_llm_call_tracing.py
+++ b/tests/test_llm_call_tracing.py
@@ -89,6 +89,66 @@ async def test_ainvoke_model_writes_full_llm_call_trace(tmp_path: Path) -> None:
     assert record["prompt_messages"][1]["role"] == "user"
 
 
+@pytest.mark.asyncio
+async def test_ainvoke_model_skips_llm_call_trace_when_behavior_log_disabled(tmp_path: Path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+        behavior_log_enabled=False,
+    )
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+
+    await runtime.ainvoke_model(
+        _TraceModel(),
+        [HumanMessage(content="do not persist this")],
+        model_name="google/gemini-3-flash-preview",
+    )
+
+    assert not runtime._llm_call_trace_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_model_redacts_inline_media_from_llm_call_trace(tmp_path: Path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+    image_data_url = "data:image/jpeg;base64,/9j/QUJDREVGRw=="
+    audio_b64 = "QUJDREVGRw=="
+
+    await runtime.ainvoke_model(
+        _TraceModel(),
+        [
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": "Analyze this upload."},
+                    {"type": "image_url", "image_url": {"url": image_data_url}},
+                    {"type": "input_audio", "input_audio": {"data": audio_b64, "format": "mp3"}},
+                ]
+            )
+        ],
+        model_name="google/gemini-3-flash-preview",
+        call_context={"call_site": "file_analysis"},
+    )
+
+    record = json.loads(runtime._llm_call_trace_path.read_text(encoding="utf-8").splitlines()[-1])
+    prompt_message = record["prompt_messages"][0]
+    prompt_content = prompt_message["content"]
+    serialized_record = json.dumps(record, ensure_ascii=False)
+
+    assert prompt_content[1]["image_url"]["url"] == "data:image/jpeg;base64,[redacted]"
+    assert prompt_content[2]["input_audio"]["data"] == "[redacted]"
+    assert image_data_url not in serialized_record
+    assert audio_b64 not in serialized_record
+    assert image_data_url not in prompt_message["text"]
+    assert audio_b64 not in prompt_message["text"]
+
+
 def test_llm_call_trace_keeps_latest_100_records(tmp_path: Path) -> None:
     runtime = object.__new__(OpenTulpaLangGraphRuntime)
     runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -248,9 +248,10 @@ async def test_interactive_prompt_injects_memory_grounding_after_stable_prefix()
         )
 
     async def _ainvoke_model(model: Any, messages: list[Any], *, stable_prefix_count: int = 0, **kwargs: Any) -> AIMessage:
-        del model, kwargs
+        del model
         captured["messages"] = messages
         captured["stable_prefix_count"] = stable_prefix_count
+        captured["call_context"] = kwargs.get("call_context")
         return AIMessage(content="ok")
 
     async def _verify_completion_claim(**kwargs: Any) -> dict[str, Any]:
@@ -305,6 +306,9 @@ async def test_interactive_prompt_injects_memory_grounding_after_stable_prefix()
         if isinstance(msg, HumanMessage)
     )
     assert grounding_index < last_human_index
+    assert isinstance(captured["call_context"], dict)
+    assert captured["call_context"]["call_site"] == "graph_agent"
+    assert "memory_grounding" in captured["call_context"]["prompt_sections"]
 
 
 def test_memory_grounding_block_stays_compact() -> None:

--- a/tests/test_telegram_media_model_routing.py
+++ b/tests/test_telegram_media_model_routing.py
@@ -28,6 +28,7 @@ class _RoutingRuntime:
         *,
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        call_context: dict[str, Any] | None = None,
     ) -> Any:
         self.calls.append(
             {
@@ -35,6 +36,7 @@ class _RoutingRuntime:
                 "model_name": model_name,
                 "messages": messages,
                 "stable_prefix_count": stable_prefix_count,
+                "call_context": call_context,
             }
         )
         return SimpleNamespace(content="Media summary from Gemini.")

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from opentulpa.agent.tool_parser import compact_tool_call_record, compact_tool_payload
+
+
+def test_compact_tool_payload_flattens_jsonish_dict() -> None:
+    payload = {
+        "status": "ok",
+        "data": {
+            "id": "conv_123",
+            "latest_message": {
+                "text": "hello there",
+                "sender": "customer",
+            },
+        },
+        "items": ["a", "b"],
+    }
+
+    compact = compact_tool_payload(payload, value_char_limit=100)
+
+    assert "status=ok" in compact
+    assert "data.id=conv_123" in compact
+    assert "data.latest_message.text=hello there" in compact
+    assert "items[0]=a" in compact
+    assert "items[1]=b" in compact
+
+
+def test_compact_tool_payload_truncates_each_value_not_whole_payload() -> None:
+    payload = {
+        "status": "ok",
+        "message": "x" * 160,
+        "result": "y" * 140,
+    }
+
+    compact = compact_tool_payload(payload, value_char_limit=100)
+
+    assert "status=ok" in compact
+    assert "message=" in compact
+    assert "result=" in compact
+    assert "x" * 120 not in compact
+    assert "y" * 120 not in compact
+
+
+def test_compact_tool_call_record_formats_tool_args_and_result() -> None:
+    line = compact_tool_call_record(
+        tool_name="INSTAGRAM_GET_CONVERSATION",
+        args={"conversation_id": "conv_123", "limit": 20},
+        result={"status": "ok", "data": {"username": "@luna", "latest_message": "hi"}},
+        args_value_char_limit=None,
+        result_value_char_limit=100,
+    )
+
+    assert line.startswith("tool=INSTAGRAM_GET_CONVERSATION")
+    assert "args[conversation_id=conv_123 | limit=20]" in line
+    assert "status=ok" in line
+    assert "data.username=@luna" in line


### PR DESCRIPTION
## Summary
- capture full runtime-owned LLM calls in a bounded local JSONL trace with an inspector script
- compact stale tool history into reusable flattened key-value records while preserving full content for the latest 5 tool calls
- thread call-site metadata through graph/runtime/media paths and clean up Telegram client shutdown for attachment and typing helpers

## Details
This PR adds `.opentulpa/logs/llm_call_traces.jsonl` capture for runtime-owned model calls, including prepared prompt messages, response payloads, usage fields, prompt section metadata, and history counters. It also adds `scripts/inspect_llm_call_traces.py` so recent calls can be decomposed locally by trace id.

For prompt slimming, stale tool-call history now uses a shared `tool_parser` module that flattens payloads into compact `key=value | ...` records instead of replaying bulky JSON. The latest 5 tool-call instances still retain full content, only reformatted, while older stale tool results are truncated per field.

The diff also tags context compaction and file analysis calls with `call_site` metadata for tracing, closes temporary Telegram clients cleanly in attachment and typing paths, and adds the matching regression coverage.

## Verification
```bash
uv run pytest -q tests/test_llm_call_tracing.py tests/test_context_engineer.py tests/test_tool_parser.py tests/test_runtime_pending_context_input.py tests/test_prompt_cache_split.py tests/test_telegram_media_model_routing.py tests/test_telegram_stream_segments.py tests/test_telegram_stream_timeout.py tests/test_runtime_stream_fallback.py tests/test_voice_message_support.py
```

Result: `61 passed`
