### PR TITLE
Support multiple debug log files and Telegram media-group sending

### DIFF
--- a/src/opentulpa/core/debug_logs.py
+++ b/src/opentulpa/core/debug_logs.py
@@ -7,15 +7,44 @@ from pathlib import Path
 from opentulpa.tasks.sandbox import PROJECT_ROOT
 
 
+def _debug_log_candidates() -> tuple[Path, ...]:
+    return (
+        (PROJECT_ROOT / ".cursor" / "debug.log").resolve(),
+        (PROJECT_ROOT / ".opentulpa" / "logs" / "app.log").resolve(),
+    )
+
+
+def iter_available_debug_log_paths() -> list[Path]:
+    discovered: list[Path] = []
+    seen: set[Path] = set()
+    for path in _debug_log_candidates():
+        if path in seen:
+            continue
+        seen.add(path)
+        if path.exists() and path.is_file():
+            discovered.append(path)
+    logs_dir = (PROJECT_ROOT / ".opentulpa" / "logs").resolve()
+    if logs_dir.exists() and logs_dir.is_dir():
+        for path in sorted(logs_dir.glob("*.log")) + sorted(logs_dir.glob("*.jsonl")):
+            resolved = path.resolve()
+            if resolved in seen or not resolved.is_file():
+                continue
+            seen.add(resolved)
+            discovered.append(resolved)
+    return discovered
+
+
 def get_debug_log_path() -> Path:
-    return PROJECT_ROOT / ".opentulpa" / "logs" / "app.log"
+    available = iter_available_debug_log_paths()
+    if available:
+        return available[0]
+    return _debug_log_candidates()[0]
 
 
 def read_debug_log_bytes() -> bytes | None:
-    path = get_debug_log_path()
-    if not path.exists() or not path.is_file():
-        return None
-    try:
-        return path.read_bytes()
-    except Exception:
-        return None
+    for path in iter_available_debug_log_paths():
+        try:
+            return path.read_bytes()
+        except Exception:
+            continue
+    return None

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from opentulpa.context.file_vault import FileVaultService
 from opentulpa.core.config import get_openai_compatible_api_key_from_env
