### PR TITLE
Rollback to c741705 and keep stale intake guard

### DIFF
--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -23,6 +23,7 @@ _ALLOWED_PROVIDERS = {"composio", "telegram_bot_api"}
 _ALLOWED_SINK_TYPES = {"google_sheets_composio", "local_csv", "generic_composio_write"}
 _DEFAULT_SCHEDULE = "*/5 * * * *"
 _DEFAULT_EDIT_WINDOW = timedelta(hours=2)
+_MAX_LATEST_INBOUND_AGE = timedelta(hours=1)
 _MAX_DECISION_RECOVERY_ATTEMPTS = 2
 _TELEGRAM_BUSINESS_WEBHOOK_DEBOUNCE_SECONDS = 1.5
 
@@ -46,6 +47,14 @@ def _parse_datetime(value: Any) -> datetime | None:
                 return parsed.replace(tzinfo=UTC)
             return parsed.astimezone(UTC)
     return None
+
+
+def _is_older_than(value: Any, *, max_age: timedelta, now: datetime | None = None) -> bool:
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return False
+    reference = now or _utc_now()
+    return parsed < (reference - max_age)
 
 
 def _json_dumps(value: Any) -> str:
@@ -1312,6 +1321,34 @@ class IntakeWorkflowService:
                     workflow_id=str(workflow["workflow_id"]),
                     conversation_id=conversation_id,
                 )
+                if not force and _is_older_than(
+                    conversation_summary.get("latest_inbound_message_created_time"),
+                    max_age=_MAX_LATEST_INBOUND_AGE,
+                ):
+                    self._set_cursor(
+                        workflow_id=str(workflow["workflow_id"]),
+                        conversation_id=conversation_id,
+                        latest_inbound_message_id=str(
+                            conversation_summary.get("latest_inbound_message_id", "") or ""
+                        ).strip(),
+                        latest_inbound_message_time=str(
+                            conversation_summary.get("latest_inbound_message_created_time", "") or ""
+                        ).strip(),
+                        conversation_updated_time=str(
+                            conversation_summary.get("conversation_updated_time", "") or ""
+                        ).strip(),
+                        latest_outbound_message_id=str(
+                            conversation_summary.get("latest_outbound_message_id", "") or ""
+                        ).strip(),
+                        agent_action_at=_utc_now_iso(),
+                    )
+                    self._emit_observability(
+                        event="intake.conversation.ignored",
+                        workflow=workflow,
+                        conversation_summary=conversation_summary,
+                        reason="stale_inbound_message",
+                    )
+                    continue
                 if not self._has_new_inbound_signal(
                     conversation_summary=conversation_summary,
                     cursor=cursor,

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -17,6 +17,15 @@ from opentulpa.scheduler.service import SchedulerService
 from opentulpa.skills.service import SkillStoreService
 
 
+@pytest.fixture(autouse=True)
+def _freeze_intake_test_now(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: intake_service_module._parse_datetime("2026-04-07T08:30:00+00:00"),
+    )
+
+
 def _instagram_conversation(
     *,
     conversation_id: str,
@@ -524,6 +533,73 @@ async def test_telegram_business_workflow_upsert_reuses_existing_workflow_for_cu
         item for item in workflows if item["channel"] == "telegram_business_dm"
     ]
     assert len(telegram_workflows) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_ignores_latest_inbound_older_than_one_hour(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_sender_username": "alice",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Book my sedan tomorrow at 3pm for a full wash.",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Book sedan wash.",
+                "extracted_fields": {"date": "tomorrow"},
+                "missing_fields": ["time"],
+                "reply_action": "send_reply",
+                "reply_text": "What time works for you?",
+                "ready_to_save": False,
+                "booking_action": "create_new_booking",
+                "save_payload": {},
+                "reason": "clear booking request",
+            }
+        ]
+    )
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=_FakeComposio(summary, conversation),
+    )
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: intake_service_module._parse_datetime("2026-04-07T10:00:01+00:00"),
+    )
+
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle booking requests.",
+        required_fields=["date", "time"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+
+    result = await service.run_workflow(customer_id="telegram_123", workflow_id=workflow["workflow_id"])
+
+    assert result["ok"] is True
+    assert result["processed_conversations"] == 0
+    assert result["matched_conversations"] == 0
+    assert result["summary"] == NO_NOTIFY_TOKEN
+    assert runtime.calls == []
+    cursor = service._get_cursor(workflow_id=workflow["workflow_id"], conversation_id="conv_1")  # noqa: SLF001
+    assert cursor["last_seen_inbound_message_id"] == "msg_1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Rollback `main` to the `fix: documentation` state and keep only the stale-intake safeguard.

What this PR does:
- returns the codebase to commit `c741705`
- reapplies only the one-hour stale inbound intake guard
- includes a focused regression test for that behavior

Validation:
- `uv run pytest tests/test_intake_workflow_service.py -q`
- `20 passed in 6.14s`