### PR TITLE
Fix workflow setup finalization loop

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -626,6 +626,7 @@ def build_runtime_graph(runtime: Any):
         "intake_workflow_setup_mark_proposed": (),
         "intake_workflow_setup_confirm_current": (),
         "intake_workflow_setup_commit": (),
+        "intake_workflow_setup_finalize_confirmation": (),
         "intake_workflow_setup_pause": (),
         "intake_workflow_setup_cancel": (),
         "intake_workflow_run": ("workflow_id",),
@@ -686,6 +687,7 @@ def build_runtime_graph(runtime: Any):
         "intake_workflow_setup_mark_proposed",
         "intake_workflow_setup_confirm_current",
         "intake_workflow_setup_commit",
+        "intake_workflow_setup_finalize_confirmation",
         "intake_workflow_setup_pause",
         "intake_workflow_setup_cancel",
         "intake_workflow_run",
@@ -1356,9 +1358,9 @@ def build_runtime_graph(runtime: Any):
                     "- If the draft is complete after the update: call intake_workflow_setup_preflight; "
                     "when ready, call intake_workflow_setup_mark_proposed before summarizing the proposal.\n"
                     "- If the latest owner message explicitly confirms a shown proposal: call "
-                    "intake_workflow_setup_get, then intake_workflow_setup_confirm_current and "
-                    "intake_workflow_setup_commit. If no proposal hash exists but a proposal was shown "
-                    "in the conversation, call preflight and mark_proposed first, then confirm and commit.\n"
+                    "intake_workflow_setup_finalize_confirmation. Pass any small final behavior-rule "
+                    "edits in that same tool call when needed instead of doing a separate "
+                    "update/preflight loop.\n"
                     "- Do not repeat an older proposal or ask for details already present in the latest "
                     "owner message. If blocked, give the one concrete setup-tool error or follow-up."
                 )

--- a/src/opentulpa/agent/prompt_sections.py
+++ b/src/opentulpa/agent/prompt_sections.py
@@ -45,7 +45,7 @@ def build_prompt_mode_message(prompt_mode: PromptMode) -> SystemMessage:
             "Do not ask for Telegram Business DM polling/schedule intervals; those workflows run from inbound messages.\n"
             "Before showing the final proposal, run the setup preflight once; if it returns a focused follow-up, ask that instead of proposing.\n"
             "After a ready preflight, call intake_workflow_setup_mark_proposed before sending the proposal summary.\n"
-            "If the owner explicitly confirms a proposal, save only through intake_workflow_setup_confirm_current followed by intake_workflow_setup_commit; if the visible proposal was not marked yet, run preflight and mark_proposed first, then confirm and commit.\n"
+            "If the owner explicitly confirms a proposal, call intake_workflow_setup_finalize_confirmation; pass any small final behavior-rule edits in that same tool call when needed instead of doing a separate update/preflight loop.\n"
             "When enough required fields are known, propose the workflow with stated assumptions instead of continuing optional clarification.\n"
             "Schema contract: required_fields are stable machine field ids, not customer-facing labels. Use concise ASCII snake_case ids such as service_name, vehicle_type, date, time, lead_name, phone, quoted_price. Put localized names, wording, and extraction notes in field_guidance or assistant_instructions, not in required_fields.\n"
             "field_guidance keys must match required_fields ids. If the sink needs localized or human-readable column labels, express that in sink_config.field_mapping instead of changing required_fields ids.\n"

--- a/src/opentulpa/agent/tools/intake_tools.py
+++ b/src/opentulpa/agent/tools/intake_tools.py
@@ -462,6 +462,36 @@ def register_intake_tools(runtime: Any) -> dict[str, Any]:
         return r.json().get("session", {})
 
     @tool
