### PR TITLE
[P2] Let Google Sheets setup preflight resolve single-tab sheetName

### DIFF
--- a/src/opentulpa/agent/workflow_setup_prompt_context.py
+++ b/src/opentulpa/agent/workflow_setup_prompt_context.py
@@ -40,8 +40,6 @@ def _sink_status(*, sink_type: str, sink_config: dict[str, Any]) -> tuple[str, l
         static_arguments = _safe_dict(sink_config.get("static_arguments"))
         if not str(static_arguments.get("spreadsheetId", "") or "").strip():
             missing.append("sink_config.static_arguments.spreadsheetId")
-        if not str(static_arguments.get("sheetName", "") or "").strip():
-            missing.append("sink_config.static_arguments.sheetName")
         toolkit = str(sink_config.get("toolkit", "") or "").strip()
         if toolkit != "googlesheets":
             missing.append("sink_config.toolkit=googlesheets")

--- a/tests/test_workflow_setup_prompt_context.py
+++ b/tests/test_workflow_setup_prompt_context.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from opentulpa.agent.workflow_setup_prompt_context import build_workflow_setup_control_context
+
+
+def _session_with_google_sheets_sink(*, sheet_name: str = "") -> dict[str, object]:
+    static_arguments: dict[str, str] = {"spreadsheetId": "sheet_123"}
+    if sheet_name:
+        static_arguments["sheetName"] = sheet_name
+    return {
+        "status": "active",
+        "mode": "create",
+        "draft_upsert": {
+            "name": "AutoSpa",
+            "channel": "telegram_business_dm",
+            "intent_description": "Book car wash leads",
+            "required_fields": ["service_name", "date", "time", "phone"],
+            "sink_type": "google_sheets_composio",
+            "sink_config": {
+                "toolkit": "googlesheets",
+                "static_arguments": static_arguments,
+            },
+        },
+        "scratchpad": {},
+    }
+
+
+def test_control_card_allows_preflight_without_google_sheets_sheet_name() -> None:
+    card = build_workflow_setup_control_context(_session_with_google_sheets_sink())
+
+    assert "draft_status: needs_preflight" in card
+    assert "missing_core_inputs: none" in card
+    assert "Call intake_workflow_setup_preflight" in card
+
+
+def test_control_card_asks_follow_up_when_preflight_needs_google_sheets_tab_clarification() -> None:
+    session = _session_with_google_sheets_sink()
+    session["scratchpad"] = {
+        "last_preflight": {
+            "ok": False,
+            "status": "needs_clarification",
+            "follow_up_questions": ["Which tab should I write into?"],
+        }
+    }
+
+    card = build_workflow_setup_control_context(session)
+
+    assert "draft_status: needs_clarification" in card
+    assert "latest_preflight_follow_up: Which tab should I write into?" in card
+    assert "ask this blocker only: Which tab should I write into?" in card


### PR DESCRIPTION
### Motivation
- The workflow setup control card treated a missing `sink_config.static_arguments.sheetName` as a blocker even though the backend can auto-resolve `sheetName` when a spreadsheet has exactly one tab, which prevents preflight from running unnecessarily.
- The behavior must still require `spreadsheetId` and `toolkit=googlesheets`, and must continue to surface clarification when tab resolution is genuinely ambiguous.

### Description
- Stop treating a missing `sink_config.static_arguments.sheetName` as a required field in the control-card sink completeness check by removing that check in `_sink_status` in `src/opentulpa/agent/workflow_setup_prompt_context.py` so drafts with `spreadsheetId` can proceed to preflight.
- Preserve the existing requirement for `sink_config.static_arguments.spreadsheetId` and `sink_config.toolkit=googlesheets` in the same check.
- Add focused unit tests in `tests/test_workflow_setup_prompt_context.py` that assert the control card returns `draft_status: needs_preflight` when only `sheetName` is missing and that it surfaces follow-up clarification when `last_preflight` indicates `needs_clarification`.

### Testing
- Ran `pytest -q tests/test_workflow_setup_prompt_context.py` and the two new tests passed.
- Attempted to run a larger runtime test collection, but collection failed due to a missing test dependency (`ModuleNotFoundError: No module named 'langgraph'`) when importing other test modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b9fbc3248331a15e6a684e41af81)