### PR TITLE
[P2] Standardize SQLite runtime store connection policy

### DIFF
--- a/docs/sqlite-runtime-policy.md
+++ b/docs/sqlite-runtime-policy.md
@@ -1,0 +1,46 @@
+# SQLite runtime store policy
+
+## Inventory of OpenTulpa-owned runtime SQLite stores
+
+These stores are owned by OpenTulpa runtime code and now use the shared connection policy helper:
+
+- `src/opentulpa/tasks/service.py`
+- `src/opentulpa/tasks/wake_queue.py`
+- `src/opentulpa/scheduler/service.py`
+- `src/opentulpa/intake/service.py`
+- `src/opentulpa/intake/workflow_setup_store.py`
+- `src/opentulpa/approvals/store.py`
+- `src/opentulpa/context/service.py`
+- `src/opentulpa/context/customer_profiles.py`
+- `src/opentulpa/context/link_aliases.py`
+- `src/opentulpa/context/thread_rollups.py`
+- `src/opentulpa/context/file_vault.py`
+- `src/opentulpa/interfaces/telegram/business.py`
+- `src/opentulpa/skills/service.py`
+- `src/opentulpa/business_knowledge/service.py`
+
+LangGraph checkpoint internals are intentionally out of scope.
+
+## Standard connection policy
+
+`opentulpa.persistence.sqlite.connect_sqlite` centralizes:
+
+- nonzero `timeout` on `sqlite3.connect`
+- `PRAGMA busy_timeout`
+- `PRAGMA synchronous=NORMAL`
+- optional `PRAGMA journal_mode=WAL` (enabled for runtime stores above)
+
+## SQLAlchemy/SQLModel boundary decision
+
+For this refactor, we keep raw `sqlite3` for OpenTulpa-owned stores and standardize behavior through a thin helper.
+
+Rationale:
+
+- The lock failures came from inconsistent connection pragmas rather than query composition.
+- Most stores are small, simple, and already stable with direct SQL statements.
+- Migrating to SQLAlchemy Core/SQLModel would add dependency and migration overhead without directly reducing lock contention.
+
+Boundary:
+
+- OpenTulpa durable runtime stores should use `connect_sqlite`.
+- If future modules require cross-database portability, rich transaction orchestration, or declarative schema management, SQLAlchemy Core can be adopted module-by-module rather than globally.

--- a/src/opentulpa/approvals/store.py
+++ b/src/opentulpa/approvals/store.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -20,9 +22,7 @@ class PendingApprovalStore:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/business_knowledge/service.py
+++ b/src/opentulpa/business_knowledge/service.py
@@ -7,6 +7,8 @@ import json
 import os
 import re
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 import threading
 import time
 from contextlib import suppress
@@ -38,8 +40,6 @@ from opentulpa.context.file_vault import FileVaultService
 from opentulpa.core.ids import new_short_id
 
 _VALID_SCOPE_TYPES = {"workflow_setup", "intake_workflow", "customer_business"}
-_SQLITE_BUSY_TIMEOUT_MS = 10_000
-_SQLITE_CONNECT_TIMEOUT_SECONDS = _SQLITE_BUSY_TIMEOUT_MS / 1000
 _DEFAULT_SOURCE_PACK_CHAR_LIMIT = 800_000
 _DEFAULT_ORACLE_MODEL = "google/gemini-3.1-flash-lite-preview"
 _DEFAULT_ORACLE_MAX_OUTPUT_TOKENS = 1000
