### PR TITLE
Add claim_check node and completion-claim repair flow with tests

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -726,7 +726,9 @@ def build_runtime_graph(runtime: Any):
         payload.update(fields)
         log_event(event=event, **payload)
 
-    async def agent_node(state: AgentState) -> Command[Literal["agent", "validate_tools", "finalize_turn"]]:
+    async def agent_node(
+        state: AgentState,
+    ) -> Command[Literal["agent", "validate_tools", "claim_check", "finalize_turn"]]:
         customer_id = state.get("customer_id", "")
         thread_id = state.get("thread_id", "")
         turn_mode = _normalize_turn_mode(state.get("turn_mode"))
@@ -1306,10 +1308,10 @@ def build_runtime_graph(runtime: Any):
             update["active_invoked_skill_context"] = invoked_skill_context
             update["active_invoked_skill_names"] = invoked_skill_names
             update["active_skill_context"] = invoked_skill_context
-        goto: Literal["validate_tools", "finalize_turn"] = (
+        goto: Literal["validate_tools", "claim_check"] = (
             "validate_tools"
             if isinstance(response, AIMessage) and bool(getattr(response, "tool_calls", []))
-            else "finalize_turn"
+            else "claim_check"
         )
         if (
             turn_mode == "workflow_setup"
@@ -2043,7 +2045,7 @@ def build_runtime_graph(runtime: Any):
         "agent",
         agent_node,
         retry_policy=RetryPolicy(max_attempts=3),
-        destinations=("agent", "validate_tools", "finalize_turn"),
+        destinations=("agent", "validate_tools", "claim_check", "finalize_turn"),
     )
     builder.add_node(
         "validate_tools",
@@ -2056,6 +2058,12 @@ def build_runtime_graph(runtime: Any):
         tools_node,
         retry_policy=RetryPolicy(max_attempts=3),
         destinations=("agent", END),
+    )
+    builder.add_node(
+        "claim_check",
+        claim_check_node,
+        retry_policy=RetryPolicy(max_attempts=2),
+        destinations=("agent", "finalize_turn"),
     )
     builder.add_node("finalize_turn", finalize_turn_node, retry_policy=RetryPolicy(max_attempts=1))
     builder.add_edge(START, "agent")

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -165,9 +165,11 @@ def _install_minimal_graph_runtime_stubs(
     runtime.ainvoke_model = ainvoke_model  # type: ignore[method-assign]
     runtime.resolve_link_aliases_in_args = lambda **kwargs: kwargs.get("args", {})  # type: ignore[assignment]
     runtime.register_links_from_text = lambda **kwargs: []  # type: ignore[assignment]
-    runtime.verify_completion_claim = verify_completion_claim or (  # type: ignore[assignment]
-        (lambda **kwargs: {"usable": True, "mismatch": False, "applies": False, "confidence": 0.0})
-    )
+    async def _default_verify_completion_claim(**kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {"usable": True, "mismatch": False, "applies": False, "confidence": 0.0}
+
+    runtime.verify_completion_claim = verify_completion_claim or _default_verify_completion_claim  # type: ignore[assignment]
     runtime.log_behavior_event = (  # type: ignore[assignment]
         (lambda **kwargs: behavior_events.append(str(kwargs.get("event", ""))))
         if behavior_events is not None

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -131,6 +131,7 @@ def _install_minimal_graph_runtime_stubs(
     runtime: OpenTulpaLangGraphRuntime,
     *,
     ainvoke_model: Any,
+    verify_completion_claim: Any | None = None,
     behavior_events: list[str] | None = None,
 ) -> None:
     async def _live_time(customer_id: str) -> dict[str, str]:
@@ -164,6 +165,9 @@ def _install_minimal_graph_runtime_stubs(
     runtime.ainvoke_model = ainvoke_model  # type: ignore[method-assign]
     runtime.resolve_link_aliases_in_args = lambda **kwargs: kwargs.get("args", {})  # type: ignore[assignment]
     runtime.register_links_from_text = lambda **kwargs: []  # type: ignore[assignment]
+    runtime.verify_completion_claim = verify_completion_claim or (  # type: ignore[assignment]
+        (lambda **kwargs: {"usable": True, "mismatch": False, "applies": False, "confidence": 0.0})
+    )
     runtime.log_behavior_event = (  # type: ignore[assignment]
         (lambda **kwargs: behavior_events.append(str(kwargs.get("event", ""))))
         if behavior_events is not None
@@ -228,6 +232,92 @@ async def test_graph_finalize_does_not_reuse_prior_turn_assistant_reply() -> Non
 
     assert first["final_response_text"] == "first reply"
     assert second["final_response_text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_graph_claim_check_repairs_false_success_claim() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    call_count = 0
+
+    async def _ainvoke_model(
+        model: Any,
+        messages: list[Any],
+        *,
+        stable_prefix_count: int = 0,
+        **kwargs: Any,
+    ) -> AIMessage:
+        del model, messages, stable_prefix_count, kwargs
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return AIMessage(content="Done — I already sent the update.")
+        return AIMessage(content="I have not sent it yet. I can do that now.")
+
+    async def _verify_completion_claim(**kwargs: Any) -> dict[str, Any]:
+        assistant_text = str(kwargs.get("assistant_text", ""))
+        if "already sent" in assistant_text:
+            return {"usable": True, "mismatch": True, "reason": "unsupported completion claim"}
+        return {"usable": True, "mismatch": False}
+
+    _install_minimal_graph_runtime_stubs(
+        runtime,
+        ainvoke_model=_ainvoke_model,
+        verify_completion_claim=_verify_completion_claim,
+    )
+    graph = build_runtime_graph(runtime)
+    result = await graph.ainvoke(
+        {
+            "messages": [HumanMessage(content="Did you send the update?")],
+            "customer_id": "telegram_test",
+            "thread_id": "chat-claim-check-repair",
+            "turn_mode": "interactive",
+            "turn_status": "running",
+            "final_response_text": "",
+            "pending_context_summary": "",
+            "agent_trace_id": "turn_claim_repair",
+        },
+        config={"configurable": {"thread_id": "chat-claim-check-repair"}, "recursion_limit": 8},
+    )
+    assert call_count == 2
+    assert result["final_response_text"] == "I have not sent it yet. I can do that now."
+
+
+@pytest.mark.asyncio
+async def test_graph_claim_check_repairs_empty_output() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    call_count = 0
+
+    async def _ainvoke_model(
+        model: Any,
+        messages: list[Any],
+        *,
+        stable_prefix_count: int = 0,
+        **kwargs: Any,
+    ) -> AIMessage:
+        del model, messages, stable_prefix_count, kwargs
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return AIMessage(content="")
+        return AIMessage(content="Here is the answer.")
+
+    _install_minimal_graph_runtime_stubs(runtime, ainvoke_model=_ainvoke_model)
+    graph = build_runtime_graph(runtime)
+    result = await graph.ainvoke(
+        {
+            "messages": [HumanMessage(content="answer please")],
+            "customer_id": "telegram_test",
+            "thread_id": "chat-claim-check-empty",
+            "turn_mode": "interactive",
+            "turn_status": "running",
+            "final_response_text": "",
+            "pending_context_summary": "",
+            "agent_trace_id": "turn_empty_repair",
+        },
+        config={"configurable": {"thread_id": "chat-claim-check-empty"}, "recursion_limit": 8},
+    )
+    assert call_count == 2
+    assert result["final_response_text"] == "Here is the answer."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Add a verification/repair step to the agent runtime graph to detect and repair incorrect or empty assistant completion claims before finalizing a turn.

### Description

- Extend the `agent_node` return type and goto logic to include a new `claim_check` destination and route non-tool AI responses to `claim_check` instead of directly to `finalize_turn` when appropriate by changing the `goto` selection to include `"claim_check"`.
- Register a new graph node `claim_check` with `claim_check_node` and add it to the builder destinations (`("agent", "claim_check", "finalize_turn")` in the root destinations tuple and the node registration), and update the builder's destinations tuple to include `"claim_check"`.
- Add runtime stub wiring for `runtime.verify_completion_claim` in `_install_minimal_graph_runtime_stubs` so tests can inject a verifier implementation.
- Add two tests exercising the repair behavior: `test_graph_claim_check_repairs_false_success_claim` and `test_graph_claim_check_repairs_empty_output` which verify that the graph re-invokes the model to repair mismatched or empty assistant outputs.

### Testing

- Ran the modified test module with `pytest tests/test_runtime_pending_context_input.py` and the new tests `test_graph_claim_check_repairs_false_success_claim` and `test_graph_claim_check_repairs_empty_output` completed successfully.
- Existing related tests in the same file, including `test_graph_finalize_does_not_reuse_prior_turn_assistant_reply`, also ran and passed.
- No new failing tests were observed when running `pytest -q` on the test suite containing the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b0bc203483319584af75b1b8b232)