### PR TITLE
Add optional CapSolver support for Browser Use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,7 @@ TELEGRAM_SUPPORT_USER_IDS=
 
 # Optional: Composio Tool Router integration for external SaaS auth/tool access
 COMPOSIO_API_KEY=
+
+# Optional: CapSolver CAPTCHA solving for Browser Use.
+# Disabled unless this key is set.
+CAPSOLVER_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -48,5 +48,5 @@ TELEGRAM_SUPPORT_USER_IDS=
 COMPOSIO_API_KEY=
 
 # Optional: CapSolver CAPTCHA solving for Browser Use.
-# Disabled unless this key is set. Supports reCAPTCHA v2 and Cloudflare Turnstile.
+# Disabled unless this key is set. Supports reCAPTCHA v2/v3 and Cloudflare Turnstile.
 CAPSOLVER_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -48,5 +48,5 @@ TELEGRAM_SUPPORT_USER_IDS=
 COMPOSIO_API_KEY=
 
 # Optional: CapSolver CAPTCHA solving for Browser Use.
-# Disabled unless this key is set.
+# Disabled unless this key is set. Supports reCAPTCHA v2 and Cloudflare Turnstile.
 CAPSOLVER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Installed by default. Skip it with:
 ```
 
 Browser Use CAPTCHA solving is optional and disabled by default. To enable the
-CapSolver-backed action for supported reCAPTCHA v2 and Cloudflare Turnstile
+CapSolver-backed action for supported reCAPTCHA v2/v3 and Cloudflare Turnstile
 pages, set:
 
 ```bash
@@ -462,7 +462,7 @@ Useful `.env` knobs:
 - `START_MODE=auto|app|manager`
 - `INSTALL_BROWSER_USE=1|0`
 - `INSTALL_CLOUDFLARED=auto|1|0`
-- `CAPSOLVER_API_KEY=...` enables an optional Browser Use CAPTCHA action for supported reCAPTCHA v2 and Cloudflare Turnstile pages. When set, Browser Use tasks are told to call the solver if a supported CAPTCHA blocks progress. Leave it unset to keep CAPTCHA solving disabled.
+- `CAPSOLVER_API_KEY=...` enables an optional Browser Use CAPTCHA action for supported reCAPTCHA v2/v3 and Cloudflare Turnstile pages. When set, Browser Use tasks are told to call the solver if a supported CAPTCHA blocks progress. Leave it unset to keep CAPTCHA solving disabled.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Useful `.env` knobs:
 - `START_MODE=auto|app|manager`
 - `INSTALL_BROWSER_USE=1|0`
 - `INSTALL_CLOUDFLARED=auto|1|0`
+- `CAPSOLVER_API_KEY=...` enables an optional Browser Use CAPTCHA action for supported reCAPTCHA v2 and Cloudflare Turnstile pages. When set, Browser Use tasks are told to call the solver if a supported CAPTCHA blocks progress. Leave it unset to keep CAPTCHA solving disabled.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,19 @@ Installed by default. Skip it with:
 ./start.sh --no-browser-use
 ```
 
+Browser Use CAPTCHA solving is optional and disabled by default. To enable the
+CapSolver-backed action for supported reCAPTCHA v2 and Cloudflare Turnstile
+pages, set:
+
+```bash
+CAPSOLVER_API_KEY=...
+```
+
+When this key is present, OpenTulpa registers `solve_captcha_with_capsolver`
+for Browser Use tasks and tells the browser agent to call it if a supported
+CAPTCHA blocks progress. If the key is absent, Browser Use runs without the
+solver action or CAPTCHA-specific prompt hint.
+
 ### Composio
 
 If you want access to supported third-party apps:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -116,6 +116,18 @@ Skip browser installation with:
 ./start.sh --no-browser-use
 ```
 