@@ -279,15 +279,7 @@ class BusinessKnowledgeService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(
-            self.db_path,
-            check_same_thread=False,
-            timeout=_SQLITE_CONNECT_TIMEOUT_SECONDS,
-        )
-        conn.row_factory = sqlite3.Row
-        conn.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
-        conn.execute("PRAGMA synchronous=NORMAL")
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.root_dir.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/context/customer_profiles.py
+++ b/src/opentulpa/context/customer_profiles.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -38,9 +40,7 @@ class CustomerProfileService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/context/file_vault.py
+++ b/src/opentulpa/context/file_vault.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
@@ -113,9 +115,7 @@ class FileVaultService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.root_dir.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/context/link_aliases.py
+++ b/src/opentulpa/context/link_aliases.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -80,9 +82,7 @@ class LinkAliasService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/context/service.py
+++ b/src/opentulpa/context/service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -17,9 +19,7 @@ class EventContextService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/context/thread_rollups.py
+++ b/src/opentulpa/context/thread_rollups.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -17,9 +19,7 @@ class ThreadRollupService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -8,6 +8,8 @@ import json
 import logging
 import re
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 import threading
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
@@ -886,9 +888,7 @@ class IntakeWorkflowService:
         }
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self._db_path, wal=True)
 
     def _init_db(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/intake/workflow_setup_store.py
+++ b/src/opentulpa/intake/workflow_setup_store.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -37,9 +39,7 @@ class WorkflowSetupSessionStore:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self._db_path, wal=True)
 
     def _init_db(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/interfaces/telegram/business.py
+++ b/src/opentulpa/interfaces/telegram/business.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -49,9 +51,7 @@ class TelegramBusinessService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self._db_path, wal=True)
 
     def _init_db(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/persistence/__init__.py
+++ b/src/opentulpa/persistence/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence helpers shared across OpenTulpa runtime stores."""
+
+from opentulpa.persistence.sqlite import SQLITE_BUSY_TIMEOUT_MS, SQLITE_CONNECT_TIMEOUT_SECONDS, connect_sqlite
+
+__all__ = ["connect_sqlite", "SQLITE_BUSY_TIMEOUT_MS", "SQLITE_CONNECT_TIMEOUT_SECONDS"]

--- a/src/opentulpa/persistence/sqlite.py
+++ b/src/opentulpa/persistence/sqlite.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+SQLITE_CONNECT_TIMEOUT_SECONDS = 10.0
+SQLITE_BUSY_TIMEOUT_MS = 10_000
+
+
+def connect_sqlite(
+    db_path: Path,
+    *,
+    check_same_thread: bool = False,
+    timeout_seconds: float = SQLITE_CONNECT_TIMEOUT_SECONDS,
+    busy_timeout_ms: int = SQLITE_BUSY_TIMEOUT_MS,
+    row_factory: type[sqlite3.Row] | None = sqlite3.Row,
+    synchronous_normal: bool = True,
+    wal: bool = False,
+) -> sqlite3.Connection:
+    """Create a SQLite connection using OpenTulpa's runtime-safe defaults."""
+    conn = sqlite3.connect(
+        db_path,
+        check_same_thread=check_same_thread,
+        timeout=timeout_seconds,
+    )
+    if row_factory is not None:
+        conn.row_factory = row_factory
+    conn.execute(f"PRAGMA busy_timeout={max(1, int(busy_timeout_ms))}")
+    if synchronous_normal:
+        conn.execute("PRAGMA synchronous=NORMAL")
+    if wal:
+        conn.execute("PRAGMA journal_mode=WAL")
+    return conn

--- a/src/opentulpa/scheduler/service.py
+++ b/src/opentulpa/scheduler/service.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -51,9 +53,7 @@ class SchedulerService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self._db_path, wal=True)
 
     def _init_db(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/skills/service.py
+++ b/src/opentulpa/skills/service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 import shutil
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 import threading
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -342,9 +344,7 @@ class SkillStoreService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/tasks/service.py
+++ b/src/opentulpa/tasks/service.py
@@ -7,6 +7,8 @@ import contextlib
 import json
 import logging
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -68,9 +70,7 @@ class TaskService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/opentulpa/tasks/wake_queue.py
+++ b/src/opentulpa/tasks/wake_queue.py
@@ -7,6 +7,8 @@ import contextlib
 import json
 import logging
 import sqlite3
+
+from opentulpa.persistence.sqlite import connect_sqlite
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -36,9 +38,7 @@ class WakeQueueService:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
+        return connect_sqlite(self.db_path, wal=True)
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_task_service_sqlite_policy.py
+++ b/tests/test_task_service_sqlite_policy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+from opentulpa.tasks.service import TaskService
+
+
+def test_task_service_connection_pragmas(tmp_path):
+    db_path = tmp_path / "tasks.db"
+    service = TaskService(db_path)
+
+    with service._conn() as conn:
+        journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        busy_timeout = int(conn.execute("PRAGMA busy_timeout").fetchone()[0])
+
+    assert journal_mode == "wal"
+    assert busy_timeout >= 10_000
+
+
+def test_task_service_concurrent_creates_do_not_lock(tmp_path):
+    db_path = tmp_path / "tasks.db"
+    service = TaskService(db_path)
+
+    async def _run():
+        async def create_one(i: int):
+            return await service.create_task(
+                customer_id="cust",
+                goal=f"goal-{i}",
+                payload={"n": i},
+                idempotency_key=f"k-{i}",
+            )
+
+        results = await asyncio.gather(*(create_one(i) for i in range(40)))
+        assert len(results) == 40
+
+    asyncio.run(_run())
+
+    with sqlite3.connect(db_path) as conn:
+        count = int(conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0])
+    assert count == 40


### PR DESCRIPTION
### Motivation

- Prevent intermittent `database is locked` failures by standardizing SQLite connection timeouts and pragmas across OpenTulpa runtime stores. 
- Provide a single, thin helper to apply safe defaults (connect timeout, `busy_timeout`, `synchronous=NORMAL`, optional WAL) without changing higher-level persistence patterns or LangGraph checkpoint ownership.

### Description

- Add a shared helper `opentulpa.persistence.sqlite.connect_sqlite` that centralizes `timeout`, `PRAGMA busy_timeout`, `PRAGMA synchronous=NORMAL`, and optional `PRAGMA journal_mode=WAL` defaults. 
- Migrate OpenTulpa-owned runtime/customer/task SQLite stores to use `connect_sqlite(..., wal=True)` including `tasks`, `wake_queue`, `scheduler`, `intake` stores, `approvals`, context stores, `file_vault`, `telegram` business store, `skills`, and `business_knowledge` modules. 
- Add documentation `docs/sqlite-runtime-policy.md` that inventories affected stores and documents the SQLAlchemy/SQLModel boundary decision (keep raw `sqlite3` with a thin helper for now). 
- Add focused regression tests in `tests/test_task_service_sqlite_policy.py` that assert WAL and `busy_timeout` pragmas and exercise concurrent task creation to surface lock contention.

### Testing

- Ran `python -m compileall -q src/opentulpa` which succeeded. 
- Ran `pytest -q tests/test_task_service_sqlite_policy.py tests/test_business_knowledge_service.py` which failed during collection due to environment limitations: Python 3.10 in this environment lacks `datetime.UTC` usage present in the codebase and `openpyxl` (an optional test dependency) is not installed, causing test collection to abort. 
- The new `tests/test_task_service_sqlite_policy.py` implements pragma assertions and a concurrent-create regression scenario; it should pass when run in a matching project environment with required deps and a Python version compatible with existing code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba22e2988331bf4c2677e15c2d81)