-from opentulpa.core.debug_logs import read_debug_log_bytes
+from opentulpa.core.debug_logs import iter_available_debug_log_paths
 from opentulpa.core.ids import new_short_id
 from opentulpa.interfaces.telegram.attachments import (
     build_uploaded_files_context,
@@ -166,20 +166,43 @@ def _telegram_command_name(text: str) -> str:
 async def _send_debug_logs_file(*, chat_id: int, bot_token: str | None) -> str | None:
     if not str(bot_token or "").strip():
         return "Telegram file sending is unavailable because the bot token is not configured."
-    raw_bytes = read_debug_log_bytes()
-    if raw_bytes is None:
+    log_paths = iter_available_debug_log_paths()
+    if not log_paths:
         return "Debug log file is not available yet."
     client = TelegramClient(str(bot_token))
     try:
-        sent = await client.send_file(
-            chat_id=chat_id,
-            filename="app.log",
-            raw_bytes=raw_bytes,
-            kind="document",
-            mime_type="text/plain",
-            caption="OpenTulpa debug log dump",
-            parse_mode="HTML",
-        )
+        upload_files: list[dict[str, Any]] = []
+        for path in log_paths:
+            try:
+                raw_bytes = path.read_bytes()
+            except Exception:
+                continue
+            upload_files.append(
+                {
+                    "filename": path.name,
+                    "raw_bytes": raw_bytes,
+                    "mime_type": "text/plain",
+                }
+            )
+        if not upload_files:
+            return "Debug log file is not available yet."
+        if len(upload_files) == 1:
+            sent = await client.send_file(
+                chat_id=chat_id,
+                filename=str(upload_files[0]["filename"]),
+                raw_bytes=bytes(upload_files[0]["raw_bytes"]),
+                kind="document",
+                mime_type=str(upload_files[0]["mime_type"]),
+                caption="OpenTulpa debug logs dump",
+                parse_mode="HTML",
+            )
+        else:
+            sent = await client.send_files(
+                chat_id=chat_id,
+                files=upload_files,
+                caption="OpenTulpa debug logs dump",
+                parse_mode="HTML",
+            )
     finally:
         if hasattr(client, "aclose"):
             try:
@@ -187,7 +210,7 @@ async def _send_debug_logs_file(*, chat_id: int, bot_token: str | None) -> str |
             except Exception:
                 pass
     if not sent:
-        return "I couldn't send the debug log file right now."
+        return "I couldn't send the debug log files right now."
     return None
 
 

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import mimetypes
 from contextlib import suppress
@@ -321,6 +322,60 @@ class TelegramClient:
         ok = bool(isinstance(data, dict) and data.get("ok") is True)
         if not ok:
             logger.warning("Telegram API %s returned error payload: %s", method, str(data)[:400])
+        return ok
+
+    async def send_files(
+        self,
+        *,
+        chat_id: int | str,
+        files: list[dict[str, Any]],
+        caption: str | None = None,
+        parse_mode: str | None = None,
+    ) -> bool:
+        if not files:
+            return False
+        media: list[dict[str, Any]] = []
+        multipart_files: dict[str, tuple[str, bytes, str]] = {}
+        for idx, item in enumerate(files):
+            filename = str(item.get("filename") or "file.bin").strip() or "file.bin"
+            raw_bytes = item.get("raw_bytes")
+            if not isinstance(raw_bytes, (bytes, bytearray)):
+                continue
+            mime_type = str(item.get("mime_type") or "application/octet-stream").strip() or "application/octet-stream"
+            attach_name = f"file{idx}"
+            media_item: dict[str, Any] = {"type": "document", "media": f"attach://{attach_name}"}
+            if idx == 0 and caption:
+                final_caption, final_mode = prepare_text_and_mode(caption, parse_mode)
+                if final_caption:
+                    media_item["caption"] = final_caption
+                if final_mode:
+                    media_item["parse_mode"] = final_mode
+            media.append(media_item)
+            multipart_files[attach_name] = (filename, bytes(raw_bytes), mime_type)
+        if not media:
+            return False
+        payload: dict[str, Any] = {"chat_id": str(chat_id), "media": json.dumps(media, ensure_ascii=False)}
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendMediaGroup"
+        try:
+            client = self._http_client()
+            resp = await client.post(url, data=payload, files=multipart_files, timeout=120.0)
+        except Exception:
+            return False
+        if not resp.is_success:
+            logger.warning(
+                "Telegram API sendMediaGroup HTTP %s: %s",
+                resp.status_code,
+                (resp.text or "")[:400],
+            )
+            return False
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("Telegram API sendMediaGroup returned non-JSON body")
+            return False
+        ok = bool(isinstance(data, dict) and data.get("ok") is True)
+        if not ok:
+            logger.warning("Telegram API sendMediaGroup returned error payload: %s", str(data)[:400])
         return ok
 
 

--- a/tests/test_core_debug_logs.py
+++ b/tests/test_core_debug_logs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_debug_logs_module():
+    module_path = Path(__file__).resolve().parents[1] / "src" / "opentulpa" / "core" / "debug_logs.py"
+    spec = importlib.util.spec_from_file_location("opentulpa.core.debug_logs_under_test", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load debug_logs module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_debug_log_path_prefers_cursor_file(monkeypatch, tmp_path: Path) -> None:
+    debug_logs = _load_debug_logs_module()
+    cursor_path = tmp_path / ".cursor" / "debug.log"
+    app_path = tmp_path / ".opentulpa" / "logs" / "app.log"
+    cursor_path.parent.mkdir(parents=True, exist_ok=True)
+    app_path.parent.mkdir(parents=True, exist_ok=True)
+    cursor_path.write_text("cursor", encoding="utf-8")
+    app_path.write_text("app", encoding="utf-8")
+
+    monkeypatch.setattr(debug_logs, "PROJECT_ROOT", tmp_path)
+
+    assert debug_logs.get_debug_log_path() == cursor_path.resolve()
+
+
+def test_read_debug_log_bytes_falls_back_to_legacy_app_log(monkeypatch, tmp_path: Path) -> None:
+    debug_logs = _load_debug_logs_module()
+    app_path = tmp_path / ".opentulpa" / "logs" / "app.log"
+    app_path.parent.mkdir(parents=True, exist_ok=True)
+    app_path.write_bytes(b"legacy")
+
+    monkeypatch.setattr(debug_logs, "PROJECT_ROOT", tmp_path)
+
+    assert debug_logs.read_debug_log_bytes() == b"legacy"
+
+
+def test_read_debug_log_bytes_returns_none_when_missing(monkeypatch, tmp_path: Path) -> None:
+    debug_logs = _load_debug_logs_module()
+    monkeypatch.setattr(debug_logs, "PROJECT_ROOT", tmp_path)
+
+    assert debug_logs.read_debug_log_bytes() is None
+
+
+def test_iter_available_debug_log_paths_includes_logs_dir_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    debug_logs = _load_debug_logs_module()
+    logs_dir = tmp_path / ".opentulpa" / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    behavior_path = logs_dir / "agent_behavior.jsonl"
+    behavior_path.write_bytes(b"{}\n")
+
+    monkeypatch.setattr(debug_logs, "PROJECT_ROOT", tmp_path)
+
+    paths = debug_logs.iter_available_debug_log_paths()
+    assert behavior_path.resolve() in paths

--- a/tests/test_telegram_debug_logs_command.py
+++ b/tests/test_telegram_debug_logs_command.py
@@ -18,19 +18,33 @@ class _FakeStateStore:
 @pytest.mark.asyncio
 async def test_debug_logs_command_sends_log_file_without_agent_runtime(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
     monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
-    monkeypatch.setattr(chat_module, "read_debug_log_bytes", lambda: b"log line 1\nlog line 2\n")
+    first_log = tmp_path / "debug.log"
+    first_log.write_bytes(b"log line 1\nlog line 2\n")
+    second_log = tmp_path / "agent_behavior.jsonl"
+    second_log.write_bytes(b'{"ok":true}\n')
+    monkeypatch.setattr(chat_module, "iter_available_debug_log_paths", lambda: [first_log, second_log])
 
-    sent_payload: dict[str, Any] = {}
+    sent_payloads: list[dict[str, Any]] = []
+    sent_groups: list[dict[str, Any]] = []
 
     class _FakeTelegramClient:
         def __init__(self, bot_token: str) -> None:
-            sent_payload["bot_token"] = bot_token
+            self._bot_token = bot_token
 
         async def send_file(self, **kwargs: Any) -> bool:
-            sent_payload.update(kwargs)
+            payload = {"bot_token": self._bot_token}
+            payload.update(kwargs)
+            sent_payloads.append(payload)
+            return True
+
+        async def send_files(self, **kwargs: Any) -> bool:
+            payload = {"bot_token": self._bot_token}
+            payload.update(kwargs)
+            sent_groups.append(payload)
             return True
 
     monkeypatch.setattr(chat_module, "TelegramClient", _FakeTelegramClient)
@@ -42,11 +56,15 @@ async def test_debug_logs_command_sends_log_file_without_agent_runtime(
     )
 
     assert text is None
-    assert sent_payload["bot_token"] == "123:abc"
-    assert sent_payload["chat_id"] == 99
-    assert sent_payload["filename"] == "app.log"
-    assert sent_payload["raw_bytes"] == b"log line 1\nlog line 2\n"
-    assert sent_payload["mime_type"] == "text/plain"
+    assert sent_payloads == []
+    assert len(sent_groups) == 1
+    assert sent_groups[0]["bot_token"] == "123:abc"
+    assert sent_groups[0]["chat_id"] == 99
+    assert sent_groups[0]["caption"] == "OpenTulpa debug logs dump"
+    assert sent_groups[0]["parse_mode"] == "HTML"
+    assert [item["filename"] for item in sent_groups[0]["files"]] == ["debug.log", "agent_behavior.jsonl"]
+    assert sent_groups[0]["files"][0]["raw_bytes"] == b"log line 1\nlog line 2\n"
+    assert sent_groups[0]["files"][1]["raw_bytes"] == b'{"ok":true}\n'
 
 
 @pytest.mark.asyncio
@@ -55,7 +73,7 @@ async def test_debug_logs_command_reports_missing_log_file(
 ) -> None:
     fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
     monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
-    monkeypatch.setattr(chat_module, "read_debug_log_bytes", lambda: None)
+    monkeypatch.setattr(chat_module, "iter_available_debug_log_paths", lambda: [])
 
     text = await chat_module.handle_telegram_text(
         body={"message": {"chat": {"id": 99}, "from": {"id": 100}, "text": "/debug_logs"}},
@@ -64,3 +82,47 @@ async def test_debug_logs_command_reports_missing_log_file(
     )
 
     assert text == "Debug log file is not available yet."
+
+
+@pytest.mark.asyncio
+async def test_debug_logs_command_sends_single_file_without_media_group(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
+    monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
+    only_log = tmp_path / "debug.log"
+    only_log.write_bytes(b"one\n")
+    monkeypatch.setattr(chat_module, "iter_available_debug_log_paths", lambda: [only_log])
+
+    sent_payloads: list[dict[str, Any]] = []
+    sent_groups: list[dict[str, Any]] = []
+
+    class _FakeTelegramClient:
+        def __init__(self, bot_token: str) -> None:
+            self._bot_token = bot_token
+
+        async def send_file(self, **kwargs: Any) -> bool:
+            payload = {"bot_token": self._bot_token}
+            payload.update(kwargs)
+            sent_payloads.append(payload)
+            return True
+
+        async def send_files(self, **kwargs: Any) -> bool:
+            payload = {"bot_token": self._bot_token}
+            payload.update(kwargs)
+            sent_groups.append(payload)
+            return True
+
+    monkeypatch.setattr(chat_module, "TelegramClient", _FakeTelegramClient)
+
+    text = await chat_module.handle_telegram_text(
+        body={"message": {"chat": {"id": 99}, "from": {"id": 100}, "text": "/debug_logs"}},
+        bot_token="123:abc",
+        agent_runtime=None,
+    )
+
+    assert text is None
+    assert len(sent_payloads) == 1
+    assert sent_payloads[0]["filename"] == "debug.log"
+    assert sent_groups == []


### PR DESCRIPTION
### Motivation
- Prefer a new cursor debug log location and discover multiple log files so operators can retrieve all available debug output. 
- Allow the Telegram bridge to send multiple log files as a media group when more than one log is present.

### Description
- Add `_debug_log_candidates` and `iter_available_debug_log_paths` to `core/debug_logs.py` and update `get_debug_log_path` and `read_debug_log_bytes` to prefer discovered files and fall back gracefully. 
- Change the Telegram chat service to use `iter_available_debug_log_paths` and build an upload list, sending a single file with `send_file` or multiple files with `send_files` as appropriate. 
- Implement `send_files` in `interfaces/telegram/client.py` to post a `sendMediaGroup` multipart request and handle Telegram API responses. 
- Add and update unit tests in `tests/test_core_debug_logs.py` and `tests/test_telegram_debug_logs_command.py` to cover discovery, fallback, missing logs, and single vs multiple-file sending behavior.

### Testing
- Ran the unit tests for the changed modules including `tests/test_core_debug_logs.py` and `tests/test_telegram_debug_logs_command.py`. 
- Verified the new and updated tests execute and pass locally under `pytest` for the modified behavior. 
- Existing Telegram client API handling tests were retained and validated as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5d26e39c83318d7a1631be29cdb5)