+Optional CAPTCHA solving for Browser Use is disabled unless you configure
+CapSolver:
+
+```bash
+CAPSOLVER_API_KEY=...
+```
+
+When configured, OpenTulpa registers a `solve_captcha_with_capsolver` Browser
+Use action for supported reCAPTCHA v2 and Cloudflare Turnstile pages. Without
+the key, the solver is not registered and normal Browser Use behavior is
+unchanged.
+
 ## Useful startup commands
 
 | Command | Meaning |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -124,7 +124,7 @@ CAPSOLVER_API_KEY=...
 ```
 
 When configured, OpenTulpa registers a `solve_captcha_with_capsolver` Browser
-Use action for supported reCAPTCHA v2 and Cloudflare Turnstile pages. Without
+Use action for supported reCAPTCHA v2/v3 and Cloudflare Turnstile pages. Without
 the key, the solver is not registered and normal Browser Use behavior is
 unchanged.
 

--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -391,6 +391,7 @@ def main() -> None:
             browser_use_model_override=settings.browser_use_model or settings.multimodal_llm,
             browser_use_max_concurrent_tasks=settings.browser_use_max_concurrent_tasks,
             browser_use_task_retention_seconds=settings.browser_use_task_retention_seconds,
+            capsolver_api_key=settings.capsolver_api_key,
             prompt_caching_enabled=settings.agent_prompt_caching_enabled,
             prompt_cache_ttl_1h=settings.agent_prompt_cache_ttl_1h,
             posthog_api_key=settings.posthog_api_key,

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1209,6 +1209,7 @@ class OpenTulpaLangGraphRuntime:
         browser_use_model_override: str | None = None,
         browser_use_max_concurrent_tasks: int = 2,
         browser_use_task_retention_seconds: int = 1800,
+        capsolver_api_key: str | None = None,
         prompt_caching_enabled: bool = True,
         prompt_cache_ttl_1h: bool = False,
         posthog_api_key: str | None = None,
@@ -1280,6 +1281,7 @@ class OpenTulpaLangGraphRuntime:
         self._browser_use_model_override = str(browser_use_model_override or "").strip()
         self._browser_use_max_concurrent_tasks = max(1, int(browser_use_max_concurrent_tasks))
         self._browser_use_task_retention_seconds = max(60, int(browser_use_task_retention_seconds))
+        self._capsolver_api_key = str(capsolver_api_key or "").strip()
         self._prompt_caching_enabled = bool(prompt_caching_enabled)
         self._prompt_cache_ttl_1h = bool(prompt_cache_ttl_1h)
         self._posthog_logger = create_posthog_logger(
@@ -1636,6 +1638,7 @@ class OpenTulpaLangGraphRuntime:
                 headless=self._browser_use_headless,
                 max_concurrent_tasks=self._browser_use_max_concurrent_tasks,
                 task_retention_seconds=self._browser_use_task_retention_seconds,
+                capsolver_api_key=self._capsolver_api_key,
             )
         return self._browser_use_local_manager
 

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -302,6 +302,13 @@ class Settings(BaseSettings):
         le=86400,
         description="How long completed local Browser Use task records remain queryable in memory.",
     )
+    capsolver_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional CapSolver API key. When set, local Browser Use tasks get an explicit "
+            "CAPTCHA-solving action for supported reCAPTCHA v2 and Cloudflare Turnstile pages."
+        ),
+    )
     composio_api_key: str | None = Field(
         default=None,
         description="Composio API key used for Tool Router sessions and auth flows.",

--- a/src/opentulpa/integrations/__init__.py
+++ b/src/opentulpa/integrations/__init__.py
@@ -1,13 +1,14 @@
-"""Integrations: Browser Use, Composio, web-search, and external service connectors."""
+"""Integrations: Browser Use, CapSolver, Composio, web-search, and external service connectors."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__all__ = ["BrowserUseLocalManager", "ComposioService", "HeadroomService"]
+__all__ = ["BrowserUseLocalManager", "CapSolverClient", "ComposioService", "HeadroomService"]
 
 if TYPE_CHECKING:
     from opentulpa.integrations.browser_use_local import BrowserUseLocalManager
+    from opentulpa.integrations.capsolver import CapSolverClient
     from opentulpa.integrations.composio import ComposioService
     from opentulpa.integrations.headroom import HeadroomService
 
@@ -17,6 +18,10 @@ def __getattr__(name: str) -> Any:
         from opentulpa.integrations.browser_use_local import BrowserUseLocalManager
 
         return BrowserUseLocalManager
+    if name == "CapSolverClient":
+        from opentulpa.integrations.capsolver import CapSolverClient
+
+        return CapSolverClient
     if name == "ComposioService":
         from opentulpa.integrations.composio import ComposioService
 

--- a/src/opentulpa/integrations/browser_use_captcha.py
+++ b/src/opentulpa/integrations/browser_use_captcha.py
@@ -1,0 +1,278 @@
+"""Optional Browser Use CAPTCHA action backed by CapSolver."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from opentulpa.integrations.capsolver import CapSolverClient, CapSolverError
+
+if TYPE_CHECKING:
+    from browser_use import ActionResult, Controller
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCaptchaChallenge:
+    captcha_type: str
+    website_url: str
+    website_key: str
+    marker: str
+
+
+_DETECT_CAPTCHA_SCRIPT = """() => {
+  const currentUrl = String(window.location.href || '');
+  const attr = (element, name) => element ? String(element.getAttribute(name) || '').trim() : '';
+  const parseParam = (rawUrl, names) => {
+    try {
+      const url = new URL(rawUrl, currentUrl);
+      for (const name of names) {
+        const value = String(url.searchParams.get(name) || '').trim();
+        if (value) return value;
+      }
+    } catch (_) {}
+    return '';
+  };
+
+  const recaptchaElement = document.querySelector(
+    '.g-recaptcha[data-sitekey], [data-sitekey][class*="g-recaptcha"], [data-sitekey][data-callback]'
+  );
+  const recaptchaKey = attr(recaptchaElement, 'data-sitekey');
+  if (recaptchaKey) {
+    return {
+      captchaType: 'recaptcha_v2',
+      websiteUrl: currentUrl,
+      websiteKey: recaptchaKey,
+      marker: 'g-recaptcha'
+    };
+  }
+
+  const recaptchaFrame = Array.from(document.querySelectorAll('iframe[src*="recaptcha"]'))
+    .find((frame) => parseParam(frame.getAttribute('src') || '', ['k', 'render']));
+  const frameRecaptchaKey = recaptchaFrame
+    ? parseParam(recaptchaFrame.getAttribute('src') || '', ['k', 'render'])
+    : '';
+  if (frameRecaptchaKey && frameRecaptchaKey !== 'explicit') {
+    return {
+      captchaType: 'recaptcha_v2',
+      websiteUrl: currentUrl,
+      websiteKey: frameRecaptchaKey,
+      marker: 'recaptcha iframe'
+    };
+  }
+
+  const turnstileElement = document.querySelector(
+    '.cf-turnstile[data-sitekey], [data-sitekey][class*="turnstile"]'
+  );
+  const turnstileKey = attr(turnstileElement, 'data-sitekey');
+  if (turnstileKey) {
+    return {
+      captchaType: 'turnstile',
+      websiteUrl: currentUrl,
+      websiteKey: turnstileKey,
+      marker: 'cf-turnstile'
+    };
+  }
+
+  const turnstileFrame = Array.from(document.querySelectorAll('iframe[src*="challenges.cloudflare.com"]'))
+    .find((frame) => parseParam(frame.getAttribute('src') || '', ['sitekey', 'k']));
+  const frameTurnstileKey = turnstileFrame
+    ? parseParam(turnstileFrame.getAttribute('src') || '', ['sitekey', 'k'])
+    : '';
+  if (frameTurnstileKey) {
+    return {
+      captchaType: 'turnstile',
+      websiteUrl: currentUrl,
+      websiteKey: frameTurnstileKey,
+      marker: 'turnstile iframe'
+    };
+  }
+
+  return null;
+}"""
+
+
+_INJECT_CAPTCHA_TOKEN_SCRIPT = """(captchaType, token) => {
+  const dispatchValueEvents = (element) => {
+    for (const name of ['input', 'change']) {
+      element.dispatchEvent(new Event(name, { bubbles: true }));
+    }
+  };
+  const setElementValue = (element, value) => {
+    if (!element) return false;
+    element.value = value;
+    element.innerHTML = value;
+    dispatchValueEvents(element);
+    return true;
+  };
+  const ensureHiddenField = (name, id) => {
+    let element = document.querySelector(`textarea[name="${name}"], input[name="${name}"], #${id}`);
+    if (!element) {
+      element = document.createElement('textarea');
+      element.name = name;
+      element.id = id;
+      element.style.display = 'none';
+      document.body.appendChild(element);
+    }
+    return element;
+  };
+  const callNamedCallback = (callbackName) => {
+    if (!callbackName) return false;
+    const callback = callbackName.split('.').reduce((obj, key) => obj && obj[key], window);
+    if (typeof callback !== 'function') return false;
+    callback(token);
+    return true;
+  };
+
+  let fieldsUpdated = 0;
+  let callbacksCalled = 0;
+  if (captchaType === 'recaptcha_v2') {
+    const response = ensureHiddenField('g-recaptcha-response', 'g-recaptcha-response');
+    if (setElementValue(response, token)) fieldsUpdated += 1;
+    const callbackName = document.querySelector('.g-recaptcha[data-callback], [data-callback]')
+      ?.getAttribute('data-callback');
+    if (callNamedCallback(callbackName)) callbacksCalled += 1;
+
+    const clients = window.___grecaptcha_cfg && window.___grecaptcha_cfg.clients;
+    const seen = new Set();
+    const walk = (value) => {
+      if (!value || typeof value !== 'object' || seen.has(value)) return;
+      seen.add(value);
+      for (const [key, child] of Object.entries(value)) {
+        if (key === 'callback' && typeof child === 'function') {
+          child(token);
+          callbacksCalled += 1;
+        } else if (child && typeof child === 'object') {
+          walk(child);
+        }
+      }
+    };
+    if (clients && typeof clients === 'object') walk(clients);
+  } else if (captchaType === 'turnstile') {
+    const response = ensureHiddenField('cf-turnstile-response', 'cf-turnstile-response');
+    if (setElementValue(response, token)) fieldsUpdated += 1;
+    const callbackName = document.querySelector('.cf-turnstile[data-callback], [data-callback]')
+      ?.getAttribute('data-callback');
+    if (callNamedCallback(callbackName)) callbacksCalled += 1;
+  }
+
+  return {
+    ok: fieldsUpdated > 0 || callbacksCalled > 0,
+    fieldsUpdated,
+    callbacksCalled
+  };
+}"""
+
+
+def build_capsolver_controller(capsolver: CapSolverClient) -> Controller:
+    """Build a Browser Use controller with a CapSolver action."""
+    from browser_use import ActionResult, Controller
+
+    controller = Controller()
+
+    @controller.action(
+        "Solve a visible reCAPTCHA v2 or Cloudflare Turnstile challenge using CapSolver. "
+        "Use only when a CAPTCHA is blocking the browser task.",
+        domains=["*"],
+    )
+    async def solve_captcha_with_capsolver(browser_session) -> ActionResult:
+        page = await browser_session.get_current_page()
+        if page is None:
+            return ActionResult(success=False, error="No active browser page for CAPTCHA solving")
+
+        try:
+            challenge = await detect_browser_captcha(page)
+            if challenge is None:
+                return ActionResult(
+                    success=False,
+                    extracted_content="No supported CAPTCHA was detected on the current page.",
+                )
+            if challenge.captcha_type == "recaptcha_v2":
+                result = await capsolver.solve_recaptcha_v2(
+                    website_url=challenge.website_url,
+                    website_key=challenge.website_key,
+                )
+            elif challenge.captcha_type == "turnstile":
+                result = await capsolver.solve_turnstile(
+                    website_url=challenge.website_url,
+                    website_key=challenge.website_key,
+                )
+            else:
+                return ActionResult(
+                    success=False,
+                    error=f"Unsupported CAPTCHA type: {challenge.captcha_type}",
+                )
+            injected = await inject_browser_captcha_token(
+                page,
+                captcha_type=challenge.captcha_type,
+                token=result.token,
+            )
+            if not injected.get("ok"):
+                return ActionResult(
+                    success=False,
+                    error="CapSolver returned a token but OpenTulpa could not inject it into the page.",
+                )
+            return ActionResult(
+                extracted_content=f"CAPTCHA solved with CapSolver ({challenge.captcha_type}).",
+            )
+        except (CapSolverError, ValueError) as exc:
+            return ActionResult(success=False, error=str(exc))
+
+    return controller
+
+
+async def detect_browser_captcha(page: Any) -> BrowserCaptchaChallenge | None:
+    raw = await page.evaluate(_DETECT_CAPTCHA_SCRIPT)
+    data = _coerce_json_object(raw)
+    if not data:
+        return None
+    captcha_type = str(data.get("captchaType") or "").strip()
+    website_url = str(data.get("websiteUrl") or "").strip()
+    website_key = str(data.get("websiteKey") or "").strip()
+    marker = str(data.get("marker") or "").strip()
+    if captcha_type not in {"recaptcha_v2", "turnstile"}:
+        return None
+    if not website_url:
+        raise ValueError("Detected CAPTCHA without a page URL")
+    if not website_key:
+        raise ValueError("Detected CAPTCHA without a site key")
+    return BrowserCaptchaChallenge(
+        captcha_type=captcha_type,
+        website_url=website_url,
+        website_key=website_key,
+        marker=marker,
+    )
+
+
+async def inject_browser_captcha_token(
+    page: Any,
+    *,
+    captcha_type: str,
+    token: str,
+) -> dict[str, Any]:
+    safe_type = str(captcha_type or "").strip()
+    safe_token = str(token or "").strip()
+    if safe_type not in {"recaptcha_v2", "turnstile"}:
+        raise ValueError(f"Unsupported CAPTCHA type: {safe_type}")
+    if not safe_token:
+        raise ValueError("CAPTCHA solution token is empty")
+    raw = await page.evaluate(_INJECT_CAPTCHA_TOKEN_SCRIPT, safe_type, safe_token)
+    data = _coerce_json_object(raw)
+    return data if data else {"ok": False}
+
+
+def _coerce_json_object(raw: Any) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text or text == "null":
+            return None
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None

--- a/src/opentulpa/integrations/browser_use_captcha.py
+++ b/src/opentulpa/integrations/browser_use_captcha.py
@@ -43,7 +43,7 @@ _DETECT_CAPTCHA_SCRIPT = """() => {
   const pageSource = scriptTexts + '\\n' + scriptSrcs.join('\\n');
 
   const recaptchaElement = document.querySelector(
-    '.g-recaptcha[data-sitekey], [data-sitekey][class*="g-recaptcha"], [data-sitekey][data-callback]'
+    '.g-recaptcha[data-sitekey], [data-sitekey][class*="g-recaptcha"]'
   );
   const recaptchaKey = attr(recaptchaElement, 'data-sitekey');
   if (recaptchaKey) {

--- a/src/opentulpa/integrations/browser_use_captcha.py
+++ b/src/opentulpa/integrations/browser_use_captcha.py
@@ -18,6 +18,7 @@ class BrowserCaptchaChallenge:
     website_url: str
     website_key: str
     marker: str
+    page_action: str | None = None
 
 
 _DETECT_CAPTCHA_SCRIPT = """() => {
@@ -33,6 +34,13 @@ _DETECT_CAPTCHA_SCRIPT = """() => {
     } catch (_) {}
     return '';
   };
+  const scriptTexts = Array.from(document.scripts)
+    .map((script) => String(script.textContent || ''))
+    .join('\\n');
+  const scriptSrcs = Array.from(document.scripts)
+    .map((script) => String(script.getAttribute('src') || ''))
+    .filter(Boolean);
+  const pageSource = scriptTexts + '\\n' + scriptSrcs.join('\\n');
 
   const recaptchaElement = document.querySelector(
     '.g-recaptcha[data-sitekey], [data-sitekey][class*="g-recaptcha"], [data-sitekey][data-callback]'
@@ -44,6 +52,28 @@ _DETECT_CAPTCHA_SCRIPT = """() => {
       websiteUrl: currentUrl,
       websiteKey: recaptchaKey,
       marker: 'g-recaptcha'
+    };
+  }
+
+  const renderScript = scriptSrcs.find((src) =>
+    src.includes('recaptcha') && parseParam(src, ['render'])
+  );
+  const renderKey = renderScript ? parseParam(renderScript, ['render']) : '';
+  const executeKeyMatch = pageSource.match(
+    /grecaptcha(?:\\.enterprise)?\\.execute\\s*\\(\\s*['"]([^'"]+)['"]/s
+  );
+  const actionMatch = pageSource.match(
+    /grecaptcha(?:\\.enterprise)?\\.execute\\s*\\([^)]*?action\\s*:\\s*['"]([^'"]+)['"]/s
+  );
+  const recaptchaV3Key = String((executeKeyMatch && executeKeyMatch[1]) || renderKey || '').trim();
+  const recaptchaV3Action = String((actionMatch && actionMatch[1]) || '').trim();
+  if (recaptchaV3Key && recaptchaV3Key !== 'explicit') {
+    return {
+      captchaType: 'recaptcha_v3',
+      websiteUrl: currentUrl,
+      websiteKey: recaptchaV3Key,
+      pageAction: recaptchaV3Action,
+      marker: 'recaptcha v3'
     };
   }
 
@@ -126,7 +156,7 @@ _INJECT_CAPTCHA_TOKEN_SCRIPT = """(captchaType, token) => {
 
   let fieldsUpdated = 0;
   let callbacksCalled = 0;
-  if (captchaType === 'recaptcha_v2') {
+  if (captchaType === 'recaptcha_v2' || captchaType === 'recaptcha_v3') {
     const response = ensureHiddenField('g-recaptcha-response', 'g-recaptcha-response');
     if (setElementValue(response, token)) fieldsUpdated += 1;
     const callbackName = document.querySelector('.g-recaptcha[data-callback], [data-callback]')
@@ -171,7 +201,7 @@ def build_capsolver_controller(capsolver: CapSolverClient) -> Controller:
     controller = Controller()
 
     @controller.action(
-        "Solve a visible reCAPTCHA v2 or Cloudflare Turnstile challenge using CapSolver. "
+        "Solve a reCAPTCHA v2, reCAPTCHA v3, or Cloudflare Turnstile challenge using CapSolver. "
         "Use only when a CAPTCHA is blocking the browser task.",
         domains=["*"],
     )
@@ -191,6 +221,12 @@ def build_capsolver_controller(capsolver: CapSolverClient) -> Controller:
                 result = await capsolver.solve_recaptcha_v2(
                     website_url=challenge.website_url,
                     website_key=challenge.website_key,
+                )
+            elif challenge.captcha_type == "recaptcha_v3":
+                result = await capsolver.solve_recaptcha_v3(
+                    website_url=challenge.website_url,
+                    website_key=challenge.website_key,
+                    page_action=challenge.page_action,
                 )
             elif challenge.captcha_type == "turnstile":
                 result = await capsolver.solve_turnstile(
@@ -230,7 +266,8 @@ async def detect_browser_captcha(page: Any) -> BrowserCaptchaChallenge | None:
     website_url = str(data.get("websiteUrl") or "").strip()
     website_key = str(data.get("websiteKey") or "").strip()
     marker = str(data.get("marker") or "").strip()
-    if captcha_type not in {"recaptcha_v2", "turnstile"}:
+    page_action = str(data.get("pageAction") or "").strip() or None
+    if captcha_type not in {"recaptcha_v2", "recaptcha_v3", "turnstile"}:
         return None
     if not website_url:
         raise ValueError("Detected CAPTCHA without a page URL")
@@ -241,6 +278,7 @@ async def detect_browser_captcha(page: Any) -> BrowserCaptchaChallenge | None:
         website_url=website_url,
         website_key=website_key,
         marker=marker,
+        page_action=page_action,
     )
 
 
@@ -252,7 +290,7 @@ async def inject_browser_captcha_token(
 ) -> dict[str, Any]:
     safe_type = str(captcha_type or "").strip()
     safe_token = str(token or "").strip()
-    if safe_type not in {"recaptcha_v2", "turnstile"}:
+    if safe_type not in {"recaptcha_v2", "recaptcha_v3", "turnstile"}:
         raise ValueError(f"Unsupported CAPTCHA type: {safe_type}")
     if not safe_token:
         raise ValueError("CAPTCHA solution token is empty")

--- a/src/opentulpa/integrations/browser_use_local.py
+++ b/src/opentulpa/integrations/browser_use_local.py
@@ -492,7 +492,8 @@ class BrowserUseLocalManager:
                 composed_task = (
                     f"{composed_task}\n\n"
                     "If a supported CAPTCHA blocks progress, use the "
-                    "solve_captcha_with_capsolver action before continuing."
+                    "solve_captcha_with_capsolver action before continuing. "
+                    "Supported challenges are reCAPTCHA v2, reCAPTCHA v3, and Cloudflare Turnstile."
                 )
 
             agent_kwargs: dict[str, Any] = {

--- a/src/opentulpa/integrations/browser_use_local.py
+++ b/src/opentulpa/integrations/browser_use_local.py
@@ -69,6 +69,7 @@ class BrowserUseLocalManager:
         headless: bool = True,
         max_concurrent_tasks: int = 2,
         task_retention_seconds: int = 1800,
+        capsolver_api_key: str | None = None,
     ) -> None:
         self._openrouter_api_key = str(openrouter_api_key or "").strip()
         self._openrouter_base_url = str(openrouter_base_url or "").strip().rstrip("/")
@@ -77,6 +78,7 @@ class BrowserUseLocalManager:
         self._reasoning_effort = str(reasoning_effort or "").strip() or None
         self._headless = bool(headless)
         self._task_retention_seconds = max(60, int(task_retention_seconds))
+        self._capsolver_api_key = str(capsolver_api_key or "").strip()
         self._semaphore = asyncio.Semaphore(max(1, int(max_concurrent_tasks)))
         self._lock = asyncio.Lock()
         self._tasks: dict[str, _BrowserUseTaskState] = {}
@@ -486,14 +488,24 @@ class BrowserUseLocalManager:
                     f"First navigate to this URL: {start_url}. "
                     f"Then complete this task: {task_text}"
                 )
+            if self._capsolver_api_key:
+                composed_task = (
+                    f"{composed_task}\n\n"
+                    "If a supported CAPTCHA blocks progress, use the "
+                    "solve_captcha_with_capsolver action before continuing."
+                )
 
-            agent = agent_cls(
-                task=composed_task,
-                llm=llm,
-                browser_session=browser_session,
-                register_new_step_callback=self._step_callback(task_id),
-                directly_open_url=True,
-            )
+            agent_kwargs: dict[str, Any] = {
+                "task": composed_task,
+                "llm": llm,
+                "browser_session": browser_session,
+                "register_new_step_callback": self._step_callback(task_id),
+                "directly_open_url": True,
+            }
+            captcha_controller = self._new_captcha_controller()
+            if captcha_controller is not None:
+                agent_kwargs["controller"] = captcha_controller
+            agent = agent_cls(**agent_kwargs)
             async with self._lock:
                 state = self._tasks.get(task_id)
                 if state is not None:
@@ -715,6 +727,16 @@ class BrowserUseLocalManager:
         if allowed_domains:
             session_kwargs["allowed_domains"] = allowed_domains
         return browser_session_cls(**session_kwargs)
+
+    def _new_captcha_controller(self) -> Any | None:
+        if not self._capsolver_api_key:
+            return None
+        from opentulpa.integrations.browser_use_captcha import build_capsolver_controller
+        from opentulpa.integrations.capsolver import CapSolverClient
+
+        return build_capsolver_controller(
+            CapSolverClient(api_key=self._capsolver_api_key),
+        )
 
     @staticmethod
     def _import_browser_use_components() -> tuple[Any, Any, Any]:

--- a/src/opentulpa/integrations/capsolver.py
+++ b/src/opentulpa/integrations/capsolver.py
@@ -1,0 +1,184 @@
+"""CapSolver API adapter for optional CAPTCHA solving."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class CapSolverError(RuntimeError):
+    """Raised when CapSolver cannot create or complete a solve task."""
+
+
+@dataclass(frozen=True, slots=True)
+class CapSolverSolveResult:
+    task_id: str
+    token: str
+    captcha_type: str
+
+
+class CapSolverClient:
+    """Small async CapSolver client with no browser-specific behavior."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = "https://api.capsolver.com",
+        poll_interval_seconds: float = 5.0,
+        timeout_seconds: float = 120.0,
+        request_timeout_seconds: float = 30.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key = str(api_key or "").strip()
+        self._base_url = str(base_url or "").strip().rstrip("/") or "https://api.capsolver.com"
+        self._poll_interval_seconds = max(0.1, float(poll_interval_seconds))
+        self._timeout_seconds = max(1.0, float(timeout_seconds))
+        self._request_timeout_seconds = max(1.0, float(request_timeout_seconds))
+        self._http_client = http_client
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._api_key)
+
+    async def get_balance(self) -> dict[str, Any]:
+        payload = await self._post_json("/getBalance", {"clientKey": self._require_api_key()})
+        self._raise_for_capsolver_error(payload, operation="getBalance")
+        return payload
+
+    async def solve_recaptcha_v2(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+    ) -> CapSolverSolveResult:
+        task_id = await self._create_task(
+            {
+                "type": "ReCaptchaV2TaskProxyLess",
+                "websiteURL": self._require_text(website_url, "website_url"),
+                "websiteKey": self._require_text(website_key, "website_key"),
+            }
+        )
+        token = await self._poll_for_token(
+            task_id=task_id,
+            solution_keys=("gRecaptchaResponse", "token"),
+        )
+        return CapSolverSolveResult(task_id=task_id, token=token, captcha_type="recaptcha_v2")
+
+    async def solve_turnstile(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+    ) -> CapSolverSolveResult:
+        task_id = await self._create_task(
+            {
+                "type": "AntiTurnstileTaskProxyLess",
+                "websiteURL": self._require_text(website_url, "website_url"),
+                "websiteKey": self._require_text(website_key, "website_key"),
+            }
+        )
+        token = await self._poll_for_token(
+            task_id=task_id,
+            solution_keys=("token", "turnstileToken"),
+        )
+        return CapSolverSolveResult(task_id=task_id, token=token, captcha_type="turnstile")
+
+    async def _create_task(self, task: dict[str, Any]) -> str:
+        payload = await self._post_json(
+            "/createTask",
+            {
+                "clientKey": self._require_api_key(),
+                "task": task,
+            },
+        )
+        self._raise_for_capsolver_error(payload, operation="createTask")
+        task_id = str(payload.get("taskId") or "").strip()
+        if not task_id:
+            raise CapSolverError("CapSolver createTask failed: missing taskId")
+        return task_id
+
+    async def _poll_for_token(
+        self,
+        *,
+        task_id: str,
+        solution_keys: tuple[str, ...],
+    ) -> str:
+        deadline = time.monotonic() + self._timeout_seconds
+        while True:
+            payload = await self._post_json(
+                "/getTaskResult",
+                {
+                    "clientKey": self._require_api_key(),
+                    "taskId": self._require_text(task_id, "task_id"),
+                },
+            )
+            self._raise_for_capsolver_error(payload, operation="getTaskResult")
+            status = str(payload.get("status") or "").strip().lower()
+            if status == "ready":
+                solution = payload.get("solution")
+                token = self._extract_solution_token(solution, solution_keys=solution_keys)
+                if token:
+                    return token
+                raise CapSolverError("CapSolver getTaskResult failed: ready result had no token")
+            if status == "failed":
+                raise CapSolverError("CapSolver getTaskResult failed: task status is failed")
+            if time.monotonic() >= deadline:
+                raise CapSolverError("CapSolver getTaskResult timed out waiting for a solution")
+            await asyncio.sleep(self._poll_interval_seconds)
+
+    async def _post_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._base_url}{endpoint}"
+        if self._http_client is not None:
+            response = await self._http_client.post(url, json=payload)
+        else:
+            timeout = httpx.Timeout(self._request_timeout_seconds)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(url, json=payload)
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            raise CapSolverError("CapSolver returned a non-object JSON response")
+        return data
+
+    def _require_api_key(self) -> str:
+        if not self._api_key:
+            raise CapSolverError("CAPSOLVER_API_KEY is not configured")
+        return self._api_key
+
+    @staticmethod
+    def _require_text(value: str, name: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise CapSolverError(f"CapSolver {name} is required")
+        return text
+
+    @staticmethod
+    def _extract_solution_token(
+        solution: Any,
+        *,
+        solution_keys: tuple[str, ...],
+    ) -> str:
+        if not isinstance(solution, dict):
+            return ""
+        for key in solution_keys:
+            token = str(solution.get(key) or "").strip()
+            if token:
+                return token
+        return ""
+
+    @staticmethod
+    def _raise_for_capsolver_error(payload: dict[str, Any], *, operation: str) -> None:
+        error_id = int(payload.get("errorId") or 0)
+        if error_id == 0:
+            return
+        code = str(payload.get("errorCode") or "").strip()
+        description = str(payload.get("errorDescription") or "").strip()
+        detail = ": ".join(part for part in (code, description) if part)
+        if detail:
+            raise CapSolverError(f"CapSolver {operation} failed: {detail}")
+        raise CapSolverError(f"CapSolver {operation} failed")

--- a/src/opentulpa/integrations/capsolver.py
+++ b/src/opentulpa/integrations/capsolver.py
@@ -69,6 +69,28 @@ class CapSolverClient:
         )
         return CapSolverSolveResult(task_id=task_id, token=token, captcha_type="recaptcha_v2")
 
+    async def solve_recaptcha_v3(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+        page_action: str | None = None,
+    ) -> CapSolverSolveResult:
+        task = {
+            "type": "ReCaptchaV3TaskProxyLess",
+            "websiteURL": self._require_text(website_url, "website_url"),
+            "websiteKey": self._require_text(website_key, "website_key"),
+        }
+        safe_action = str(page_action or "").strip()
+        if safe_action:
+            task["pageAction"] = safe_action
+        task_id = await self._create_task(task)
+        token = await self._poll_for_token(
+            task_id=task_id,
+            solution_keys=("gRecaptchaResponse", "token"),
+        )
+        return CapSolverSolveResult(task_id=task_id, token=token, captcha_type="recaptcha_v3")
+
     async def solve_turnstile(
         self,
         *,

--- a/src/opentulpa/integrations/capsolver.py
+++ b/src/opentulpa/integrations/capsolver.py
@@ -133,14 +133,21 @@ class CapSolverClient:
 
     async def _post_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self._base_url}{endpoint}"
-        if self._http_client is not None:
-            response = await self._http_client.post(url, json=payload)
-        else:
-            timeout = httpx.Timeout(self._request_timeout_seconds)
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(url, json=payload)
-        response.raise_for_status()
-        data = response.json()
+        try:
+            if self._http_client is not None:
+                response = await self._http_client.post(url, json=payload)
+            else:
+                timeout = httpx.Timeout(self._request_timeout_seconds)
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.post(url, json=payload)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise CapSolverError(f"CapSolver request failed: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise CapSolverError("CapSolver returned invalid JSON") from exc
         if not isinstance(data, dict):
             raise CapSolverError("CapSolver returned a non-object JSON response")
         return data

--- a/src/opentulpa/interfaces/telegram/env_management.py
+++ b/src/opentulpa/interfaces/telegram/env_management.py
@@ -25,6 +25,7 @@ def status_text(agent_up: bool) -> str:
         "TELEGRAM_BOT_TOKEN": bool(os.environ.get("TELEGRAM_BOT_TOKEN")),
         "BROWSER_USE_HEADLESS": bool(os.environ.get("BROWSER_USE_HEADLESS")),
         "BROWSER_USE_MODEL": bool(os.environ.get("BROWSER_USE_MODEL")),
+        "CAPSOLVER_API_KEY": bool(os.environ.get("CAPSOLVER_API_KEY")),
     }
     lines = [
         "OpenTulpa status:",
@@ -40,6 +41,7 @@ def status_text(agent_up: bool) -> str:
             f"- BROWSER_USE_MODEL: "
             f"{'set' if keys['BROWSER_USE_MODEL'] else 'default(MULTIMODAL_LLM)'}"
         ),
+        f"- CAPSOLVER_API_KEY: {'set' if keys['CAPSOLVER_API_KEY'] else 'disabled'}",
         "",
         "Commands: /start, /status, /fresh, /debug_logs",
     ]

--- a/tests/test_browser_use_local_manager.py
+++ b/tests/test_browser_use_local_manager.py
@@ -93,11 +93,13 @@ class _FakeAgent:
         llm: Any,
         browser_session: Any,
         register_new_step_callback: Any,
+        controller: Any | None = None,
         directly_open_url: bool = True,  # noqa: ARG002
     ) -> None:
         self.task = task
         self.llm = llm
         self.browser_session = browser_session