+    async def intake_workflow_setup_finalize_confirmation(
+        draft_patch: dict[str, Any] | None = None,
+        scratchpad_patch: dict[str, Any] | None = None,
+    ) -> Any:
+        """Finalize an explicitly confirmed workflow setup in one backend operation.
+
+        Use this when the owner confirms a shown workflow proposal. If the same owner
+        message also adds small final behavior rules, pass them as draft_patch or
+        scratchpad_patch; this tool will persist them, preflight, mark the current
+        draft as proposed, confirm it, and commit it. Do not call the separate
+        preflight/mark_proposed/confirm_current/commit tools after this succeeds.
+        """
+        customer_id = require_customer_id(runtime)
+        thread_id = require_thread_id(runtime)
+        r = await runtime._request_with_backoff(
+            "POST",
+            "/internal/intake/setup/finalize_confirmation",
+            json_body={
+                "customer_id": customer_id,
+                "thread_id": thread_id,
+                "draft_patch": draft_patch if isinstance(draft_patch, dict) else None,
+                "scratchpad_patch": scratchpad_patch if isinstance(scratchpad_patch, dict) else None,
+            },
+            timeout=45.0,
+        )
+        if r.status_code != 200:
+            return {"error": f"intake_workflow_setup_finalize_confirmation failed: {r.text}"}
+        return r.json().get("session", {})
+
+    @tool
     async def intake_workflow_setup_pause() -> Any:
         """Pause the active workflow setup session for the current thread."""
         customer_id = require_customer_id(runtime)
@@ -525,6 +555,7 @@ def register_intake_tools(runtime: Any) -> dict[str, Any]:
         "intake_workflow_setup_mark_proposed": intake_workflow_setup_mark_proposed,
         "intake_workflow_setup_confirm_current": intake_workflow_setup_confirm_current,
         "intake_workflow_setup_commit": intake_workflow_setup_commit,
+        "intake_workflow_setup_finalize_confirmation": intake_workflow_setup_finalize_confirmation,
         "intake_workflow_setup_pause": intake_workflow_setup_pause,
         "intake_workflow_setup_cancel": intake_workflow_setup_cancel,
         "intake_workflow_run": intake_workflow_run,

--- a/src/opentulpa/agent/turn_policy.py
+++ b/src/opentulpa/agent/turn_policy.py
@@ -34,7 +34,7 @@ def build_turn_mode_system_message(turn_mode: str | None) -> SystemMessage:
                 "When the owner provides new workflow facts, sink details, source files, field requirements, or behavior rules, call intake_workflow_setup_update to persist them in the draft; do not merely acknowledge them in prose.\n"
                 "When the owner provides Google Sheets details, store them under sink_type=google_sheets_composio and sink_config.static_arguments, including spreadsheetId and sheetName when provided.\n"
                 "After updating a draft that now appears complete, call intake_workflow_setup_preflight. If ready, call intake_workflow_setup_mark_proposed before showing the proposal.\n"
-                "When the owner explicitly confirms a shown proposal, call intake_workflow_setup_confirm_current and intake_workflow_setup_commit before saying it is saved. If a proposal was shown in the conversation but last_proposed_draft_hash is missing, call preflight, mark_proposed, confirm_current, and commit in order.\n"
+                "When the owner explicitly confirms a shown proposal, call intake_workflow_setup_finalize_confirmation before saying it is saved. If the same message adds small final behavior rules, pass them in that finalize tool call instead of doing a separate update/preflight loop.\n"
                 "If any setup tool returns an error or focused follow-up, report that specific blocker instead of repeating an older proposal.\n"
                 "Ask one high-value setup question at a time.\n"
                 "If uploaded files are part of the workflow, track original source_file_ids and prepare them with business_knowledge_index.\n"

--- a/src/opentulpa/agent/workflow_setup_prompt_context.py
+++ b/src/opentulpa/agent/workflow_setup_prompt_context.py
@@ -103,6 +103,7 @@ def build_workflow_setup_control_context(session: dict[str, Any] | None) -> str:
     follow_up_questions = _nonempty_list(last_preflight.get("follow_up_questions"))
     errors = _nonempty_list(last_preflight.get("errors"))
     warnings = _nonempty_list(last_preflight.get("warnings"))
+    preflight_next_action = str(last_preflight.get("next_action", "") or "").strip()
 
     name = str(draft.get("name", "") or "").strip()
     channel = str(draft.get("channel", "") or "").strip()