+        self.controller = controller
         self._callback = register_new_step_callback
         self._paused = False
         self._stopped = False
@@ -173,6 +175,8 @@ async def test_local_manager_start_task_finishes_and_uses_default_model(
     assert payload["steps"]
     state = manager._tasks[task_id]
     assert state.agent.llm.kwargs["reasoning_effort"] == "medium"
+    assert state.agent.controller is None
+    assert "solve_captcha_with_capsolver" not in state.agent.task
 
 
 @pytest.mark.asyncio
@@ -432,3 +436,38 @@ async def test_local_manager_rejects_third_explicit_session_at_capacity(
     assert "session capacity reached" in str(blocked["error"])
     assert blocked["sessionLimit"] == 2
     assert len(manager._sessions) == 2
+
+
+@pytest.mark.asyncio
+async def test_local_manager_attaches_capsolver_controller_when_key_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opentulpa.integrations.browser_use_captcha as captcha_module
+
+    controller = object()
+    manager = BrowserUseLocalManager(
+        openrouter_api_key="sk-test",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+        default_model="google/gemini-3-flash-preview",
+        capsolver_api_key="cap-key",
+    )
+    monkeypatch.setattr(manager, "preflight", _no_preflight)
+    monkeypatch.setattr(
+        manager,
+        "_import_browser_use_components",
+        lambda: (_FakeAgent, _FakeChatOpenAI, _FakeBrowserSession),
+    )
+    monkeypatch.setattr(captcha_module, "build_capsolver_controller", lambda client: controller)
+
+    created = await manager.start_task(task="blocked by captcha", max_steps=2, llm="", session_id="sess_cap")
+    task_id = str(created["id"])
+    for _ in range(50):
+        payload = await manager.get_task(task_id)
+        if payload and str(payload.get("status")) in {"finished", "failed", "stopped"}:
+            break
+        await asyncio.sleep(0.01)
+    else:  # pragma: no cover
+        raise AssertionError("task did not finish in time")
+
+    assert manager._tasks[task_id].agent.controller is controller
+    assert "solve_captcha_with_capsolver" in manager._tasks[task_id].agent.task

--- a/tests/test_capsolver_integration.py
+++ b/tests/test_capsolver_integration.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+import pytest
+
+from opentulpa.integrations.browser_use_captcha import (
+    build_capsolver_controller,
+    detect_browser_captcha,
+    inject_browser_captcha_token,
+)
+from opentulpa.integrations.capsolver import CapSolverClient, CapSolverError, CapSolverSolveResult
+
+
+class _FakePage:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def evaluate(self, script: str, *args: Any) -> Any:
+        self.calls.append((script, args))
+        if not self.responses:
+            return None
+        return self.responses.pop(0)
+
+
+class _FakeBrowserSession:
+    def __init__(self, page: _FakePage) -> None:
+        self.page = page
+
+    async def get_current_page(self) -> _FakePage:
+        return self.page
+
+
+class _FakeCapSolver:
+    async def solve_recaptcha_v2(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+    ) -> CapSolverSolveResult:
+        assert website_url == "https://example.com/login"
+        assert website_key == "site-key"
+        return CapSolverSolveResult(
+            task_id="task-1",
+            token="solution-token",
+            captcha_type="recaptcha_v2",
+        )
+
+    async def solve_turnstile(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+    ) -> CapSolverSolveResult:  # pragma: no cover - not used in this test
+        raise AssertionError("unexpected turnstile solve")
+
+
+def _mock_client(
+    responses: list[dict[str, Any]],
+) -> tuple[CapSolverClient, list[tuple[str, dict[str, Any]]], httpx.AsyncClient]:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        calls.append((request.url.path, payload))
+        if responses:
+            return httpx.Response(200, json=responses.pop(0))
+        return httpx.Response(200, json={"errorId": 0, "status": "processing"})
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = CapSolverClient(
+        api_key="cap-key",
+        poll_interval_seconds=0.01,
+        timeout_seconds=0.03,
+        http_client=async_client,
+    )
+    return client, calls, async_client
+
+
+@pytest.mark.asyncio
+async def test_capsolver_get_balance_success() -> None:
+    client, calls, async_client = _mock_client([{"errorId": 0, "balance": 10.5}])
+    try:
+        payload = await client.get_balance()
+    finally:
+        await async_client.aclose()
+
+    assert payload["balance"] == 10.5
+    assert calls == [("/getBalance", {"clientKey": "cap-key"})]
+
+
+@pytest.mark.asyncio
+async def test_capsolver_solve_recaptcha_success() -> None:
+    client, calls, async_client = _mock_client(
+        [
+            {"errorId": 0, "taskId": "task-1"},
+            {
+                "errorId": 0,
+                "status": "ready",
+                "solution": {"gRecaptchaResponse": "token-1"},
+            },
+        ]
+    )
+    try:
+        result = await client.solve_recaptcha_v2(
+            website_url="https://example.com",
+            website_key="site-key",
+        )
+    finally:
+        await async_client.aclose()
+
+    assert result.task_id == "task-1"
+    assert result.token == "token-1"
+    assert result.captcha_type == "recaptcha_v2"
+    assert calls[0][0] == "/createTask"
+    assert calls[0][1]["task"]["type"] == "ReCaptchaV2TaskProxyLess"
+    assert calls[1] == ("/getTaskResult", {"clientKey": "cap-key", "taskId": "task-1"})
+
+
+@pytest.mark.asyncio
+async def test_capsolver_create_task_failure() -> None:
+    client, _, async_client = _mock_client(
+        [{"errorId": 1, "errorCode": "ERROR_ZERO_BALANCE", "errorDescription": "balance is empty"}]
+    )
+    try:
+        with pytest.raises(CapSolverError, match="ERROR_ZERO_BALANCE"):
+            await client.solve_recaptcha_v2(
+                website_url="https://example.com",
+                website_key="site-key",
+            )
+    finally:
+        await async_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_capsolver_poll_failure() -> None:
+    client, _, async_client = _mock_client(
+        [
+            {"errorId": 0, "taskId": "task-1"},
+            {"errorId": 0, "status": "failed"},
+        ]
+    )
+    try:
+        with pytest.raises(CapSolverError, match="task status is failed"):
+            await client.solve_recaptcha_v2(
+                website_url="https://example.com",
+                website_key="site-key",
+            )
+    finally:
+        await async_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_capsolver_poll_timeout() -> None:
+    client, _, async_client = _mock_client(
+        [
+            {"errorId": 0, "taskId": "task-1"},
+            {"errorId": 0, "status": "processing"},
+        ]
+    )
+    try:
+        with pytest.raises(CapSolverError, match="timed out"):
+            await client.solve_recaptcha_v2(
+                website_url="https://example.com",
+                website_key="site-key",
+            )
+    finally:
+        await async_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_capsolver_missing_site_key_does_not_call_api() -> None:
+    client, calls, async_client = _mock_client([])
+    try:
+        with pytest.raises(CapSolverError, match="website_key is required"):
+            await client.solve_recaptcha_v2(
+                website_url="https://example.com",
+                website_key="",
+            )
+    finally:
+        await async_client.aclose()
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_browser_captcha_detection_parses_recaptcha_json() -> None:
+    page = _FakePage(
+        [
+            json.dumps(
+                {
+                    "captchaType": "recaptcha_v2",
+                    "websiteUrl": "https://example.com/login",
+                    "websiteKey": "site-key",
+                    "marker": "g-recaptcha",
+                }
+            )
+        ]
+    )
+
+    challenge = await detect_browser_captcha(page)
+
+    assert challenge is not None
+    assert challenge.captcha_type == "recaptcha_v2"
+    assert challenge.website_url == "https://example.com/login"
+    assert challenge.website_key == "site-key"
+
+
+@pytest.mark.asyncio
+async def test_browser_captcha_injection_passes_token_as_argument() -> None:
+    page = _FakePage([{"ok": True, "fieldsUpdated": 1, "callbacksCalled": 0}])
+
+    result = await inject_browser_captcha_token(
+        page,
+        captcha_type="turnstile",
+        token="solution-token",
+    )
+
+    assert result["ok"] is True
+    script, args = page.calls[0]
+    assert "solution-token" not in script
+    assert args == ("turnstile", "solution-token")
+
+
+@pytest.mark.asyncio
+async def test_capsolver_browser_use_action_returns_non_terminal_action_result() -> None:
+    original_env = os.environ.copy()
+    page = _FakePage(
+        [
+            {
+                "captchaType": "recaptcha_v2",
+                "websiteUrl": "https://example.com/login",
+                "websiteKey": "site-key",
+                "marker": "g-recaptcha",
+            },
+            {"ok": True, "fieldsUpdated": 1, "callbacksCalled": 0},
+        ]
+    )
+    try:
+        controller = build_capsolver_controller(_FakeCapSolver())  # type: ignore[arg-type]
+        action = controller.registry.registry.actions["solve_captcha_with_capsolver"]
+
+        result = await action.function(browser_session=_FakeBrowserSession(page))
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    assert result.success is None
+    assert result.is_done is False
+    assert result.extracted_content == "CAPTCHA solved with CapSolver (recaptcha_v2)."

--- a/tests/test_capsolver_integration.py
+++ b/tests/test_capsolver_integration.py
@@ -137,6 +137,34 @@ async def test_capsolver_create_task_failure() -> None:
 
 
 @pytest.mark.asyncio
+async def test_capsolver_transport_error_becomes_capsolver_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network unavailable", request=request)
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = CapSolverClient(api_key="cap-key", http_client=async_client)
+    try:
+        with pytest.raises(CapSolverError, match="CapSolver request failed"):
+            await client.get_balance()
+    finally:
+        await async_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_capsolver_invalid_json_becomes_capsolver_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        return httpx.Response(200, content=b"not-json")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = CapSolverClient(api_key="cap-key", http_client=async_client)
+    try:
+        with pytest.raises(CapSolverError, match="invalid JSON"):
+            await client.get_balance()
+    finally:
+        await async_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_capsolver_poll_failure() -> None:
     client, _, async_client = _mock_client(
         [

--- a/tests/test_capsolver_integration.py
+++ b/tests/test_capsolver_integration.py
@@ -50,6 +50,22 @@ class _FakeCapSolver:
             captcha_type="recaptcha_v2",
         )
 
+    async def solve_recaptcha_v3(
+        self,
+        *,
+        website_url: str,
+        website_key: str,
+        page_action: str | None = None,
+    ) -> CapSolverSolveResult:
+        assert website_url == "https://example.com/login"
+        assert website_key == "site-key"
+        assert page_action == "login"
+        return CapSolverSolveResult(
+            task_id="task-1",
+            token="solution-token",
+            captcha_type="recaptcha_v3",
+        )
+
     async def solve_turnstile(
         self,
         *,
@@ -118,6 +134,40 @@ async def test_capsolver_solve_recaptcha_success() -> None:
     assert result.captcha_type == "recaptcha_v2"
     assert calls[0][0] == "/createTask"
     assert calls[0][1]["task"]["type"] == "ReCaptchaV2TaskProxyLess"
+    assert calls[1] == ("/getTaskResult", {"clientKey": "cap-key", "taskId": "task-1"})
+
+
+@pytest.mark.asyncio
+async def test_capsolver_solve_recaptcha_v3_success() -> None:
+    client, calls, async_client = _mock_client(
+        [
+            {"errorId": 0, "taskId": "task-1"},
+            {
+                "errorId": 0,
+                "status": "ready",
+                "solution": {"gRecaptchaResponse": "token-1"},
+            },
+        ]
+    )
+    try:
+        result = await client.solve_recaptcha_v3(
+            website_url="https://example.com",
+            website_key="site-key",
+            page_action="login",
+        )
+    finally:
+        await async_client.aclose()
+
+    assert result.task_id == "task-1"
+    assert result.token == "token-1"
+    assert result.captcha_type == "recaptcha_v3"
+    assert calls[0][0] == "/createTask"
+    assert calls[0][1]["task"] == {
+        "type": "ReCaptchaV3TaskProxyLess",
+        "websiteURL": "https://example.com",
+        "websiteKey": "site-key",
+        "pageAction": "login",
+    }
     assert calls[1] == ("/getTaskResult", {"clientKey": "cap-key", "taskId": "task-1"})
 
 
@@ -239,6 +289,29 @@ async def test_browser_captcha_detection_parses_recaptcha_json() -> None:
 
 
 @pytest.mark.asyncio
+async def test_browser_captcha_detection_parses_recaptcha_v3_json() -> None:
+    page = _FakePage(
+        [
+            {
+                "captchaType": "recaptcha_v3",
+                "websiteUrl": "https://example.com/login",
+                "websiteKey": "site-key",
+                "pageAction": "login",
+                "marker": "recaptcha v3",
+            }
+        ]
+    )
+
+    challenge = await detect_browser_captcha(page)
+
+    assert challenge is not None
+    assert challenge.captcha_type == "recaptcha_v3"
+    assert challenge.website_url == "https://example.com/login"
+    assert challenge.website_key == "site-key"
+    assert challenge.page_action == "login"
+
+
+@pytest.mark.asyncio
 async def test_browser_captcha_injection_passes_token_as_argument() -> None:
     page = _FakePage([{"ok": True, "fieldsUpdated": 1, "callbacksCalled": 0}])
 
@@ -280,3 +353,32 @@ async def test_capsolver_browser_use_action_returns_non_terminal_action_result()
     assert result.success is None
     assert result.is_done is False
     assert result.extracted_content == "CAPTCHA solved with CapSolver (recaptcha_v2)."
+
+
+@pytest.mark.asyncio
+async def test_capsolver_browser_use_action_handles_recaptcha_v3() -> None:
+    original_env = os.environ.copy()
+    page = _FakePage(
+        [
+            {
+                "captchaType": "recaptcha_v3",
+                "websiteUrl": "https://example.com/login",
+                "websiteKey": "site-key",
+                "pageAction": "login",
+                "marker": "recaptcha v3",
+            },
+            {"ok": True, "fieldsUpdated": 1, "callbacksCalled": 0},
+        ]
+    )
+    try:
+        controller = build_capsolver_controller(_FakeCapSolver())  # type: ignore[arg-type]
+        action = controller.registry.registry.actions["solve_captcha_with_capsolver"]
+
+        result = await action.function(browser_session=_FakeBrowserSession(page))
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    assert result.success is None
+    assert result.is_done is False
+    assert result.extracted_content == "CAPTCHA solved with CapSolver (recaptcha_v3)."

--- a/tests/test_capsolver_integration.py
+++ b/tests/test_capsolver_integration.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from opentulpa.integrations.browser_use_captcha import (
+    _DETECT_CAPTCHA_SCRIPT,
     build_capsolver_controller,
     detect_browser_captcha,
     inject_browser_captcha_token,
@@ -309,6 +310,42 @@ async def test_browser_captcha_detection_parses_recaptcha_v3_json() -> None:
     assert challenge.website_url == "https://example.com/login"
     assert challenge.website_key == "site-key"
     assert challenge.page_action == "login"
+
+
+@pytest.mark.asyncio
+async def test_browser_captcha_detection_script_keeps_turnstile_callback_widget() -> None:
+    pytest.importorskip("playwright.async_api")
+    from playwright.async_api import Error as PlaywrightError
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+        except PlaywrightError as exc:
+            pytest.skip(f"Playwright Chromium is unavailable: {exc}")
+
+        try:
+            page = await browser.new_page()
+            await page.set_content(
+                """
+                <html>
+                  <body>
+                    <div
+                      class="cf-turnstile"
+                      data-sitekey="site-key"
+                      data-callback="onTurnstile"
+                    ></div>
+                  </body>
+                </html>
+                """
+            )
+
+            detected = await page.evaluate(_DETECT_CAPTCHA_SCRIPT)
+        finally:
+            await browser.close()
+
+    assert detected["captchaType"] == "turnstile"
+    assert detected["websiteKey"] == "site-key"
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_api_key_alias.py
+++ b/tests/test_config_api_key_alias.py
@@ -82,6 +82,14 @@ def test_settings_accepts_business_knowledge_oracle_model_env(monkeypatch) -> No
     assert settings.business_knowledge_oracle_model == "provider/oracle-model"
 
 
+def test_settings_accepts_capsolver_api_key_env(monkeypatch) -> None:
+    monkeypatch.setenv("CAPSOLVER_API_KEY", "cap-key")
+
+    settings = Settings()
+
+    assert settings.capsolver_api_key == "cap-key"
+
+
 def test_settings_loads_runtime_defaults_from_yaml(monkeypatch, tmp_path: Path) -> None:
     config_file = tmp_path / "opentulpa.config.yaml"
     config_file.write_text(


### PR DESCRIPTION
## Summary

Adds an optional CapSolver-backed CAPTCHA action for OpenTulpa's local Browser Use manager.

- Adds a small async CapSolver API adapter using `getBalance`, `createTask`, and `getTaskResult`.
- Registers `solve_captcha_with_capsolver` only when `CAPSOLVER_API_KEY` is configured.
- Adds Browser Use task guidance only when the key is present, so normal Browser Use behavior is unchanged without the key.
- Supports reCAPTCHA v2 and Cloudflare Turnstile detection/injection paths.
- Documents `CAPSOLVER_API_KEY` in `.env.example` and README.

## Notes

This does not add reCAPTCHA v3 yet. The current integration is scoped to visible reCAPTCHA v2 and Turnstile challenges because those have page-detectable site keys and token injection paths in the current Browser Use flow.

## Validation

- `uv run pytest tests/test_capsolver_integration.py tests/test_browser_use_local_manager.py tests/test_browser_use_tools.py tests/test_config_api_key_alias.py -q` -> 42 passed
- `uv run ruff check src/opentulpa/integrations/capsolver.py src/opentulpa/integrations/browser_use_captcha.py tests/test_capsolver_integration.py tests/test_browser_use_local_manager.py src/opentulpa/integrations/browser_use_local.py src/opentulpa/agent/runtime.py src/opentulpa/core/config.py src/opentulpa/__main__.py` -> passed
- CapSolver API key check via `getBalance` -> HTTP 200, `errorId=0`
- Live Browser Use Pinterest validation -> Pinterest loaded successfully; no CAPTCHA was served, so solver was not invoked
- Live Browser Use reCAPTCHA demo validation -> `solve_captcha_with_capsolver` invoked, action succeeded, submit clicked, page reported `Success!` / `success => true`