@@ -164,14 +165,14 @@ def build_workflow_setup_control_context(session: dict[str, Any] | None) -> str:
     elif proposal == "proposed_current":
         suggested = (
             "If the latest owner message explicitly confirms the proposal, call "
-            "intake_workflow_setup_confirm_current followed by intake_workflow_setup_commit, then stop. "
+            "intake_workflow_setup_finalize_confirmation, then report the created workflow id and stop. "
             "If the owner requests changes, call intake_workflow_setup_update, then preflight again."
         )
     elif preflight_ok and preflight_status == "ready":
         suggested = (
             "Call intake_workflow_setup_mark_proposed. Then send a concise proposal summary and ask for confirmation, then stop. "
             "If the latest owner message is already an explicit confirmation of a proposal visible in this conversation, "
-            "call intake_workflow_setup_mark_proposed, intake_workflow_setup_confirm_current, and intake_workflow_setup_commit in order."
+            "call intake_workflow_setup_finalize_confirmation instead."
         )
     elif preflight_status != "not_run" and follow_up_questions:
         suggested = (
@@ -209,6 +210,7 @@ def build_workflow_setup_control_context(session: dict[str, Any] | None) -> str:
         f"- knowledge_file_count: {len(knowledge_file_ids or source_file_ids)}",
         f"- last_preflight_status: {preflight_status}",
         f"- last_preflight_ok: {_yes_no(preflight_ok)}",
+        f"- last_preflight_next_action: {preflight_next_action or 'none'}",
         f"- proposal_status: {proposal}",
         f"- confirmation_status: {confirmation}",
         f"- missing_core_inputs: {', '.join(missing_core) if missing_core else 'none'}",

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -193,6 +193,21 @@ def register_intake_workflow_routes(
             return JSONResponse(status_code=400, content={"detail": str(exc)})
         return {"ok": True, "session": session}
 
+    @app.post("/internal/intake/setup/finalize_confirmation")
+    async def internal_intake_setup_finalize_confirmation(request: Request) -> Any:
+        service = get_workflow_setup_service()
+        body = await request.json()
+        try:
+            session = service.finalize_confirmation(
+                customer_id=str(body.get("customer_id", "")).strip(),
+                thread_id=str(body.get("thread_id", "")).strip(),
+                draft_patch=body.get("draft_patch") if isinstance(body.get("draft_patch"), dict) else None,
+                scratchpad_patch=body.get("scratchpad_patch") if isinstance(body.get("scratchpad_patch"), dict) else None,
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return {"ok": True, "session": session, "preflight": session.get("preflight", {})}
+
     @app.post("/internal/intake/setup/pause")
     async def internal_intake_setup_pause(request: Request) -> Any:
         service = get_workflow_setup_service()

--- a/src/opentulpa/api/routes/telegram_webhook.py
+++ b/src/opentulpa/api/routes/telegram_webhook.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from typing import Any
 
-from fastapi import BackgroundTasks, FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 
 from opentulpa.interfaces.telegram.client import (
@@ -21,6 +21,26 @@ from opentulpa.interfaces.telegram.client import (
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
 
 logger = logging.getLogger(__name__)
+
+
+def _track_background_task(app: FastAPI, task: asyncio.Task[Any]) -> None:
+    tasks = getattr(app.state, "telegram_webhook_tasks", None)
+    if not isinstance(tasks, set):
+        tasks = set()
+        app.state.telegram_webhook_tasks = tasks
+    tasks.add(task)
+
+    def _on_done(done_task: asyncio.Task[Any]) -> None:
+        tasks.discard(done_task)
+        with suppress(asyncio.CancelledError):
+            exc = done_task.exception()
+            if exc is not None:
+                logger.error(
+                    "telegram webhook background handler failed",
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+    task.add_done_callback(_on_done)
 
 
 def _parse_approval_callback_data(data: str) -> tuple[str, str] | None:
@@ -196,7 +216,7 @@ def register_telegram_webhook_routes(
     """Register Telegram webhook with callback-driven approval support."""
 
     @app.post("/webhook/telegram")
-    async def telegram_webhook(request: Request, background_tasks: BackgroundTasks) -> Response:
+    async def telegram_webhook(request: Request) -> Response:
         if not settings.telegram_bot_token:
             return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         expected_secret = str(settings.telegram_webhook_secret or "").strip()
@@ -210,8 +230,8 @@ def register_telegram_webhook_routes(
             return JSONResponse(status_code=403, content={"detail": "invalid telegram secret"})
         body = await request.json()
 
-        # Immediate 200 OK, logic runs in background.
-        background_tasks.add_task(_telegram_background_handler, body=body)
+        # Return 200 before long-running agent work so Telegram does not retry the same update.
+        _track_background_task(app, asyncio.create_task(_telegram_background_handler(body=body)))
         return Response(status_code=200)
 
     async def _telegram_background_handler(body: dict[str, Any]) -> None:

--- a/src/opentulpa/intake/workflow_setup_service.py
+++ b/src/opentulpa/intake/workflow_setup_service.py
@@ -116,6 +116,8 @@ def _compact_preflight_for_scratchpad(preflight: dict[str, Any]) -> dict[str, An
     return {
         "ok": bool(preflight.get("ok", False)),
         "status": str(preflight.get("status", "") or ""),
+        "next_action": str(preflight.get("next_action", "") or ""),
+        "commit_blockers": _safe_list(preflight.get("commit_blockers")),
         "errors": _safe_list(preflight.get("errors")),
         "warnings": _safe_list(preflight.get("warnings")),
         "follow_up_questions": _safe_list(preflight.get("follow_up_questions")),
@@ -358,6 +360,20 @@ class WorkflowSetupService:
                     "The uploaded business knowledge could not be grounded from source files. Please provide a text, spreadsheet, PDF, DOCX, CSV, or clearer source for the workflow."
                 )
                 preflight["follow_up_questions"] = questions
+        commit_blockers = [
+            str(item).strip()
+            for item in [
+                *_safe_list(preflight.get("errors")),
+                *_safe_list(preflight.get("follow_up_questions")),
+            ]
+            if str(item).strip()
+        ]
+        if bool(preflight.get("ok", False)) and str(preflight.get("status", "") or "") == "ready":
+            preflight["commit_blockers"] = []
+            preflight["next_action"] = "finalize_confirmation_if_owner_confirmed_else_mark_proposed"
+        else:
+            preflight["commit_blockers"] = commit_blockers
+            preflight["next_action"] = "ask_preflight_blocker"
         scratchpad = _deep_merge(
             _safe_dict(session.get("scratchpad")),
             {
@@ -376,6 +392,56 @@ class WorkflowSetupService:
         )
         updated["preflight"] = preflight
         return updated
+
+    def finalize_confirmation(
+        self,
+        *,
+        customer_id: str,
+        thread_id: str,
+        draft_patch: dict[str, Any] | None = None,
+        scratchpad_patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Apply final edits, validate, mark, confirm, and commit in one explicit owner-confirmation path."""
+
+        if isinstance(draft_patch, dict) or isinstance(scratchpad_patch, dict):
+            self.update_session(
+                customer_id=customer_id,
+                thread_id=thread_id,
+                draft_patch=draft_patch,
+                scratchpad_patch=scratchpad_patch,
+            )
+        session = self._store.get_thread_session(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            statuses=("active",),
+        )
+        if session is None:
+            completed = self._store.get_thread_session(
+                customer_id=customer_id,
+                thread_id=thread_id,
+                statuses=("completed",),
+            )
+            if completed and str(completed.get("created_or_updated_workflow_id", "") or "").strip():
+                completed["already_completed"] = True
+                return completed
+            raise ValueError("active workflow setup session not found")
+
+        preflight_session = self.preflight_current(customer_id=customer_id, thread_id=thread_id)
+        preflight = _safe_dict(preflight_session.get("preflight"))
+        if not bool(preflight.get("ok", False)) or str(preflight.get("status", "") or "") != "ready":
+            blockers = _safe_list(preflight.get("commit_blockers")) or _safe_list(
+                preflight.get("follow_up_questions")
+            ) or _safe_list(preflight.get("errors"))
+            blocker = "; ".join(str(item).strip() for item in blockers if str(item).strip())
+            if not blocker:
+                blocker = "workflow draft is not ready to commit"
+            raise ValueError(blocker)
+
+        self.mark_proposed(customer_id=customer_id, thread_id=thread_id)
+        self.confirm_current(customer_id=customer_id, thread_id=thread_id)
+        committed = self.commit(customer_id=customer_id, thread_id=thread_id)
+        committed["preflight"] = preflight
+        return committed
 
     def _preflight_knowledge_scope(
         self,

--- a/tests/test_intake_tools.py
+++ b/tests/test_intake_tools.py
@@ -137,6 +137,33 @@ async def test_intake_workflow_setup_preflight_posts_expected_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_intake_workflow_setup_finalize_confirmation_posts_expected_payload() -> None:
+    runtime = DummyRuntime(
+        [
+            Response(
+                200,
+                {"session": {"status": "completed", "created_or_updated_workflow_id": "iwf_abc"}},
+            )
+        ]
+    )
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["intake_workflow_setup_finalize_confirmation"].ainvoke(
+        {"draft_patch": {"assistant_instructions": "Use '-' when optional pricing is unknown."}}
+    )
+
+    assert result["status"] == "completed"
+    assert runtime.calls[0][0] == "POST"
+    assert runtime.calls[0][1] == "/internal/intake/setup/finalize_confirmation"
+    assert runtime.calls[0][2]["json_body"] == {
+        "customer_id": "telegram_123",
+        "thread_id": "thread_123",
+        "draft_patch": {"assistant_instructions": "Use '-' when optional pricing is unknown."},
+        "scratchpad_patch": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_uploaded_file_inspect_structure_posts_expected_payload() -> None:
     runtime = DummyRuntime(
         [

--- a/tests/test_intake_workflow_routes.py
+++ b/tests/test_intake_workflow_routes.py
@@ -218,3 +218,49 @@ def test_intake_workflow_setup_routes_create_confirm_commit(tmp_path: Path) -> N
         session = committed.json()["session"]
         assert session["status"] == "completed"
         assert session["workflow"]["name"] == "Car Wash Intake"
+
+
+def test_intake_workflow_setup_finalize_confirmation_route_commits(tmp_path: Path) -> None:
+    with _mk_client(tmp_path) as client:
+        begin = client.post(
+            "/internal/intake/setup/begin",
+            json={
+                "customer_id": "telegram_123",
+                "thread_id": "thread_123",
+                "mode": "create",
+            },
+        )
+        assert begin.status_code == 200
+
+        updated = client.post(
+            "/internal/intake/setup/update",
+            json={
+                "customer_id": "telegram_123",
+                "thread_id": "thread_123",
+                "draft_patch": {
+                    "name": "Car Wash Intake",
+                    "intent_description": "Handle booking requests that arrive in Instagram DMs.",
+                    "required_fields": ["day", "time", "car_type", "wash_type"],
+                    "sink_type": "local_csv",
+                    "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+                },
+            },
+        )
+        assert updated.status_code == 200
+
+        finalized = client.post(
+            "/internal/intake/setup/finalize_confirmation",
+            json={
+                "customer_id": "telegram_123",
+                "thread_id": "thread_123",
+                "draft_patch": {"assistant_instructions": "Use '-' when optional pricing is unknown."},
+            },
+        )
+
+        assert finalized.status_code == 200
+        session = finalized.json()["session"]
+        assert session["status"] == "completed"
+        assert session["workflow"]["name"] == "Car Wash Intake"
+        assert session["workflow"]["assistant_instructions"] == (
+            "Use '-' when optional pricing is unknown."
+        )

--- a/tests/test_telegram_business_webhook.py
+++ b/tests/test_telegram_business_webhook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -79,6 +80,15 @@ class _FakeIntakeWorkflows:
         return {"ok": False, "summary": "send failed"}
 
 
+def _wait_for_webhook_tasks(app: FastAPI, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not getattr(app.state, "telegram_webhook_tasks", set()):
+            return
+        time.sleep(0.01)
+    raise AssertionError("telegram webhook background task did not finish")
+
+
 def test_business_message_webhook_triggers_matching_workflow_and_notifies_owner(tmp_path: Path) -> None:
     app = FastAPI()
     telegram_client = _RecordingTelegramClient()
@@ -129,6 +139,7 @@ def test_business_message_webhook_triggers_matching_workflow_and_notifies_owner(
             },
             headers={"x-telegram-bot-api-secret-token": "secret-token"},
         )
+        _wait_for_webhook_tasks(app)
 
     assert response.status_code == 200
     assert intake.run_calls == [

--- a/tests/test_telegram_webhook_ordering.py
+++ b/tests/test_telegram_webhook_ordering.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 from fastapi import FastAPI
@@ -60,6 +61,15 @@ class _FakeIntakeWorkflows:
         return []
 
 
+def _wait_for_webhook_tasks(app: FastAPI, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not getattr(app.state, "telegram_webhook_tasks", set()):
+            return
+        time.sleep(0.01)
+    raise AssertionError("telegram webhook background task did not finish")
+
+
 def test_webhook_flushes_approval_challenges_before_optional_follow_up_message() -> None:
     app = FastAPI()
     call_order: list[str] = []
@@ -100,6 +110,7 @@ def test_webhook_flushes_approval_challenges_before_optional_follow_up_message()
         },
         headers={"x-telegram-bot-api-secret-token": "secret-token"},
     )
+    _wait_for_webhook_tasks(app)
     assert response.status_code == 200
     assert call_order == [
         "flush_deferred_challenges",

--- a/tests/test_workflow_setup_prompt_context.py
+++ b/tests/test_workflow_setup_prompt_context.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 from opentulpa.agent.workflow_setup_prompt_context import build_workflow_setup_control_context
 
 
@@ -48,3 +51,23 @@ def test_control_card_asks_follow_up_when_preflight_needs_google_sheets_tab_clar
     assert "draft_status: needs_clarification" in card
     assert "latest_preflight_follow_up: Which tab should I write into?" in card
     assert "ask this blocker only: Which tab should I write into?" in card
+
+
+def test_control_card_uses_finalize_for_confirmed_proposal_path() -> None:
+    session = _session_with_google_sheets_sink(sheet_name="Leads")
+    session["scratchpad"] = {
+        "last_preflight": {
+            "ok": True,
+            "status": "ready",
+            "next_action": "finalize_confirmation_if_owner_confirmed_else_mark_proposed",
+        }
+    }
+    draft_hash = hashlib.sha256(
+        json.dumps(session["draft_upsert"], ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    session["last_proposed_draft_hash"] = draft_hash
+
+    card = build_workflow_setup_control_context(session)
+
+    assert "proposal_status: proposed_current" in card
+    assert "intake_workflow_setup_finalize_confirmation" in card

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -217,6 +217,43 @@ def test_workflow_setup_commit_create_persists_active_workflow(tmp_path: Path) -
     assert workflows[0]["name"] == "Car Wash Intake"
 
 
+def test_workflow_setup_finalize_confirmation_applies_final_patch_and_commits(
+    tmp_path: Path,
+) -> None:
+    setup, intake_service, _ = _mk_setup_service(tmp_path)
+    setup.begin_session(customer_id="telegram_123", thread_id="thread_123", mode="create")
+    setup.update_session(
+        customer_id="telegram_123",
+        thread_id="thread_123",
+        draft_patch={
+            "name": "Car Wash Intake",
+            "intent_description": "Handle booking requests from Instagram DMs.",
+            "required_fields": ["day", "time", "car_type", "wash_type"],
+            "assistant_instructions": "Be direct.",
+            "sink_type": "local_csv",
+            "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+        },
+    )
+    setup.mark_proposed(customer_id="telegram_123", thread_id="thread_123")
+
+    session = setup.finalize_confirmation(
+        customer_id="telegram_123",
+        thread_id="thread_123",
+        draft_patch={
+            "assistant_instructions": (
+                "Be direct. If a price is missing, ask the owner; use '-' after one hour."
+            )
+        },
+    )
+
+    assert session["status"] == "completed"
+    assert session["created_or_updated_workflow_id"]
+    assert session["preflight"]["status"] == "ready"
+    workflows = intake_service.list_workflows(customer_id="telegram_123", include_disabled=True)
+    assert len(workflows) == 1
+    assert workflows[0]["assistant_instructions"].endswith("use '-' after one hour.")
+
+
 def test_workflow_setup_commit_edit_recreates_telegram_workflow(tmp_path: Path) -> None:
     setup, intake_service, telegram_business = _mk_setup_service(tmp_path)
     telegram_business.upsert_connection(


### PR DESCRIPTION
## Summary
- add atomic workflow setup finalize endpoint/tool for owner confirmation turns
- steer setup prompts/control cards to finalize when preflight is ready and the owner confirms
- return Telegram webhook 200 immediately while processing the update in a tracked asyncio task

## Verification
- uv run ruff check src/opentulpa/intake/workflow_setup_service.py src/opentulpa/api/routes/intake.py src/opentulpa/agent/tools/intake_tools.py src/opentulpa/agent/graph_builder.py src/opentulpa/agent/prompt_sections.py src/opentulpa/agent/turn_policy.py src/opentulpa/agent/workflow_setup_prompt_context.py src/opentulpa/api/routes/telegram_webhook.py tests/test_workflow_setup_service.py tests/test_intake_workflow_routes.py tests/test_intake_tools.py tests/test_workflow_setup_prompt_context.py tests/test_telegram_business_webhook.py tests/test_telegram_webhook_ordering.py
- uv run pytest tests/test_workflow_setup_service.py tests/test_intake_workflow_routes.py tests/test_intake_tools.py tests/test_workflow_setup_prompt_context.py tests/test_runtime_pending_context_input.py::test_workflow_setup_prompt_injects_authoritative_next_action tests/test_telegram_business_webhook.py tests/test_telegram_webhook_ordering.py
- railway up /tmp/opentulpa-ope21-deploy.Q4vPdZ --path-as-root --service opentulpa --environment production --message "OPE-21 finalize workflow setup and async telegram webhook" --detach