### PR TITLE
Make workflow setup durable

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -372,6 +372,7 @@ def main() -> None:
             wake_execution_model_name=settings.wake_execution_model,
             telegram_media_model_name=settings.multimodal_llm,
             guardrail_classifier_model_name=settings.guardrail_classifier_model,
+            workflow_setup_input_classifier_model_name=settings.workflow_setup_input_classifier_model,
             checkpoint_db_path=settings.agent_checkpoint_db_path,
             recursion_limit=settings.agent_recursion_limit,
             max_completion_tokens=settings.agent_max_completion_tokens,

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -117,7 +117,10 @@ logger = logging.getLogger(__name__)
 
 _MEMORY_GROUNDING_KIND_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("preferences_and_directives", ("directive_fact", "preference_fact")),
-    ("durable_personal_facts", ("user_profile_fact", "life_fact", "relationship_fact", "contact_fact")),
+    (
+        "durable_personal_facts",
+        ("user_profile_fact", "life_fact", "relationship_fact", "contact_fact"),
+    ),
     ("aspirations_and_plans", ("aspirations_fact", "project_fact")),
     ("active_projects_or_workflows", ("workflow_fact", "skill_fact")),
     ("technical_or_code_facts", ("code_fact", "credential_fact")),
@@ -249,7 +252,9 @@ def _deep_merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[st
     return merged
 
 
-def _disable_deepseek_v4_pro_thinking_extra(*, model_name: str, reasoning_effort: str | None) -> dict[str, Any]:
+def _disable_deepseek_v4_pro_thinking_extra(
+    *, model_name: str, reasoning_effort: str | None
+) -> dict[str, Any]:
     if reasoning_effort:
         return {}
     slug = str(model_name or "").strip().lower()
@@ -263,7 +268,9 @@ def _disable_deepseek_v4_pro_thinking_extra(*, model_name: str, reasoning_effort
     }
 
 
-def _cap_max_completion_tokens_for_model(model_kwargs: dict[str, Any], *, model_name: str) -> dict[str, Any]:
+def _cap_max_completion_tokens_for_model(
+    model_kwargs: dict[str, Any], *, model_name: str
+) -> dict[str, Any]:
     if str(model_name or "").strip().casefold() != "google/gemini-3.1-flash-lite-preview":
         return model_kwargs
     capped = dict(model_kwargs)
@@ -330,7 +337,9 @@ def _init_runtime_chat_model(
             adapter_kwargs["app_url"] = referer
         if title := app_headers.get("X-OpenRouter-Title"):
             adapter_kwargs["app_title"] = title
-        return ChatOpenRouter(**{key: value for key, value in adapter_kwargs.items() if value is not None})
+        return ChatOpenRouter(
+            **{key: value for key, value in adapter_kwargs.items() if value is not None}
+        )
 
     return init_chat_model(
         model_name,
@@ -601,6 +610,8 @@ def _extract_response_usage_fields(response: Any) -> dict[str, Any]:
             if cost_details.get("completion") not in (None, ""):
                 fields["native_cost_completion_usd"] = float(cost_details.get("completion"))
     return fields
+
+
 _LINK_ID_TOKEN_RE = re.compile(r"\blink_[A-Za-z0-9]{4,12}\b")
 STREAM_WAIT_SIGNAL = "__TULPA_STREAM_WAIT__"
 STREAM_APPROVAL_HANDOFF_SIGNAL = "__TULPA_APPROVAL_HANDOFF__"
@@ -702,6 +713,16 @@ class _RoutineCreateIntentDecision(BaseModel):
     reason: str = ""
 
 
+class _WorkflowSetupInterruptionDecision(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    ok: bool = True
+    kind: str = "setup_input"
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    status_reply: str = ""
+    reason: str = ""
+
+
 class _SkillSelectionItem(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -786,7 +807,7 @@ def _build_intake_workflow_system_prompt() -> str:
         "- For a clear cancellation of an active or recent completed booking: use matches_workflow=true, "
         "booking_action=update_active or edit_recent_completed, reply_action=mark_cancelled, and a reply_text "
         "that confirms the cancellation. If the sink should be updated, ready_to_save=true and save_payload "
-        "should contain the merged booking fields plus status=\"cancelled\".\n\n"
+        'should contain the merged booking fields plus status="cancelled".\n\n'
         "Business knowledge request policy:\n"
         "- If workflow has knowledge_file_ids, workflow.knowledge_answer is empty, and the latest message needs a "
         "source-backed price, service, policy, menu, or capability fact that is not already present in saved "
@@ -804,7 +825,7 @@ def _build_intake_workflow_system_prompt() -> str:
         "- If details are missing, set reply_action=send_reply with one concise, high-leverage follow-up question.\n"
         "- Ask at most one compact question at a time unless a single sentence can naturally request two tightly related missing fields.\n"
         "- reply_text should be plain outbound DM text, not explanations about JSON or system behavior.\n"
-        "- If no reply is needed, use reply_action=none and reply_text=\"\".\n"
+        '- If no reply is needed, use reply_action=none and reply_text="".\n'
         "- Use mark_cancelled only when the customer clearly cancels, abandons, or says they no longer want the booking.\n"
         "- Never ask for Telegram approval. This is background workflow execution.\n\n"
         "Booking action policy:\n"
@@ -823,7 +844,7 @@ def _build_intake_workflow_system_prompt() -> str:
         "- When ready_to_save=true, reply_text must describe the completed action. Never ask the customer to confirm "
         "a booking or change that you are saving now. If confirmation is still needed, set ready_to_save=false.\n"
         "- When needs_business_knowledge=true and workflow.knowledge_file_ids is non-empty, set ready_to_save=false, "
-        "reply_action=none, reply_text=\"\", and business_knowledge_query to the exact missing source-backed fact.\n"
+        'reply_action=none, reply_text="", and business_knowledge_query to the exact missing source-backed fact.\n'
         "- sink_arguments may contain sink-tool arguments or overrides discovered via tools or context "
         "(for example sheetName for Google Sheets). These are merged into the final sink write.\n"
         "- When ready_to_save=false, save_payload should usually be empty.\n"
@@ -906,7 +927,9 @@ def _compact_workflow_for_prompt(workflow: dict[str, Any]) -> dict[str, Any]:
             if str(key or "").strip()
         ]
         compact_sink["static_arguments"] = _compact_jsonish_dict(static_arguments)
-    compact_knowledge_answer = _trim_text_chars(safe_workflow.get("knowledge_answer", ""), limit=3600)
+    compact_knowledge_answer = _trim_text_chars(
+        safe_workflow.get("knowledge_answer", ""), limit=3600
+    )
     return {
         "workflow_id": str(safe_workflow.get("workflow_id", "") or "").strip(),
         "name": _trim_text_chars(safe_workflow.get("name", ""), limit=80),
@@ -1098,7 +1121,7 @@ def _build_intake_workflow_agent_prompt(
         "- If ready_to_save=true, reply_text must be a final saved/updated/cancelled confirmation and must not ask "
         "for confirmation. If you still need confirmation from the customer, use ready_to_save=false.\n"
         "- If needs_business_knowledge=true and workflow.knowledge_file_ids is non-empty, set ready_to_save=false, "
-        "reply_action=none, reply_text=\"\", and business_knowledge_query to the exact missing source-backed fact.\n"
+        'reply_action=none, reply_text="", and business_knowledge_query to the exact missing source-backed fact.\n'
         "- If the customer asks a business/service/pricing/booking question that is close to the workflow but outside its configured scope, return matches_workflow=false, booking_action=ignore, reply_action=send_reply with a concise redirect based on workflow instructions.\n"
         "- If the latest customer message is only cancelling, rescheduling, or correcting an active/recent booking, "
         "reuse active_booking or recent_completed_booking and do not call business_knowledge_query unless a new "
@@ -1211,6 +1234,7 @@ class OpenTulpaLangGraphRuntime:
         wake_execution_model_name: str | None = None,
         telegram_media_model_name: str | None = None,
         guardrail_classifier_model_name: str | None = None,
+        workflow_setup_input_classifier_model_name: str | None = None,
         checkpoint_db_path: str,
         recursion_limit: int = 30,
         max_completion_tokens: int = 4096,
@@ -1239,7 +1263,9 @@ class OpenTulpaLangGraphRuntime:
     ) -> None:
         self.app_url = app_url.rstrip("/")
         self.openrouter_api_key = openrouter_api_key
-        self.openrouter_base_url = str(openrouter_base_url or "").strip() or "https://openrouter.ai/api/v1"
+        self.openrouter_base_url = (
+            str(openrouter_base_url or "").strip() or "https://openrouter.ai/api/v1"
+        )
         self.model_name = _normalize_model_name(model_name)
         self._reasoning_effort = str(reasoning_effort or "").strip() or None
         self._max_completion_tokens = max(128, min(int(max_completion_tokens), 32768))
@@ -1265,6 +1291,14 @@ class OpenTulpaLangGraphRuntime:
             else "minimax/minimax-m2.5"
         )
         self._guardrail_classifier_model_name = _normalize_model_name(guardrail_model)
+        workflow_setup_classifier_model = (
+            str(workflow_setup_input_classifier_model_name).strip()
+            if str(workflow_setup_input_classifier_model_name or "").strip()
+            else "z-ai/glm-5.1"
+        )
+        self._workflow_setup_input_classifier_model_name = _normalize_model_name(
+            workflow_setup_classifier_model
+        )
         self.checkpoint_db_path = checkpoint_db_path
         self.recursion_limit = recursion_limit
         self._context_events = context_events
@@ -1289,9 +1323,13 @@ class OpenTulpaLangGraphRuntime:
             int(context_compaction_source_tokens),
         )
         self._input_debounce_seconds = max(0.0, min(float(input_debounce_seconds), 3.0))
-        self._proactive_heartbeat_default_hours = max(1, min(int(proactive_heartbeat_default_hours), 24))
+        self._proactive_heartbeat_default_hours = max(
+            1, min(int(proactive_heartbeat_default_hours), 24)
+        )
         self._behavior_log_enabled = bool(behavior_log_enabled)
-        raw_behavior_path = str(behavior_log_path or "").strip() or ".opentulpa/logs/agent_behavior.jsonl"
+        raw_behavior_path = (
+            str(behavior_log_path or "").strip() or ".opentulpa/logs/agent_behavior.jsonl"
+        )
         self._behavior_log_path = Path(raw_behavior_path).resolve()
         self._behavior_log_lock = threading.Lock()
         self._llm_call_trace_path = self._behavior_log_path.parent / "llm_call_traces.jsonl"
@@ -1431,6 +1469,41 @@ class OpenTulpaLangGraphRuntime:
                 )
                 self._guardrail_classifier_model = self._model
 
+        classifier_model_kwargs = dict(model_init_kwargs)
+        classifier_model_kwargs["max_completion_tokens"] = min(
+            int(classifier_model_kwargs.get("max_completion_tokens", 160) or 160),
+            160,
+        )
+        if self._workflow_setup_input_classifier_model_name == self.model_name:
+            self._workflow_setup_input_classifier_model = self._model
+        elif self._workflow_setup_input_classifier_model_name == self._wake_classifier_model_name:
+            self._workflow_setup_input_classifier_model = self._wake_classifier_model
+        elif self._workflow_setup_input_classifier_model_name == self._wake_execution_model_name:
+            self._workflow_setup_input_classifier_model = self._wake_execution_model
+        elif self._workflow_setup_input_classifier_model_name == self._telegram_media_model_name:
+            self._workflow_setup_input_classifier_model = self._telegram_media_model
+        elif (
+            self._workflow_setup_input_classifier_model_name
+            == self._guardrail_classifier_model_name
+        ):
+            self._workflow_setup_input_classifier_model = self._guardrail_classifier_model
+        else:
+            try:
+                self._workflow_setup_input_classifier_model = _init_runtime_chat_model(
+                    self._workflow_setup_input_classifier_model_name,
+                    base_kwargs=classifier_model_kwargs,
+                    openrouter_base_url=self.openrouter_base_url,
+                    reasoning_effort=None,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to initialize workflow setup input classifier model '%s'; "
+                    "falling back to main model '%s'.",
+                    self._workflow_setup_input_classifier_model_name,
+                    self.model_name,
+                )
+                self._workflow_setup_input_classifier_model = self._model
+
         self._checkpointer_cm: Any | None = None
         self._checkpointer: Any | None = None
         self._graph = None
@@ -1476,7 +1549,9 @@ class OpenTulpaLangGraphRuntime:
     def _model_request_attempts(self, *, model_name: str | None = None) -> list[dict[str, Any]]:
         return [{"name": "default", "invoke_extras": {}, "call_context": {}}]
 
-    def _resolve_model_name_for_runtime_call(self, model: Any, explicit_name: str | None = None) -> str:
+    def _resolve_model_name_for_runtime_call(
+        self, model: Any, explicit_name: str | None = None
+    ) -> str:
         if explicit_name:
             return str(explicit_name).strip()
         if model is getattr(self, "_wake_classifier_model", None):
@@ -1485,9 +1560,15 @@ class OpenTulpaLangGraphRuntime:
             return str(getattr(self, "_wake_execution_model_name", "") or "").strip()
         if model is getattr(self, "_guardrail_classifier_model", None):
             return str(getattr(self, "_guardrail_classifier_model_name", "") or "").strip()
+        if model is getattr(self, "_workflow_setup_input_classifier_model", None):
+            return str(
+                getattr(self, "_workflow_setup_input_classifier_model_name", "") or ""
+            ).strip()
         if model is getattr(self, "_wake_execution_model_with_tools", None):
             return str(getattr(self, "_wake_execution_model_name", "") or "").strip()
-        if model is getattr(self, "_model", None) or model is getattr(self, "_model_with_tools", None):
+        if model is getattr(self, "_model", None) or model is getattr(
+            self, "_model_with_tools", None
+        ):
             return str(getattr(self, "model_name", "") or "").strip()
         model_name = getattr(model, "model_name", None)
         if isinstance(model_name, str) and model_name.strip():
@@ -1496,7 +1577,10 @@ class OpenTulpaLangGraphRuntime:
 
     def model_with_tools_for_turn_mode(self, turn_mode: str) -> Any:
         normalized_turn_mode = str(turn_mode or "").strip().lower()
-        if normalized_turn_mode == "routine_wake" and self._wake_execution_model_with_tools is not None:
+        if (
+            normalized_turn_mode == "routine_wake"
+            and self._wake_execution_model_with_tools is not None
+        ):
             return self._wake_execution_model_with_tools
         return self._model_with_tools
 
@@ -1543,7 +1627,9 @@ class OpenTulpaLangGraphRuntime:
         stable_prefix_count: int = 0,
         call_context: dict[str, Any] | None = None,
     ) -> Any:
-        resolved_model_name = self._resolve_model_name_for_runtime_call(model, explicit_name=model_name)
+        resolved_model_name = self._resolve_model_name_for_runtime_call(
+            model, explicit_name=model_name
+        )
         prepared_messages = self.prepare_messages_for_prompt_cache(
             list(messages),
             model_name=resolved_model_name,
@@ -1559,7 +1645,9 @@ class OpenTulpaLangGraphRuntime:
             )
             attempt_context = dict(call_context or {})
             attempt_context.update(dict(attempt.get("call_context") or {}))
-            attempt_context["provider_attempt_name"] = str(attempt.get("name") or "").strip() or "default"
+            attempt_context["provider_attempt_name"] = (
+                str(attempt.get("name") or "").strip() or "default"
+            )
             attempt_context["provider_attempt_index"] = attempt_index + 1
             attempt_context["provider_attempt_count"] = len(attempts)
             callback_target = self._model_with_callbacks(model, call_context=attempt_context)
@@ -1586,7 +1674,8 @@ class OpenTulpaLangGraphRuntime:
                     event="llm.provider_fallback",
                     model_name=resolved_model_name,
                     failed_provider_attempt=attempt_context["provider_attempt_name"],
-                    next_provider_attempt=str(attempts[attempt_index + 1].get("name") or "").strip() or "default",
+                    next_provider_attempt=str(attempts[attempt_index + 1].get("name") or "").strip()
+                    or "default",
                     error=error_text,
                 )
             finally:
@@ -1641,7 +1730,13 @@ class OpenTulpaLangGraphRuntime:
         for name in names[:2]:
             label = _PROGRESS_TOOL_NAME_ALIASES.get(name)
             if label is None:
-                label = name.replace("tulpa_", "").replace("browser_use_", "").replace("_", " ").strip().capitalize()
+                label = (
+                    name.replace("tulpa_", "")
+                    .replace("browser_use_", "")
+                    .replace("_", " ")
+                    .strip()
+                    .capitalize()
+                )
             labels.append(label)
         if len(names) == 1:
             return f"{labels[0]}…"
@@ -1696,7 +1791,9 @@ class OpenTulpaLangGraphRuntime:
                 model_name=model_name or self.model_name,
             )
         except Exception:
-            logger.exception("tool result compression failed for %s", str(tool_name or "").strip() or "tool")
+            logger.exception(
+                "tool result compression failed for %s", str(tool_name or "").strip() or "tool"
+            )
             return raw_result_text
         normalized = str(compressed or "").strip()
         return normalized or raw_result_text
@@ -1774,9 +1871,7 @@ class OpenTulpaLangGraphRuntime:
             normalized["prompt_sections"] = [
                 str(part).strip() for part in prompt_sections if str(part).strip()
             ]
-        normalized["call_site"] = str(
-            normalized.get("call_site") or "runtime_model_invoke"
-        ).strip()
+        normalized["call_site"] = str(normalized.get("call_site") or "runtime_model_invoke").strip()
         return normalized
 
     def _write_llm_call_trace(self, payload: dict[str, Any]) -> None:
@@ -1823,11 +1918,7 @@ class OpenTulpaLangGraphRuntime:
         if not bool(getattr(self, "_behavior_log_enabled", True)):
             return
         normalized_context = self._normalize_llm_call_context(call_context)
-        usage_fields = (
-            self.extract_response_usage_fields(response)
-            if response is not None
-            else {}
-        )
+        usage_fields = self.extract_response_usage_fields(response) if response is not None else {}
         response_content = getattr(response, "content", response) if response is not None else ""
         safe_response_content = _json_safe(response_content)
         record: dict[str, Any] = {
@@ -1838,7 +1929,9 @@ class OpenTulpaLangGraphRuntime:
             "prompt_message_count": len(prepared_messages),
             "response_type": type(response).__name__ if response is not None else "",
             "response_message": _serialize_message(response) if response is not None else None,
-            "response_text": _content_to_text(safe_response_content).strip() if response is not None else "",
+            "response_text": _content_to_text(safe_response_content).strip()
+            if response is not None
+            else "",
             "response_content": safe_response_content,
             "response_tool_calls": _json_safe(getattr(response, "tool_calls", None)),
             "error": str(error or "").strip() or None,
@@ -1884,7 +1977,9 @@ class OpenTulpaLangGraphRuntime:
         call_context: dict[str, Any] | None = None,
     ) -> tuple[BaseModel | None, str | None]:
         last_error: str | None = None
-        resolved_model_name = self._resolve_model_name_for_runtime_call(model, explicit_name=model_name)
+        resolved_model_name = self._resolve_model_name_for_runtime_call(
+            model, explicit_name=model_name
+        )
         prepared_messages = self.prepare_messages_for_prompt_cache(
             list(messages),
             model_name=resolved_model_name,
@@ -1899,7 +1994,9 @@ class OpenTulpaLangGraphRuntime:
             )
             attempt_context = dict(call_context or {})
             attempt_context.update(dict(attempt.get("call_context") or {}))
-            attempt_context["provider_attempt_name"] = str(attempt.get("name") or "").strip() or "default"
+            attempt_context["provider_attempt_name"] = (
+                str(attempt.get("name") or "").strip() or "default"
+            )
             attempt_context["provider_attempt_index"] = attempt_index + 1
             attempt_context["provider_attempt_count"] = len(attempts)
             callback_target = self._model_with_callbacks(model, call_context=attempt_context)
@@ -1967,7 +2064,8 @@ class OpenTulpaLangGraphRuntime:
                     event="llm.provider_fallback",
                     model_name=resolved_model_name,
                     failed_provider_attempt=attempt_context["provider_attempt_name"],
-                    next_provider_attempt=str(attempts[attempt_index + 1].get("name") or "").strip() or "default",
+                    next_provider_attempt=str(attempts[attempt_index + 1].get("name") or "").strip()
+                    or "default",
                     error=error_text,
                 )
                 continue
@@ -1979,7 +2077,9 @@ class OpenTulpaLangGraphRuntime:
                 stable_prefix_count=stable_prefix_count,
                 call_context={
                     **dict(call_context or {}),
-                    "call_site": str((call_context or {}).get("call_site") or "structured_model_fallback"),
+                    "call_site": str(
+                        (call_context or {}).get("call_site") or "structured_model_fallback"
+                    ),
                 },
             )
             raw = _content_to_text(getattr(response, "content", response)).strip()
@@ -2204,7 +2304,9 @@ class OpenTulpaLangGraphRuntime:
             return self._link_alias_service.expand_link_ids_in_text(cid, raw)
         return raw
 
-    def resolve_link_aliases_in_args(self, *, customer_id: str, args: dict[str, Any]) -> dict[str, Any]:
+    def resolve_link_aliases_in_args(
+        self, *, customer_id: str, args: dict[str, Any]
+    ) -> dict[str, Any]:
         if not isinstance(args, dict):
             return {}
 
@@ -2340,14 +2442,21 @@ class OpenTulpaLangGraphRuntime:
                 if any(tok in hay for tok in tokens):
                     return True
         if isinstance(thread_rollup_sections, dict):
-            hay = " ".join(str(thread_rollup_sections.get(k) or "").lower() for k in ("conversation_summary", "open_loops", "durable_facts"))
+            hay = " ".join(
+                str(thread_rollup_sections.get(k) or "").lower()
+                for k in ("conversation_summary", "open_loops", "durable_facts")
+            )
             if any(tok in hay for tok in tokens):
                 return True
         return False
 
     @staticmethod
     def _normalize_memory_search_results(raw: Any) -> list[dict[str, Any]]:
-        payload = raw.get("results") if isinstance(raw, dict) and isinstance(raw.get("results"), list) else raw
+        payload = (
+            raw.get("results")
+            if isinstance(raw, dict) and isinstance(raw.get("results"), list)
+            else raw
+        )
         if not isinstance(payload, list):
             payload = [payload] if payload not in (None, "") else []
         normalized: list[dict[str, Any]] = []
@@ -2360,7 +2469,10 @@ class OpenTulpaLangGraphRuntime:
                 continue
             metadata = item.get("metadata")
             metadata = dict(metadata) if isinstance(metadata, dict) else {}
-            kind = str(item.get("kind") or metadata.get("kind") or "").strip().lower() or "thread_context_rollup"
+            kind = (
+                str(item.get("kind") or metadata.get("kind") or "").strip().lower()
+                or "thread_context_rollup"
+            )
             dedupe_key = (kind, text.lower())
             if dedupe_key in seen:
                 continue
@@ -2371,8 +2483,12 @@ class OpenTulpaLangGraphRuntime:
                     "kind": kind,
                     "score": item.get("score"),
                     "metadata": metadata,
-                    "thread_id": str(item.get("thread_id") or metadata.get("thread_id") or "").strip(),
-                    "skill_name": str(item.get("skill_name") or metadata.get("skill_name") or "").strip(),
+                    "thread_id": str(
+                        item.get("thread_id") or metadata.get("thread_id") or ""
+                    ).strip(),
+                    "skill_name": str(
+                        item.get("skill_name") or metadata.get("skill_name") or ""
+                    ).strip(),
                 }
             )
         return normalized
@@ -2600,13 +2716,13 @@ class OpenTulpaLangGraphRuntime:
                     content=(
                         "You select reusable skills for the current user request.\n"
                         "Return strict JSON object with key 'selected', an array of objects:\n"
-                        "  {\"name\": string, \"score\": number, \"reason\": string}\n"
+                        '  {"name": string, "score": number, "reason": string}\n'
                         "Choose only skills that materially improve answer quality.\n"
                         "Never select persona, tone, or style-only skills for literal definitions, acronym expansions, translations, or short factual clarifications.\n"
                         "If the request is about reminders, schedules, recurring jobs, or cron, "
                         "prefer selecting routine-schedule-composer when available.\n"
                         "Prioritize skills that improve execution reliability and claim accuracy over style-only skills.\n"
-                        "If none apply, return {\"selected\": []}."
+                        'If none apply, return {"selected": []}.'
                     )
                 ),
                 HumanMessage(
@@ -2651,7 +2767,9 @@ class OpenTulpaLangGraphRuntime:
         query = str(user_text or "").strip()
         if not cid or not query:
             return {"skill_names": [], "context": ""}
-        available = candidates if isinstance(candidates, list) else await self._list_available_skills(cid)
+        available = (
+            candidates if isinstance(candidates, list) else await self._list_available_skills(cid)
+        )
         if not available:
             return {"skill_names": [], "context": ""}
         selected = await self._select_relevant_skills(
@@ -2776,9 +2894,7 @@ class OpenTulpaLangGraphRuntime:
 
         user_offset_text = await self._load_user_utc_offset(customer_id)
         source = "profile"
-        user_offset_minutes = (
-            _utc_offset_to_minutes(user_offset_text) if user_offset_text else None
-        )
+        user_offset_minutes = _utc_offset_to_minutes(user_offset_text) if user_offset_text else None
         if user_offset_minutes is None:
             user_offset_minutes = server_offset_minutes
             user_offset_text = server_offset_text
@@ -2930,7 +3046,9 @@ class OpenTulpaLangGraphRuntime:
     async def _compress_rollup(self, existing_rollup: str, additional_text: str) -> str:
         return await _compress_rollup(self, existing_rollup, additional_text)
 
-    async def _persist_rollup_memory(self, *, customer_id: str, thread_id: str, rollup: str) -> None:
+    async def _persist_rollup_memory(
+        self, *, customer_id: str, thread_id: str, rollup: str
+    ) -> None:
         await _persist_rollup_memory(
             self,
             customer_id=customer_id,
@@ -2975,8 +3093,12 @@ class OpenTulpaLangGraphRuntime:
                 "active_skill_names": forced_names,
                 "active_available_skills": available_skills,
                 "active_skill_discovery_context": "",
-                "active_invoked_skill_context": str(forced_skill_context.get("context", "")).strip(),
-                "active_invoked_skill_names": list(forced_skill_context.get("skill_names", []) or []),
+                "active_invoked_skill_context": str(
+                    forced_skill_context.get("context", "")
+                ).strip(),
+                "active_invoked_skill_names": list(
+                    forced_skill_context.get("skill_names", []) or []
+                ),
                 "active_skill_context": str(forced_skill_context.get("context", "")).strip(),
             }
         if forced_names:
@@ -2986,8 +3108,12 @@ class OpenTulpaLangGraphRuntime:
                 "active_skill_names": forced_names,
                 "active_available_skills": available_skills,
                 "active_skill_discovery_context": "",
-                "active_invoked_skill_context": str(forced_skill_context.get("context", "")).strip(),
-                "active_invoked_skill_names": list(forced_skill_context.get("skill_names", []) or []),
+                "active_invoked_skill_context": str(
+                    forced_skill_context.get("context", "")
+                ).strip(),
+                "active_invoked_skill_names": list(
+                    forced_skill_context.get("skill_names", []) or []
+                ),
                 "active_skill_context": str(forced_skill_context.get("context", "")).strip(),
             }
         if prompt_mode == "literal_chat":
@@ -3008,7 +3134,11 @@ class OpenTulpaLangGraphRuntime:
             prompt_mode=prompt_mode,
             max_skills=3,
         )
-        names = [str(item.get("name", "")).strip() for item in selected if str(item.get("name", "")).strip()]
+        names = [
+            str(item.get("name", "")).strip()
+            for item in selected
+            if str(item.get("name", "")).strip()
+        ]
         return {
             "prompt_mode": prompt_mode,
             "active_skill_query": query,
@@ -3036,7 +3166,9 @@ class OpenTulpaLangGraphRuntime:
         if self._wake_execution_model is self._model:
             self._wake_execution_model_with_tools = self._model_with_tools
         else:
-            self._wake_execution_model_with_tools = self._wake_execution_model.bind_tools(list(self._tools.values()))
+            self._wake_execution_model_with_tools = self._wake_execution_model.bind_tools(
+                list(self._tools.values())
+            )
         self._graph = self._build_graph()
         manager = self.get_browser_use_local_manager()
         with suppress(Exception):
@@ -3131,9 +3263,8 @@ class OpenTulpaLangGraphRuntime:
             customer_id=customer_id,
             include_pending_context=include_pending_context,
         )
-        prompt_mode = (
-            str(prompt_mode_override or "").strip().lower()
-            or _classify_prompt_mode(user_text, turn_mode=turn_mode)
+        prompt_mode = str(prompt_mode_override or "").strip().lower() or _classify_prompt_mode(
+            user_text, turn_mode=turn_mode
         )
         try:
             skill_state = await self._pre_resolve_skill_state(
@@ -3210,15 +3341,15 @@ class OpenTulpaLangGraphRuntime:
             properties=properties,
         )
 
-    def _model_with_callbacks(self, model: Any, *, call_context: dict[str, Any] | None = None) -> Any:
+    def _model_with_callbacks(
+        self, model: Any, *, call_context: dict[str, Any] | None = None
+    ) -> Any:
         if model is None:
             return model
         context = dict(call_context or {})
         callbacks = self._build_posthog_callbacks(
             customer_id=str(
-                context.get("customer_id")
-                or self.get_active_customer_id()
-                or ""
+                context.get("customer_id") or self.get_active_customer_id() or ""
             ).strip()
             or None,
             trace_id=str(context.get("trace_id") or "").strip() or None,
@@ -3226,7 +3357,9 @@ class OpenTulpaLangGraphRuntime:
             turn_mode=str(context.get("turn_mode") or "").strip() or None,
             prompt_mode=str(context.get("prompt_mode") or "").strip() or None,
             call_site=str(context.get("call_site") or "").strip() or "runtime_model_invoke",
-            model_name=self._resolve_model_name_for_runtime_call(model, explicit_name=context.get("model_name")),
+            model_name=self._resolve_model_name_for_runtime_call(
+                model, explicit_name=context.get("model_name")
+            ),
         )
         if not callbacks:
             return model
@@ -3277,7 +3410,9 @@ class OpenTulpaLangGraphRuntime:
         customer_scope_token = self.set_active_customer_id(customer_id)
         thread_scope_token = self.set_active_thread_id(thread_id)
         try:
-            if turn_state is not None or not (normalized_turn_mode == "interactive" and interactive_session is not None):
+            if turn_state is not None or not (
+                normalized_turn_mode == "interactive" and interactive_session is not None
+            ):
                 self.log_behavior_event(
                     event="turn_start",
                     trace_id=turn_trace_id,
@@ -3309,7 +3444,10 @@ class OpenTulpaLangGraphRuntime:
                 )
                 return ""
             result = await self._graph.ainvoke(prepared.graph_input, config=prepared.config)
-            if bool(result.get("approval_handoff", False)) or str(result.get("turn_status", "")) == "approval_pending":
+            if (
+                bool(result.get("approval_handoff", False))
+                or str(result.get("turn_status", "")) == "approval_pending"
+            ):
                 self.log_behavior_event(
                     event="turn_approval_handoff",
                     trace_id=turn_trace_id,
@@ -3391,7 +3529,9 @@ class OpenTulpaLangGraphRuntime:
                             truncated_chars=len(cleaned.strip()),
                         )
                     if prepared.through_id is not None and self._context_events is not None:
-                        self._context_events.clear_events(customer_id, through_id=prepared.through_id)
+                        self._context_events.clear_events(
+                            customer_id, through_id=prepared.through_id
+                        )
                     self.log_behavior_event(
                         event="turn_complete",
                         trace_id=turn_trace_id,
@@ -3450,7 +3590,11 @@ class OpenTulpaLangGraphRuntime:
             turn_state, effective_text = await self._thread_inputs.begin_turn(
                 thread_id=thread_id, text=text
             )
-        if turn_state is None and normalized_turn_mode == "interactive" and interactive_session is not None:
+        if (
+            turn_state is None
+            and normalized_turn_mode == "interactive"
+            and interactive_session is not None
+        ):
             logger.info(
                 "runtime.astream_text interactive_session_bypass thread_id=%s customer_id=%s",
                 thread_id,
@@ -3586,7 +3730,9 @@ class OpenTulpaLangGraphRuntime:
                     )
                 if node_name != "agent":
                     stream_tool_chunks += 1
-                    if node_name == "tools" and self._tool_message_indicates_approval_handoff(message_chunk):
+                    if node_name == "tools" and self._tool_message_indicates_approval_handoff(
+                        message_chunk
+                    ):
                         approval_handoff_detected = True
                         self.log_behavior_event(
                             event="turn_stream_tool_approval_handoff_detected",
@@ -3621,7 +3767,10 @@ class OpenTulpaLangGraphRuntime:
                         yielded_any = True
                         yield STREAM_APPROVAL_HANDOFF_SIGNAL
                         break
-                    if self._stream_chunk_is_tool_phase(node_name, message_chunk) and not in_tool_phase:
+                    if (
+                        self._stream_chunk_is_tool_phase(node_name, message_chunk)
+                        and not in_tool_phase
+                    ):
                         in_tool_phase = True
                         suppress_live_text_until_completion = True
                         if buffered_visible and not yielded_any:
@@ -3710,7 +3859,9 @@ class OpenTulpaLangGraphRuntime:
                         yielded_any = True
                         stream_visible_yields += 1
                         if first_visible_yield_ms is None:
-                            first_visible_yield_ms = int((time.monotonic() - stream_started_at) * 1000)
+                            first_visible_yield_ms = int(
+                                (time.monotonic() - stream_started_at) * 1000
+                            )
                         if stream_visible_yields <= 3 or stream_visible_yields % 20 == 0:
                             self.log_behavior_event(
                                 event="turn_stream_chunk_yielded",
@@ -3845,9 +3996,10 @@ class OpenTulpaLangGraphRuntime:
                     prepared.graph_input,
                     config=config,
                 )
-                if bool(fallback_result.get("approval_handoff", False)) or str(
-                    fallback_result.get("turn_status", "")
-                ) == "approval_pending":
+                if (
+                    bool(fallback_result.get("approval_handoff", False))
+                    or str(fallback_result.get("turn_status", "")) == "approval_pending"
+                ):
                     yielded_any = True
                     self.log_behavior_event(
                         event="turn_approval_handoff",
@@ -4021,7 +4173,9 @@ class OpenTulpaLangGraphRuntime:
         async with self._interactive_sessions_lock:
             self._interactive_sessions[safe_thread_id] = session
 
-    async def clear_interactive_session(self, *, thread_id: str, session: Any | None = None) -> None:
+    async def clear_interactive_session(
+        self, *, thread_id: str, session: Any | None = None
+    ) -> None:
         safe_thread_id = str(thread_id or "").strip()
         if not safe_thread_id:
             return
@@ -4143,6 +4297,56 @@ class OpenTulpaLangGraphRuntime:
             return []
         return [str(item).strip() for item in drained if str(item).strip()]
 
+    async def classify_workflow_setup_interruption(
+        self,
+        *,
+        user_text: str,
+        status: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Classify a message sent while workflow setup is already running."""
+
+        decision, invoke_error = await self._invoke_structured_model(
+            model=self._workflow_setup_input_classifier_model,
+            schema=_WorkflowSetupInterruptionDecision,
+            messages=[
+                SystemMessage(
+                    content=(
+                        "Classify one user message sent while workflow setup is already running.\n"
+                        "Return strict JSON only with keys: ok, kind, confidence, status_reply, reason.\n"
+                        "kind must be exactly one of: status_nudge, setup_input.\n"
+                        "status_nudge means the user only asks for progress/status, expresses impatience, "
+                        "or sends a low-information acknowledgement with no new workflow facts.\n"
+                        "setup_input means the message contains any workflow requirement, edit, required "
+                        "field, business rule, sink/table/file clarification, confirmation, or other fact "
+                        "the setup agent should process.\n"
+                        "When kind=status_nudge, write a concise status_reply using only the provided "
+                        "status. Do not claim the workflow is complete.\n"
+                        "When unsure, use setup_input."
+                    )
+                ),
+                HumanMessage(
+                    content=(
+                        f"status={json.dumps(status, ensure_ascii=False)[:2000]}\n"
+                        f"user_text={str(user_text or '').strip()[:2000]}"
+                    )
+                ),
+            ],
+            model_name=self._workflow_setup_input_classifier_model_name,
+            call_context={"classifier": "workflow_setup_interruption"},
+        )
+        if decision is None or not isinstance(decision, _WorkflowSetupInterruptionDecision):
+            return {"ok": False, "kind": "setup_input", "error": invoke_error or "invalid_output"}
+        kind = str(decision.kind or "").strip().lower()
+        if kind not in {"status_nudge", "setup_input"}:
+            kind = "setup_input"
+        return {
+            "ok": bool(decision.ok),
+            "kind": kind,
+            "confidence": max(0.0, min(float(decision.confidence), 1.0)),
+            "status_reply": str(decision.status_reply or "").strip()[:500],
+            "reason": str(decision.reason or "").strip()[:300],
+        }
+
     async def classify_wake_event(
         self,
         *,
@@ -4200,16 +4404,22 @@ class OpenTulpaLangGraphRuntime:
         decision: _IntakeWorkflowDecision | None = None
         workflow_id = str(workflow.get("workflow_id", "") or "").strip() or "workflow"
         conversation_summary = conversation.get("summary") if isinstance(conversation, dict) else {}
-        conversation_id = str(
-            (conversation_summary or {}).get("conversation_id", "")
-            if isinstance(conversation_summary, dict)
-            else ""
-        ).strip() or "conversation"
-        latest_inbound_id = str(
-            (conversation_summary or {}).get("latest_inbound_message_id", "")
-            if isinstance(conversation_summary, dict)
-            else ""
-        ).strip() or "latest"
+        conversation_id = (
+            str(
+                (conversation_summary or {}).get("conversation_id", "")
+                if isinstance(conversation_summary, dict)
+                else ""
+            ).strip()
+            or "conversation"
+        )
+        latest_inbound_id = (
+            str(
+                (conversation_summary or {}).get("latest_inbound_message_id", "")
+                if isinstance(conversation_summary, dict)
+                else ""
+            ).strip()
+            or "latest"
+        )
         structured_thread_id = f"intake_decision_{workflow_id}_{conversation_id}"
         structured_trace_id = f"intake_{workflow_id}_{conversation_id}_{latest_inbound_id}"
         tool_enabled_runtime = (
@@ -4218,14 +4428,18 @@ class OpenTulpaLangGraphRuntime:
             and callable(getattr(self, "ainvoke_text", None))
         )
         sink_type = str(workflow.get("sink_type", "") or "").strip().lower()
-        sink_config = workflow.get("sink_config") if isinstance(workflow.get("sink_config"), dict) else {}
-        static_arguments = sink_config.get("static_arguments") if isinstance(sink_config, dict) else {}
-        sink_needs_tool_metadata = sink_type in {"google_sheets_composio", "generic_composio_write"} and not bool(
-            static_arguments
+        sink_config = (
+            workflow.get("sink_config") if isinstance(workflow.get("sink_config"), dict) else {}
         )
+        static_arguments = (
+            sink_config.get("static_arguments") if isinstance(sink_config, dict) else {}
+        )
+        sink_needs_tool_metadata = sink_type in {
+            "google_sheets_composio",
+            "generic_composio_write",
+        } and not bool(static_arguments)
         prefer_agent_runtime = tool_enabled_runtime and (
-            bool(execution_feedback)
-            or sink_needs_tool_metadata
+            bool(execution_feedback) or sink_needs_tool_metadata
         )
         model = getattr(self, "_wake_execution_model", None) or self._model
         if prefer_agent_runtime:
@@ -4306,7 +4520,9 @@ class OpenTulpaLangGraphRuntime:
             "confidence": float(decision.confidence),
             "conversation_summary": str(decision.conversation_summary).strip()[:500],
             "extracted_fields": dict(decision.extracted_fields),
-            "missing_fields": [str(item).strip() for item in decision.missing_fields if str(item).strip()],
+            "missing_fields": [
+                str(item).strip() for item in decision.missing_fields if str(item).strip()
+            ],
             "reply_action": str(decision.reply_action).strip().lower() or "none",
             "reply_text": str(decision.reply_text).strip(),
             "ready_to_save": bool(decision.ready_to_save),
@@ -4315,7 +4531,9 @@ class OpenTulpaLangGraphRuntime:
             "sink_arguments": dict(decision.sink_arguments),
             "needs_business_knowledge": bool(decision.needs_business_knowledge),
             "business_knowledge_query": str(decision.business_knowledge_query).strip()[:500],
-            "knowledge_source_refs": _normalize_knowledge_source_refs(decision.knowledge_source_refs),
+            "knowledge_source_refs": _normalize_knowledge_source_refs(
+                decision.knowledge_source_refs
+            ),
             "grounding_status": str(decision.grounding_status).strip().lower(),
             "reason": str(decision.reason).strip()[:500],
         }
@@ -4347,7 +4565,7 @@ class OpenTulpaLangGraphRuntime:
         safe_user = str(user_text or "").strip()
         safe_turn_window = str(turn_window or "").strip()
         safe_tools: list[str] = []
-        for raw in (recent_tool_outputs or []):
+        for raw in recent_tool_outputs or []:
             text = " ".join(str(raw or "").split()).strip()
             if text:
                 safe_tools.append(text)
@@ -4820,7 +5038,11 @@ class OpenTulpaLangGraphRuntime:
         cid = str(customer_id or "").strip()
         args = dict(action_args) if isinstance(action_args, dict) else {}
         args.pop("customer_id", None)
-        if inject_customer_id and str(action_name or "").strip() in APPROVAL_EXECUTION_CUSTOMER_ID_TOOLS and not cid:
+        if (
+            inject_customer_id
+            and str(action_name or "").strip() in APPROVAL_EXECUTION_CUSTOMER_ID_TOOLS
+            and not cid
+        ):
             raise RuntimeError(f"customer_id is required for tool: {action_name}")
         args = self.resolve_link_aliases_in_args(
             customer_id=cid,

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -212,8 +212,7 @@ class Settings(BaseSettings):
     wake_classifier_model: str | None = Field(
         default=None,
         description=(
-            "Optional cheaper model for wake/heartbeat notify decisions. "
-            "If unset, uses LLM_MODEL."
+            "Optional cheaper model for wake/heartbeat notify decisions. If unset, uses LLM_MODEL."
         ),
     )
     wake_execution_model: str | None = Field(
@@ -241,6 +240,13 @@ class Settings(BaseSettings):
         description=(
             "Model used by guardrail intent classification for approval decisions. "
             "Recommended default is google/gemini-3-flash-preview."
+        ),
+    )
+    workflow_setup_input_classifier_model: str = Field(
+        default="z-ai/glm-5.1",
+        description=(
+            "Model used to classify messages sent while workflow setup is already running "
+            "as status nudges versus real setup edits."
         ),
     )
     business_knowledge_oracle_model: str = Field(
@@ -374,6 +380,7 @@ class Settings(BaseSettings):
         """Preferred neutral provider naming for embedding model."""
         return self.openrouter_embedding_model
 
+
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
@@ -404,7 +411,9 @@ class _YamlRuntimeDefaultsSource(PydanticBaseSettingsSource):
 
         return candidates
 
-    def _build_delegate(self, settings_cls: type[BaseSettings]) -> PydanticBaseSettingsSource | None:
+    def _build_delegate(
+        self, settings_cls: type[BaseSettings]
+    ) -> PydanticBaseSettingsSource | None:
         for candidate in self._candidate_paths():
             if candidate.exists():
                 return YamlConfigSettingsSource(settings_cls, yaml_file=candidate)

--- a/src/opentulpa/intake/workflow_setup_service.py
+++ b/src/opentulpa/intake/workflow_setup_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import threading
 from contextlib import suppress
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -14,6 +16,8 @@ from opentulpa.intake.workflow_setup_store import (
     SetupSessionStatus,
     WorkflowSetupSessionStore,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_dict(value: Any) -> dict[str, Any]:
@@ -92,9 +96,7 @@ def _normalize_local_csv_draft_sink_config(draft: dict[str, Any]) -> dict[str, A
         return normalized
     sink_config = _safe_dict(normalized.get("sink_config"))
     file_path = str(
-        sink_config.get("file_path", "")
-        or sink_config.get("filename", "")
-        or ""
+        sink_config.get("file_path", "") or sink_config.get("filename", "") or ""
     ).strip()
     normalized["sink_config"] = {"file_path": file_path} if file_path else {}
     return normalized
@@ -121,6 +123,8 @@ def _compact_preflight_for_scratchpad(preflight: dict[str, Any]) -> dict[str, An
         "errors": _safe_list(preflight.get("errors")),
         "warnings": _safe_list(preflight.get("warnings")),
         "follow_up_questions": _safe_list(preflight.get("follow_up_questions")),
+        "draft_hash": str(preflight.get("draft_hash", "") or ""),
+        "cache_hit": bool(preflight.get("cache_hit", False)),
         "sink_type": str(sink_preflight.get("sink_type", "") or ""),
         "dry_run": {
             "mode": str(dry_run.get("mode", "") or ""),
@@ -144,6 +148,8 @@ class WorkflowSetupService:
         self._store = store
         self._intake_workflows = intake_workflows
         self._knowledge_service = knowledge_service
+        self._preflight_lock_guard = threading.Lock()
+        self._preflight_lock_keys: set[str] = set()
 
     @staticmethod
     def _draft_scaffold() -> dict[str, Any]:
@@ -195,6 +201,37 @@ class WorkflowSetupService:
     def _utc_now_iso() -> str:
         return datetime.now(UTC).isoformat()
 
+    @staticmethod
+    def _cached_ready_preflight(session: dict[str, Any], *, draft_hash: str) -> dict[str, Any]:
+        scratchpad = _safe_dict(session.get("scratchpad"))
+        last_preflight = _safe_dict(scratchpad.get("last_preflight"))
+        if (
+            str(last_preflight.get("draft_hash", "") or "").strip() != draft_hash
+            or not bool(last_preflight.get("ok", False))
+            or str(last_preflight.get("status", "") or "").strip() != "ready"
+        ):
+            return {}
+        cached = dict(last_preflight)
+        cached["cache_hit"] = True
+        cached["draft_hash"] = draft_hash
+        knowledge_preflight = _safe_dict(scratchpad.get("knowledge_last_preflight"))
+        if knowledge_preflight:
+            cached["business_knowledge_preflight"] = knowledge_preflight
+        return cached
+
+    def _claim_preflight_lock(self, *, session_id: str, draft_hash: str) -> bool:
+        lock_key = f"{session_id}:{draft_hash}"
+        with self._preflight_lock_guard:
+            if lock_key in self._preflight_lock_keys:
+                return False
+            self._preflight_lock_keys.add(lock_key)
+        return True
+
+    def _release_preflight_lock(self, *, session_id: str, draft_hash: str) -> None:
+        lock_key = f"{session_id}:{draft_hash}"
+        with self._preflight_lock_guard:
+            self._preflight_lock_keys.discard(lock_key)
+
     def get_thread_session(
         self,
         *,
@@ -228,10 +265,14 @@ class WorkflowSetupService:
         )
         safe_workflow_id = str(workflow_id or "").strip()
         if existing_thread_session is not None:
-            existing_target = str(existing_thread_session.get("target_workflow_id", "") or "").strip()
+            existing_target = str(
+                existing_thread_session.get("target_workflow_id", "") or ""
+            ).strip()
             if existing_thread_session.get("status") == "paused":
                 if safe_workflow_id and existing_target and safe_workflow_id != existing_target:
-                    raise ValueError("a paused workflow setup session already exists for this thread")
+                    raise ValueError(
+                        "a paused workflow setup session already exists for this thread"
+                    )
                 return self._store.update_session(
                     session_id=str(existing_thread_session["session_id"]),
                     status="active",
@@ -244,10 +285,13 @@ class WorkflowSetupService:
         if safe_mode == "edit":
             if not safe_workflow_id:
                 raise ValueError("workflow_id is required for edit mode")
-            workflow_snapshot = self._intake_workflows.get_workflow(
-                customer_id=customer_id,
-                workflow_id=safe_workflow_id,
-            ) or {}
+            workflow_snapshot = (
+                self._intake_workflows.get_workflow(
+                    customer_id=customer_id,
+                    workflow_id=safe_workflow_id,
+                )
+                or {}
+            )
             if not workflow_snapshot:
                 raise ValueError("workflow not found")
         draft = self._draft_scaffold()
@@ -255,17 +299,33 @@ class WorkflowSetupService:
             draft.update(
                 {
                     "name": str(workflow_snapshot.get("name", "") or ""),
-                    "channel": str(workflow_snapshot.get("channel", "instagram_dm") or "instagram_dm"),
+                    "channel": str(
+                        workflow_snapshot.get("channel", "instagram_dm") or "instagram_dm"
+                    ),
                     "provider": str(workflow_snapshot.get("provider", "composio") or "composio"),
                     "source_config": _safe_dict(workflow_snapshot.get("source_config")),
-                    "intent_description": str(workflow_snapshot.get("intent_description", "") or ""),
-                    "required_fields": [str(item or "").strip() for item in _safe_list(workflow_snapshot.get("required_fields")) if str(item or "").strip()],
+                    "intent_description": str(
+                        workflow_snapshot.get("intent_description", "") or ""
+                    ),
+                    "required_fields": [
+                        str(item or "").strip()
+                        for item in _safe_list(workflow_snapshot.get("required_fields"))
+                        if str(item or "").strip()
+                    ],
                     "field_guidance": _safe_dict(workflow_snapshot.get("field_guidance")),
-                    "assistant_instructions": str(workflow_snapshot.get("assistant_instructions", "") or ""),
-                    "knowledge_file_ids": [str(item or "").strip() for item in _safe_list(workflow_snapshot.get("knowledge_file_ids")) if str(item or "").strip()],
+                    "assistant_instructions": str(
+                        workflow_snapshot.get("assistant_instructions", "") or ""
+                    ),
+                    "knowledge_file_ids": [
+                        str(item or "").strip()
+                        for item in _safe_list(workflow_snapshot.get("knowledge_file_ids"))
+                        if str(item or "").strip()
+                    ],
                     "sink_type": str(workflow_snapshot.get("sink_type", "") or ""),
                     "sink_config": _safe_dict(workflow_snapshot.get("sink_config")),
-                    "schedule": str(workflow_snapshot.get("schedule", "*/5 * * * *") or "*/5 * * * *"),
+                    "schedule": str(
+                        workflow_snapshot.get("schedule", "*/5 * * * *") or "*/5 * * * *"
+                    ),
                     "notify_user": bool(workflow_snapshot.get("notify_user", True)),
                     "enabled": bool(workflow_snapshot.get("enabled", True)),
                 }
@@ -296,11 +356,15 @@ class WorkflowSetupService:
         )
         if session is None:
             raise ValueError("active workflow setup session not found")
-        updated_draft = _merge_draft(_safe_dict(session.get("draft_upsert")), _safe_dict(draft_patch))
+        updated_draft = _merge_draft(
+            _safe_dict(session.get("draft_upsert")), _safe_dict(draft_patch)
+        )
         updated_draft = _normalize_local_csv_draft_sink_config(
             _normalize_schedule_for_channel(updated_draft)
         )
-        updated_scratchpad = _deep_merge(_safe_dict(session.get("scratchpad")), _safe_dict(scratchpad_patch))
+        updated_scratchpad = _deep_merge(
+            _safe_dict(session.get("scratchpad")), _safe_dict(scratchpad_patch)
+        )
         return self._store.update_session(
             session_id=str(session["session_id"]),
             draft_upsert=updated_draft,
@@ -317,81 +381,134 @@ class WorkflowSetupService:
         if session is None:
             raise ValueError("active workflow setup session not found")
         draft = _safe_dict(session.get("draft_upsert"))
+        session_id = str(session.get("session_id", "") or "").strip()
+        draft_hash = self._draft_hash(draft)
+        cached_preflight = self._cached_ready_preflight(session, draft_hash=draft_hash)
+        if cached_preflight:
+            cached_session = dict(session)
+            cached_session["preflight"] = cached_preflight
+            logger.info(
+                "workflow_setup.preflight cache_hit customer_id=%s thread_id=%s session_id=%s draft_hash=%s",
+                customer_id,
+                thread_id,
+                session_id,
+                draft_hash,
+            )
+            return cached_session
+        if session_id and not self._claim_preflight_lock(
+            session_id=session_id, draft_hash=draft_hash
+        ):
+            running = {
+                "ok": False,
+                "status": "running",
+                "next_action": "wait_for_preflight",
+                "commit_blockers": [],
+                "errors": [],
+                "warnings": ["Workflow setup preflight is already running for the current draft."],
+                "follow_up_questions": [],
+                "draft_hash": draft_hash,
+                "cache_hit": False,
+            }
+            running_session = dict(session)
+            running_session["preflight"] = running
+            return running_session
         target_workflow_id = str(session.get("target_workflow_id", "") or "").strip() or None
-        preflight = self._intake_workflows.preflight_workflow_payload(
-            customer_id=customer_id,
-            workflow_id=target_workflow_id,
-            name=str(draft.get("name", "") or ""),
-            channel=str(draft.get("channel", "instagram_dm") or "instagram_dm"),
-            provider=str(draft.get("provider", "composio") or "composio"),
-            source_config=_safe_dict(draft.get("source_config")),
-            intent_description=str(draft.get("intent_description", "") or ""),
-            required_fields=_safe_list(draft.get("required_fields")),
-            field_guidance=_safe_dict(draft.get("field_guidance")),
-            assistant_instructions=str(draft.get("assistant_instructions", "") or ""),
-            knowledge_file_ids=_safe_list(draft.get("knowledge_file_ids")),
-            sink_type=str(draft.get("sink_type", "") or ""),
-            sink_config=_safe_dict(draft.get("sink_config")),
-            schedule=str(draft.get("schedule", "*/5 * * * *") or "*/5 * * * *"),
-            notify_user=bool(draft.get("notify_user", True)),
-            enabled=bool(draft.get("enabled", True)),
-        )
-        knowledge_preflight = self._preflight_knowledge_scope(
-            customer_id=customer_id,
-            session=session,
-            draft=draft,
-        )
-        if knowledge_preflight:
-            preflight["business_knowledge_preflight"] = knowledge_preflight
-            warnings = _safe_list(preflight.get("warnings"))
-            preflight["warnings"] = [
-                *warnings,
-                *[
-                    str(item).strip()
-                    for item in _safe_list(knowledge_preflight.get("warnings"))
-                    if str(item).strip()
-                ],
+        try:
+            preflight = self._intake_workflows.preflight_workflow_payload(
+                customer_id=customer_id,
+                workflow_id=target_workflow_id,
+                name=str(draft.get("name", "") or ""),
+                channel=str(draft.get("channel", "instagram_dm") or "instagram_dm"),
+                provider=str(draft.get("provider", "composio") or "composio"),
+                source_config=_safe_dict(draft.get("source_config")),
+                intent_description=str(draft.get("intent_description", "") or ""),
+                required_fields=_safe_list(draft.get("required_fields")),
+                field_guidance=_safe_dict(draft.get("field_guidance")),
+                assistant_instructions=str(draft.get("assistant_instructions", "") or ""),
+                knowledge_file_ids=_safe_list(draft.get("knowledge_file_ids")),
+                sink_type=str(draft.get("sink_type", "") or ""),
+                sink_config=_safe_dict(draft.get("sink_config")),
+                schedule=str(draft.get("schedule", "*/5 * * * *") or "*/5 * * * *"),
+                notify_user=bool(draft.get("notify_user", True)),
+                enabled=bool(draft.get("enabled", True)),
+            )
+            knowledge_preflight = self._preflight_knowledge_scope(
+                customer_id=customer_id,
+                session=session,
+                draft=draft,
+            )
+            if knowledge_preflight:
+                preflight["business_knowledge_preflight"] = knowledge_preflight
+                warnings = _safe_list(preflight.get("warnings"))
+                preflight["warnings"] = [
+                    *warnings,
+                    *[
+                        str(item).strip()
+                        for item in _safe_list(knowledge_preflight.get("warnings"))
+                        if str(item).strip()
+                    ],
+                ]
+                if not bool(knowledge_preflight.get("ok", False)):
+                    preflight["ok"] = False
+                    preflight["status"] = "needs_clarification"
+                    questions = _safe_list(preflight.get("follow_up_questions"))
+                    questions.append(
+                        "The uploaded business knowledge could not be grounded from source files. Please provide a text, spreadsheet, PDF, DOCX, CSV, or clearer source for the workflow."
+                    )
+                    preflight["follow_up_questions"] = questions
+            commit_blockers = [
+                str(item).strip()
+                for item in [
+                    *_safe_list(preflight.get("errors")),
+                    *_safe_list(preflight.get("follow_up_questions")),
+                ]
+                if str(item).strip()
             ]
-            if not bool(knowledge_preflight.get("ok", False)):
-                preflight["ok"] = False
-                preflight["status"] = "needs_clarification"
-                questions = _safe_list(preflight.get("follow_up_questions"))
-                questions.append(
-                    "The uploaded business knowledge could not be grounded from source files. Please provide a text, spreadsheet, PDF, DOCX, CSV, or clearer source for the workflow."
+            if (
+                bool(preflight.get("ok", False))
+                and str(preflight.get("status", "") or "") == "ready"
+            ):
+                preflight["commit_blockers"] = []
+                preflight["next_action"] = (
+                    "finalize_confirmation_if_owner_confirmed_else_mark_proposed"
                 )
-                preflight["follow_up_questions"] = questions
-        commit_blockers = [
-            str(item).strip()
-            for item in [
-                *_safe_list(preflight.get("errors")),
-                *_safe_list(preflight.get("follow_up_questions")),
-            ]
-            if str(item).strip()
-        ]
-        if bool(preflight.get("ok", False)) and str(preflight.get("status", "") or "") == "ready":
-            preflight["commit_blockers"] = []
-            preflight["next_action"] = "finalize_confirmation_if_owner_confirmed_else_mark_proposed"
-        else:
-            preflight["commit_blockers"] = commit_blockers
-            preflight["next_action"] = "ask_preflight_blocker"
-        scratchpad = _deep_merge(
-            _safe_dict(session.get("scratchpad")),
-            {
-                "last_preflight": _compact_preflight_for_scratchpad(preflight),
-                "knowledge_last_index": _safe_dict(knowledge_preflight.get("index")) if knowledge_preflight else {},
-                "knowledge_last_preflight": knowledge_preflight or {},
-            },
-        )
-        update_kwargs: dict[str, Any] = {"scratchpad": scratchpad}
-        if bool(preflight.get("ok", False)) and isinstance(preflight.get("normalized_draft"), dict):
-            update_kwargs["draft_upsert"] = _safe_dict(preflight.get("normalized_draft"))
-            update_kwargs["confirmed_draft_hash"] = ""
-        updated = self._store.update_session(
-            session_id=str(session["session_id"]),
-            **update_kwargs,
-        )
-        updated["preflight"] = preflight
-        return updated
+            else:
+                preflight["commit_blockers"] = commit_blockers
+                preflight["next_action"] = "ask_preflight_blocker"
+            normalized_draft = (
+                _safe_dict(preflight.get("normalized_draft"))
+                if isinstance(preflight.get("normalized_draft"), dict)
+                else draft
+            )
+            result_draft_hash = self._draft_hash(normalized_draft)
+            preflight["draft_hash"] = result_draft_hash
+            preflight["cache_hit"] = False
+            scratchpad = _deep_merge(
+                _safe_dict(session.get("scratchpad")),
+                {
+                    "last_preflight": _compact_preflight_for_scratchpad(preflight),
+                    "last_preflight_draft_hash": result_draft_hash,
+                    "knowledge_last_index": _safe_dict(knowledge_preflight.get("index"))
+                    if knowledge_preflight
+                    else {},
+                    "knowledge_last_preflight": knowledge_preflight or {},
+                },
+            )
+            update_kwargs: dict[str, Any] = {"scratchpad": scratchpad}
+            if bool(preflight.get("ok", False)) and isinstance(
+                preflight.get("normalized_draft"), dict
+            ):
+                update_kwargs["draft_upsert"] = _safe_dict(preflight.get("normalized_draft"))
+                update_kwargs["confirmed_draft_hash"] = ""
+            updated = self._store.update_session(
+                session_id=str(session["session_id"]),
+                **update_kwargs,
+            )
+            updated["preflight"] = preflight
+            return updated
+        finally:
+            if session_id:
+                self._release_preflight_lock(session_id=session_id, draft_hash=draft_hash)
 
     def finalize_confirmation(
         self,
@@ -428,10 +545,15 @@ class WorkflowSetupService:
 
         preflight_session = self.preflight_current(customer_id=customer_id, thread_id=thread_id)
         preflight = _safe_dict(preflight_session.get("preflight"))
-        if not bool(preflight.get("ok", False)) or str(preflight.get("status", "") or "") != "ready":
-            blockers = _safe_list(preflight.get("commit_blockers")) or _safe_list(
-                preflight.get("follow_up_questions")
-            ) or _safe_list(preflight.get("errors"))
+        if (
+            not bool(preflight.get("ok", False))
+            or str(preflight.get("status", "") or "") != "ready"
+        ):
+            blockers = (
+                _safe_list(preflight.get("commit_blockers"))
+                or _safe_list(preflight.get("follow_up_questions"))
+                or _safe_list(preflight.get("errors"))
+            )
             blocker = "; ".join(str(item).strip() for item in blockers if str(item).strip())
             if not blocker:
                 blocker = "workflow draft is not ready to commit"
@@ -478,7 +600,9 @@ class WorkflowSetupService:
                 str(draft.get("name", "") or "").strip(),
                 str(draft.get("intent_description", "") or "").strip(),
                 str(draft.get("assistant_instructions", "") or "").strip(),
-                " ".join(str(item or "").strip() for item in _safe_list(draft.get("required_fields"))),
+                " ".join(
+                    str(item or "").strip() for item in _safe_list(draft.get("required_fields"))
+                ),
             ]
             if item
         )
@@ -518,7 +642,9 @@ class WorkflowSetupService:
         if not proposed_hash:
             raise ValueError("workflow draft has not been proposed yet")
         if current_hash != proposed_hash:
-            raise ValueError("workflow draft changed after proposal; propose it again before confirming")
+            raise ValueError(
+                "workflow draft changed after proposal; propose it again before confirming"
+            )
         return self._store.update_session(
             session_id=str(session["session_id"]),
             confirmed_draft_hash=current_hash,
@@ -561,7 +687,10 @@ class WorkflowSetupService:
                     **workflow_payload,
                 )
             else:
-                target_id = safe_target_workflow_id or str(target_snapshot.get("workflow_id", "") or "").strip()
+                target_id = (
+                    safe_target_workflow_id
+                    or str(target_snapshot.get("workflow_id", "") or "").strip()
+                )
                 if not target_id:
                     raise ValueError("target_workflow_id is required for edit mode")
                 created = self._intake_workflows.upsert_workflow(

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -427,7 +427,9 @@ async def _maybe_configure_support_commands_for_chat(
     try:
         setter = getattr(client, "set_my_commands", None)
         if callable(setter):
-            await setter(commands=support_bot_commands(), scope={"type": "chat", "chat_id": int(chat_id)})
+            await setter(
+                commands=support_bot_commands(), scope={"type": "chat", "chat_id": int(chat_id)}
+            )
     finally:
         if hasattr(client, "aclose"):
             with suppress(Exception):
@@ -498,7 +500,9 @@ def _format_support_customers(items: list[dict[str, Any]]) -> str:
     if not items:
         return "No customer tenants are known yet."
     lines = ["Support customers:"]
-    lines.extend(_format_support_customer_line(index, item) for index, item in enumerate(items, start=1))
+    lines.extend(
+        _format_support_customer_line(index, item) for index, item in enumerate(items, start=1)
+    )
     lines.append("")
     lines.append("Bind with /support_bind <number> or /support_bind <customer_id>.")
     return "\n".join(lines)
@@ -854,7 +858,8 @@ async def _run_interactive_session(
         direct_replies = [
             str(item.direct_reply).strip()
             for item in ready_items
-            if isinstance(item, InteractiveSubmissionResult) and str(item.direct_reply or "").strip()
+            if isinstance(item, InteractiveSubmissionResult)
+            and str(item.direct_reply or "").strip()
         ]
         for reply_text in direct_replies:
             sent = await _send_direct_telegram_reply(
@@ -900,6 +905,16 @@ async def _run_interactive_session(
                 customer_id=session.customer_id,
                 thread_id=session.thread_id,
             )
+
+            def _workflow_setup_late_reply(reply_text: str) -> None:
+                _apply_workflow_setup_after_reply(
+                    workflow_setup_after_reply=workflow_setup_after_reply,
+                    customer_id=session.customer_id,
+                    thread_id=session.thread_id,
+                    reply_text=reply_text,
+                )
+                STATE_STORE.touch_assistant_message(session.chat_id)
+
             final, suppressed = await stream_langgraph_reply_to_telegram(
                 agent_runtime=agent_runtime,
                 thread_id=session.thread_id,
@@ -909,6 +924,9 @@ async def _run_interactive_session(
                 chat_id=session.chat_id,
                 turn_mode=turn_mode,
                 interactive_session=session,
+                final_reply_callback=(
+                    _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
+                ),
             )
             if turn_mode == "workflow_setup" and final and not suppressed:
                 _apply_workflow_setup_after_reply(
@@ -1129,6 +1147,7 @@ async def handle_telegram_text(
         return thread_id, customer_id
 
     if support_allowed:
+
         def _upsert_support_session(state: dict[str, Any]) -> tuple[str, str]:
             binding = _support_binding_for_chat(state, ctx.chat_id)
             if not isinstance(binding, dict):
@@ -1249,6 +1268,16 @@ async def handle_telegram_text(
     )
     if bot_token:
         try:
+
+            def _workflow_setup_late_reply(reply_text: str) -> None:
+                _apply_workflow_setup_after_reply(
+                    workflow_setup_after_reply=workflow_setup_after_reply,
+                    customer_id=customer_id,
+                    thread_id=thread_id,
+                    reply_text=reply_text,
+                )
+                STATE_STORE.touch_assistant_message(ctx.chat_id)
+
             final, suppressed = await stream_langgraph_reply_to_telegram(
                 agent_runtime=agent_runtime,
                 thread_id=thread_id,
@@ -1257,6 +1286,9 @@ async def handle_telegram_text(
                 bot_token=bot_token,
                 chat_id=ctx.chat_id,
                 turn_mode=turn_mode,
+                final_reply_callback=(
+                    _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
+                ),
             )
             if suppressed:
                 return None

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -9,6 +9,7 @@ import time
 import zlib
 from collections.abc import Callable
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -27,6 +28,24 @@ logger = logging.getLogger(__name__)
 NO_NOTIFY_TOKEN = "__NO_NOTIFY__"
 DRAFT_INITIAL_PUBLISH_DELAY_SECONDS = 0.35
 DRAFT_PUBLISH_MIN_INTERVAL_SECONDS = 0.9
+WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS = 180.0
+WORKFLOW_SETUP_BUSY_REPLY = (
+    "I'm still working on the workflow setup. I'll send the proposal here as soon as it's ready."
+)
+WORKFLOW_SETUP_QUEUED_REPLY = (
+    "I'm still working on the workflow setup. "
+    "I got your latest note and will apply it after the current validation finishes."
+)
+
+
+@dataclass
+class _WorkflowSetupRun:
+    task: asyncio.Task[Any]
+    pending_texts: list[str]
+    delivery_task: asyncio.Task[None] | None = None
+
+
+_WORKFLOW_SETUP_RUNS: dict[str, _WorkflowSetupRun] = {}
 
 
 def _clean_thread_id(value: Any) -> str:
@@ -34,6 +53,17 @@ def _clean_thread_id(value: Any) -> str:
     if text.lower() in {"none", "null"}:
         return ""
     return text
+
+
+def _workflow_setup_run_key(*, customer_id: str, thread_id: str) -> str:
+    return f"{str(customer_id or '').strip()}:{_clean_thread_id(thread_id)}"
+
+
+def _workflow_setup_run_active(run: _WorkflowSetupRun) -> bool:
+    if not run.task.done():
+        return True
+    delivery_task = run.delivery_task
+    return delivery_task is not None and not delivery_task.done()
 
 
 def normalize_reply_text(text: str) -> str:
@@ -87,6 +117,178 @@ async def _emit_typing_until_done(
             await asyncio.wait_for(stop_event.wait(), timeout=4.0)
 
 
+async def _classify_workflow_setup_interruption(
+    *,
+    agent_runtime: Any,
+    text: str,
+    status: dict[str, Any],
+) -> dict[str, Any]:
+    classifier = getattr(agent_runtime, "classify_workflow_setup_interruption", None)
+    if not callable(classifier):
+        return {"ok": False, "kind": "setup_input", "error": "classifier_unavailable"}
+    try:
+        result = await asyncio.wait_for(
+            classifier(user_text=str(text or ""), status=status),
+            timeout=5.0,
+        )
+    except Exception as exc:
+        logger.warning(
+            "telegram.stream workflow_setup_interruption_classifier_failed error=%s",
+            f"{type(exc).__name__}: {exc}",
+        )
+        return {"ok": False, "kind": "setup_input", "error": f"{type(exc).__name__}: {exc}"}
+    if not isinstance(result, dict):
+        return {"ok": False, "kind": "setup_input", "error": "invalid_classifier_output"}
+    kind = str(result.get("kind", "") or "").strip().lower()
+    if kind not in {"status_nudge", "setup_input"}:
+        kind = "setup_input"
+    return {
+        **result,
+        "kind": kind,
+        "status_reply": str(result.get("status_reply", "") or "").strip(),
+    }
+
+
+def _start_workflow_setup_task(
+    *,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    turn_mode: str,
+) -> asyncio.Task[Any]:
+    return asyncio.create_task(
+        agent_runtime.ainvoke_text(
+            thread_id=thread_id,
+            customer_id=customer_id,
+            text=text,
+            turn_mode=turn_mode,
+        )
+    )
+
+
+async def _resolve_workflow_setup_run(
+    *,
+    run: _WorkflowSetupRun,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    turn_mode: str,
+) -> str:
+    final_text = ""
+    while True:
+        result = await run.task
+        safe = str(result or "").strip()
+        if safe:
+            final_text = safe
+        if not run.pending_texts:
+            return final_text
+        pending_text = "\n\n".join(run.pending_texts).strip()
+        run.pending_texts.clear()
+        if not pending_text:
+            continue
+        run.task = _start_workflow_setup_task(
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            text=pending_text,
+            turn_mode=turn_mode,
+        )
+
+
+async def _deliver_workflow_setup_run_when_ready(
+    *,
+    run_key: str,
+    run: _WorkflowSetupRun,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    turn_mode: str,
+    bot_token: str,
+    chat_id: int,
+    final_reply_callback: Callable[[str], Any] | None,
+) -> None:
+    try:
+        while True:
+            final_text = await _resolve_workflow_setup_run(
+                run=run,
+                agent_runtime=agent_runtime,
+                thread_id=thread_id,
+                customer_id=customer_id,
+                turn_mode=turn_mode,
+            )
+            if run.pending_texts:
+                continue
+            safe = str(final_text or "").strip()
+            if not safe or is_low_signal_reply(safe) or safe == STREAM_APPROVAL_HANDOFF_SIGNAL:
+                return
+            client = TelegramClient(bot_token)
+            try:
+                sent = await client.send_message(
+                    chat_id=chat_id,
+                    text=safe,
+                    parse_mode="HTML",
+                )
+                if sent and final_reply_callback is not None:
+                    with suppress(Exception):
+                        final_reply_callback(safe)
+                logger.info(
+                    "telegram.stream workflow_setup_background_delivered chat_id=%s thread_id=%s customer_id=%s sent=%s final_chars=%s",
+                    chat_id,
+                    thread_id,
+                    customer_id,
+                    sent,
+                    len(safe),
+                )
+            finally:
+                if hasattr(client, "aclose"):
+                    with suppress(Exception):
+                        await client.aclose()
+            if not run.pending_texts:
+                return
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception(
+            "telegram.stream workflow_setup_background_failed chat_id=%s thread_id=%s customer_id=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+        )
+    finally:
+        if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
+            _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+
+
+def _ensure_workflow_setup_delivery_task(
+    *,
+    run_key: str,
+    run: _WorkflowSetupRun,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    turn_mode: str,
+    bot_token: str,
+    chat_id: int,
+    final_reply_callback: Callable[[str], Any] | None,
+) -> None:
+    if run.delivery_task is not None and not run.delivery_task.done():
+        return
+    run.delivery_task = asyncio.create_task(
+        _deliver_workflow_setup_run_when_ready(
+            run_key=run_key,
+            run=run,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            turn_mode=turn_mode,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            final_reply_callback=final_reply_callback,
+        )
+    )
+
+
 async def stream_langgraph_reply_to_telegram(
     *,
     agent_runtime: Any,
@@ -97,6 +299,7 @@ async def stream_langgraph_reply_to_telegram(
     chat_id: int,
     turn_mode: str = "interactive",
     interactive_session: Any | None = None,
+    final_reply_callback: Callable[[str], Any] | None = None,
 ) -> tuple[str | None, bool]:
     last_streamed = ""
     final_reply = None
@@ -104,7 +307,9 @@ async def stream_langgraph_reply_to_telegram(
     live_delivery_text = ""
     live_delivery_at = 0.0
     client = TelegramClient(bot_token)
-    draft_id = zlib.crc32(f"{thread_id}:{customer_id}:{chat_id}:{new_short_id('dft')}".encode()) or 1
+    draft_id = (
+        zlib.crc32(f"{thread_id}:{customer_id}:{chat_id}:{new_short_id('dft')}".encode()) or 1
+    )
     draft_enabled = chat_id > 0
     waiting_for_segment = True
     typing_stop = asyncio.Event()
@@ -209,35 +414,121 @@ async def stream_langgraph_reply_to_telegram(
     try:
         if final_only:
             draft_enabled = False
-            try:
-                recovered = await asyncio.wait_for(
-                    agent_runtime.ainvoke_text(
+            run_key = _workflow_setup_run_key(customer_id=customer_id, thread_id=thread_id)
+            existing_run = _WORKFLOW_SETUP_RUNS.get(run_key)
+            if existing_run is not None and not _workflow_setup_run_active(existing_run):
+                _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+                existing_run = None
+            if existing_run is not None:
+                queued = False
+                status = {
+                    "state": "workflow_setup_running",
+                    "current_status": "The workflow setup/preflight/proposal run is still active.",
+                    "pending_setup_updates": len(existing_run.pending_texts),
+                    "reply_if_status_nudge": WORKFLOW_SETUP_BUSY_REPLY,
+                    "reply_if_setup_input": WORKFLOW_SETUP_QUEUED_REPLY,
+                }
+                decision = await _classify_workflow_setup_interruption(
+                    agent_runtime=agent_runtime,
+                    text=text,
+                    status=status,
+                )
+                if str(decision.get("kind", "") or "") == "status_nudge":
+                    final_reply = str(decision.get("status_reply", "") or "").strip()
+                    if not final_reply:
+                        final_reply = WORKFLOW_SETUP_BUSY_REPLY
+                else:
+                    safe_text = str(text or "").strip()
+                    if safe_text:
+                        existing_run.pending_texts.append(safe_text)
+                        queued = True
+                    final_reply = WORKFLOW_SETUP_QUEUED_REPLY
+                logger.info(
+                    "telegram.stream workflow_setup_existing_run chat_id=%s thread_id=%s customer_id=%s kind=%s queued=%s pending_count=%s",
+                    chat_id,
+                    thread_id,
+                    customer_id,
+                    str(decision.get("kind", "") or ""),
+                    queued,
+                    len(existing_run.pending_texts),
+                )
+            else:
+                run = _WorkflowSetupRun(
+                    task=_start_workflow_setup_task(
+                        agent_runtime=agent_runtime,
                         thread_id=thread_id,
                         customer_id=customer_id,
                         text=text,
                         turn_mode=turn_mode,
                     ),
-                    timeout=180.0,
+                    pending_texts=[],
                 )
-            except TimeoutError:
-                logger.error(
-                    "telegram.stream final_only_timeout chat_id=%s thread_id=%s customer_id=%s turn_mode=%s",
-                    chat_id,
-                    thread_id,
-                    customer_id,
-                    turn_mode,
-                )
-                final_reply = (
-                    "Still working, but the model response timed out. "
-                    "Please retry in a moment."
-                )
-            else:
-                safe = str(recovered or "").strip()
-                if safe == STREAM_APPROVAL_HANDOFF_SIGNAL:
-                    suppressed = True
-                    final_reply = None
-                elif safe and not is_low_signal_reply(safe):
-                    final_reply = safe
+                _WORKFLOW_SETUP_RUNS[run_key] = run
+                try:
+                    recovered = await asyncio.wait_for(
+                        asyncio.shield(run.task),
+                        timeout=WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "telegram.stream workflow_setup_backgrounded chat_id=%s thread_id=%s customer_id=%s turn_mode=%s",
+                        chat_id,
+                        thread_id,
+                        customer_id,
+                        turn_mode,
+                    )
+                    _ensure_workflow_setup_delivery_task(
+                        run_key=run_key,
+                        run=run,
+                        agent_runtime=agent_runtime,
+                        thread_id=thread_id,
+                        customer_id=customer_id,
+                        turn_mode=turn_mode,
+                        bot_token=bot_token,
+                        chat_id=chat_id,
+                        final_reply_callback=final_reply_callback,
+                    )
+                    final_reply = WORKFLOW_SETUP_BUSY_REPLY
+                except asyncio.CancelledError:
+                    _ensure_workflow_setup_delivery_task(
+                        run_key=run_key,
+                        run=run,
+                        agent_runtime=agent_runtime,
+                        thread_id=thread_id,
+                        customer_id=customer_id,
+                        turn_mode=turn_mode,
+                        bot_token=bot_token,
+                        chat_id=chat_id,
+                        final_reply_callback=final_reply_callback,
+                    )
+                    raise
+                except Exception:
+                    if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
+                        _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+                    raise
+                else:
+                    if run.pending_texts:
+                        _ensure_workflow_setup_delivery_task(
+                            run_key=run_key,
+                            run=run,
+                            agent_runtime=agent_runtime,
+                            thread_id=thread_id,
+                            customer_id=customer_id,
+                            turn_mode=turn_mode,
+                            bot_token=bot_token,
+                            chat_id=chat_id,
+                            final_reply_callback=final_reply_callback,
+                        )
+                        final_reply = WORKFLOW_SETUP_QUEUED_REPLY
+                    else:
+                        if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
+                            _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+                        safe = str(recovered or "").strip()
+                        if safe == STREAM_APPROVAL_HANDOFF_SIGNAL:
+                            suppressed = True
+                            final_reply = None
+                        elif safe and not is_low_signal_reply(safe):
+                            final_reply = safe
         else:
             stream = agent_runtime.astream_text(
                 thread_id=thread_id,
@@ -302,8 +593,7 @@ async def stream_langgraph_reply_to_telegram(
                         final_reply = recovered_text
                         break
                     timeout_text = (
-                        "Still working, but the model response timed out. "
-                        "Please retry in a moment."
+                        "Still working, but the model response timed out. Please retry in a moment."
                     )
                     logger.error(
                         "telegram.stream timeout_fail chat_id=%s thread_id=%s customer_id=%s stage=%s",
@@ -481,7 +771,9 @@ async def relay_event_via_main_agent(
                 parsed = datetime.fromisoformat(last_assistant_at.replace("Z", "+00:00"))
                 if parsed.tzinfo is None:
                     parsed = parsed.replace(tzinfo=UTC)
-                assistant_idle_hours = f"{max(0.0, (now_utc - parsed).total_seconds() / 3600.0):.2f}"
+                assistant_idle_hours = (
+                    f"{max(0.0, (now_utc - parsed).total_seconds() / 3600.0):.2f}"
+                )
 
         if (
             str(event_label).startswith("routine/")

--- a/tests/test_config_api_key_alias.py
+++ b/tests/test_config_api_key_alias.py
@@ -71,6 +71,7 @@ def test_settings_default_agent_models_use_glm(monkeypatch, tmp_path: Path) -> N
 
     assert settings.llm_model == "z-ai/glm-5.1"
     assert settings.wake_execution_model == "z-ai/glm-5.1"
+    assert settings.workflow_setup_input_classifier_model == "z-ai/glm-5.1"
     assert settings.business_knowledge_oracle_model == "google/gemini-3.1-flash-lite-preview"
 
 
@@ -120,9 +121,7 @@ def test_dotenv_overrides_yaml_runtime_defaults(monkeypatch, tmp_path: Path) -> 
     assert settings.llm_model == "from-dotenv"
 
 
-def test_settings_discovers_yaml_by_walking_parent_directories(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_settings_discovers_yaml_by_walking_parent_directories(monkeypatch, tmp_path: Path) -> None:
     config_file = tmp_path / "opentulpa.config.yaml"
     config_file.write_text("llm_model: from-parent\n", encoding="utf-8")
     nested_dir = tmp_path / "nested" / "deeper"

--- a/tests/test_telegram_stream_segments.py
+++ b/tests/test_telegram_stream_segments.py
@@ -47,6 +47,58 @@ class _FinalOnlyWorkflowSetupRuntime:
         return "Draft updated. Please confirm this workflow before I save it."
 
 
+class _SlowWorkflowSetupRuntime:
+    def __init__(self) -> None:
+        self.ainvoke_calls: list[dict[str, object]] = []
+        self.classifier_calls: list[dict[str, object]] = []
+        self.release = asyncio.Event()
+
+    async def astream_text(self, **kwargs):
+        yield "This should not stream in workflow setup mode."
+
+    async def ainvoke_text(self, **kwargs):
+        self.ainvoke_calls.append(kwargs)
+        await self.release.wait()
+        return "Workflow proposal: ready. Please confirm to activate it."
+
+    async def classify_workflow_setup_interruption(self, **kwargs):
+        self.classifier_calls.append(kwargs)
+        return {
+            "ok": True,
+            "kind": "status_nudge",
+            "confidence": 0.99,
+            "status_reply": str(kwargs["status"]["reply_if_status_nudge"]),
+            "reason": "User asked for progress only.",
+        }
+
+
+class _QueuedWorkflowSetupRuntime:
+    def __init__(self) -> None:
+        self.ainvoke_calls: list[dict[str, object]] = []
+        self.classifier_calls: list[dict[str, object]] = []
+        self.release_first = asyncio.Event()
+
+    async def astream_text(self, **kwargs):
+        yield "This should not stream in workflow setup mode."
+
+    async def ainvoke_text(self, **kwargs):
+        self.ainvoke_calls.append(kwargs)
+        if len(self.ainvoke_calls) == 1:
+            await self.release_first.wait()
+            return "Old workflow proposal: please confirm to activate it."
+        return "Updated workflow proposal: includes the new fields. Please confirm to activate it."
+
+    async def classify_workflow_setup_interruption(self, **kwargs):
+        self.classifier_calls.append(kwargs)
+        return {
+            "ok": True,
+            "kind": "setup_input",
+            "confidence": 0.98,
+            "status_reply": "",
+            "reason": "Message contains workflow fields.",
+        }
+
+
 class _UpdatingProgressRuntime:
     async def astream_text(self, **kwargs):
         yield f"{STREAM_PROGRESS_PREFIX}Searching the web…"
@@ -158,6 +210,28 @@ class _FakeTelegramClient:
         return True
 
 
+async def _cancel_workflow_setup_runs() -> None:
+    runs = list(relay_module._WORKFLOW_SETUP_RUNS.values())
+    relay_module._WORKFLOW_SETUP_RUNS.clear()
+    tasks: list[asyncio.Task] = []
+    for run in runs:
+        tasks.append(run.task)
+        if run.delivery_task is not None:
+            tasks.append(run.delivery_task)
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _wait_for_message(fake_client: _FakeTelegramClient, needle: str) -> None:
+    for _ in range(100):
+        if any(needle in text for _, text, _ in fake_client.message_calls):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"message containing {needle!r} was not sent")
+
+
 @pytest.mark.asyncio
 async def test_stream_uses_drafts_for_live_partials_without_separate_final_send(
     monkeypatch: pytest.MonkeyPatch,
@@ -178,7 +252,9 @@ async def test_stream_uses_drafts_for_live_partials_without_separate_final_send(
     assert "priority emails" in str(final or "").lower()
     assert fake_client.draft_calls
     assert len({draft_id for _, draft_id, _, _, _ in fake_client.draft_calls}) == 1
-    assert fake_client.message_calls == [(1, "I checked your inbox. 3 priority emails found.", "HTML")]
+    assert fake_client.message_calls == [
+        (1, "I checked your inbox. 3 priority emails found.", "HTML")
+    ]
     assert fake_client.chat_actions
     assert not fake_client.deleted_messages
 
@@ -202,7 +278,9 @@ async def test_wait_signal_does_not_emit_visible_progress_message(
     assert suppressed is False
     assert "priority emails" in str(final or "").lower()
     assert not any("working on it" in text.lower() for _, _, text, _, _ in fake_client.draft_calls)
-    assert fake_client.message_calls == [(1, "I checked the inbox. 3 priority emails found.", "HTML")]
+    assert fake_client.message_calls == [
+        (1, "I checked the inbox. 3 priority emails found.", "HTML")
+    ]
 
 
 @pytest.mark.asyncio
@@ -234,6 +312,114 @@ async def test_workflow_setup_turn_uses_final_reply_without_draft_streaming(
 
 
 @pytest.mark.asyncio
+async def test_slow_workflow_setup_turn_backgrounds_and_status_nudges_do_not_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _cancel_workflow_setup_runs()
+    fake_client = _FakeTelegramClient("dummy", draft_ok=False)
+    runtime = _SlowWorkflowSetupRuntime()
+    delivered_replies: list[str] = []
+    monkeypatch.setattr(relay_module, "TelegramClient", lambda token: fake_client)
+    monkeypatch.setattr(relay_module, "WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS", 0.01)
+
+    try:
+        final, suppressed = await relay_module.stream_langgraph_reply_to_telegram(
+            agent_runtime=runtime,
+            thread_id="chat-setup-slow",
+            customer_id="telegram_setup_slow",
+            text="build workflow",
+            bot_token="dummy",
+            chat_id=1,
+            turn_mode="workflow_setup",
+            final_reply_callback=delivered_replies.append,
+        )
+        follow_up, follow_up_suppressed = await relay_module.stream_langgraph_reply_to_telegram(
+            agent_runtime=runtime,
+            thread_id="chat-setup-slow",
+            customer_id="telegram_setup_slow",
+            text="so what's up?",
+            bot_token="dummy",
+            chat_id=1,
+            turn_mode="workflow_setup",
+        )
+
+        assert suppressed is False
+        assert follow_up_suppressed is False
+        assert final == relay_module.WORKFLOW_SETUP_BUSY_REPLY
+        assert follow_up == relay_module.WORKFLOW_SETUP_BUSY_REPLY
+        assert len(runtime.ainvoke_calls) == 1
+        assert len(runtime.classifier_calls) == 1
+        assert runtime.classifier_calls[0]["status"]["state"] == "workflow_setup_running"
+        assert runtime.classifier_calls[0]["user_text"] == "so what's up?"
+
+        runtime.release.set()
+        await _wait_for_message(fake_client, "Workflow proposal: ready.")
+
+        assert len(runtime.ainvoke_calls) == 1
+        assert fake_client.message_calls[-1] == (
+            1,
+            "Workflow proposal: ready. Please confirm to activate it.",
+            "HTML",
+        )
+        assert delivered_replies == ["Workflow proposal: ready. Please confirm to activate it."]
+    finally:
+        await _cancel_workflow_setup_runs()
+
+
+@pytest.mark.asyncio
+async def test_slow_workflow_setup_turn_applies_substantive_follow_up_before_final(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _cancel_workflow_setup_runs()
+    fake_client = _FakeTelegramClient("dummy", draft_ok=False)
+    runtime = _QueuedWorkflowSetupRuntime()
+    delivered_replies: list[str] = []
+    monkeypatch.setattr(relay_module, "TelegramClient", lambda token: fake_client)
+    monkeypatch.setattr(relay_module, "WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS", 0.01)
+
+    try:
+        final, suppressed = await relay_module.stream_langgraph_reply_to_telegram(
+            agent_runtime=runtime,
+            thread_id="chat-setup-queued",
+            customer_id="telegram_setup_queued",
+            text="build workflow",
+            bot_token="dummy",
+            chat_id=1,
+            turn_mode="workflow_setup",
+            final_reply_callback=delivered_replies.append,
+        )
+        queued, queued_suppressed = await relay_module.stream_langgraph_reply_to_telegram(
+            agent_runtime=runtime,
+            thread_id="chat-setup-queued",
+            customer_id="telegram_setup_queued",
+            text="Required fields: client, phone, service, day, time.",
+            bot_token="dummy",
+            chat_id=1,
+            turn_mode="workflow_setup",
+        )
+
+        assert suppressed is False
+        assert queued_suppressed is False
+        assert final == relay_module.WORKFLOW_SETUP_BUSY_REPLY
+        assert queued == relay_module.WORKFLOW_SETUP_QUEUED_REPLY
+        assert len(runtime.ainvoke_calls) == 1
+        assert len(runtime.classifier_calls) == 1
+        assert runtime.classifier_calls[0]["status"]["state"] == "workflow_setup_running"
+
+        runtime.release_first.set()
+        await _wait_for_message(fake_client, "Updated workflow proposal:")
+
+        assert len(runtime.ainvoke_calls) == 2
+        assert "Required fields: client" in str(runtime.ainvoke_calls[1]["text"])
+        assert not any("Old workflow proposal" in text for _, text, _ in fake_client.message_calls)
+        assert delivered_replies == [
+            "Updated workflow proposal: includes the new fields. Please confirm to activate it."
+        ]
+    finally:
+        await _cancel_workflow_setup_runs()
+
+
+@pytest.mark.asyncio
 async def test_progress_signals_stay_in_typing_only_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -251,8 +437,12 @@ async def test_progress_signals_stay_in_typing_only_path(
 
     assert suppressed is False
     assert final == "Here is the result."
-    assert not any("searching the web" in text.lower() for _, _, text, _, _ in fake_client.draft_calls)
-    assert not any("fetching a webpage" in text.lower() for _, _, text, _, _ in fake_client.draft_calls)
+    assert not any(
+        "searching the web" in text.lower() for _, _, text, _, _ in fake_client.draft_calls
+    )
+    assert not any(
+        "fetching a webpage" in text.lower() for _, _, text, _, _ in fake_client.draft_calls
+    )
     assert fake_client.message_calls == [(1, "Here is the result.", "HTML")]
 
 

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -321,7 +321,9 @@ def test_workflow_setup_update_clears_schedule_for_telegram_channel(tmp_path: Pa
     assert session["draft_upsert"]["schedule"] == ""
 
 
-def test_workflow_setup_update_replaces_field_guidance_and_sink_field_mapping(tmp_path: Path) -> None:
+def test_workflow_setup_update_replaces_field_guidance_and_sink_field_mapping(
+    tmp_path: Path,
+) -> None:
     setup, _, _ = _mk_setup_service(tmp_path)
     setup.begin_session(customer_id="telegram_123", thread_id="thread_123", mode="create")
     setup.update_session(
@@ -414,9 +416,7 @@ def test_workflow_setup_update_normalizes_local_csv_filename_alias(tmp_path: Pat
         },
     )
 
-    assert session["draft_upsert"]["sink_config"] == {
-        "file_path": "tulpa_stuff/bookings.csv"
-    }
+    assert session["draft_upsert"]["sink_config"] == {"file_path": "tulpa_stuff/bookings.csv"}
 
 
 def test_workflow_setup_preflight_normalizes_single_google_sheet_tab_and_dry_runs(
@@ -465,17 +465,72 @@ def test_workflow_setup_preflight_normalizes_single_google_sheet_tab_and_dry_run
     assert all(call["method"] != "execute_tool" for call in composio.calls)
 
 
+def test_workflow_setup_preflight_reuses_ready_result_for_unchanged_draft(
+    tmp_path: Path,
+) -> None:
+    composio = _SheetsComposio()
+    setup, _, _ = _mk_setup_service(tmp_path, composio=composio)
+    setup.begin_session(customer_id="telegram_123", thread_id="thread_123", mode="create")
+    setup.update_session(
+        customer_id="telegram_123",
+        thread_id="thread_123",
+        draft_patch={
+            "name": "AutoSpa Telegram Intake",
+            "intent_description": "Записывать клиентов на мойку.",
+            "required_fields": ["тип услуги", "телефон клиента"],
+            "sink_type": "google_sheets_composio",
+            "sink_config": {
+                "toolkit": "googlesheets",
+                "field_mapping": {
+                    "тип услуги": "тип услуги",
+                    "телефон клиента": "телефон клиента",
+                },
+                "static_arguments": {"spreadsheet_id": "sheet_123"},
+            },
+        },
+    )
+
+    first = setup.preflight_current(customer_id="telegram_123", thread_id="thread_123")
+    first_call_count = len(composio.calls)
+    second = setup.preflight_current(customer_id="telegram_123", thread_id="thread_123")
+
+    assert first["preflight"]["status"] == "ready"
+    assert second["preflight"]["status"] == "ready"
+    assert second["preflight"]["cache_hit"] is True
+    assert len(composio.calls) == first_call_count
+
+    setup.update_session(
+        customer_id="telegram_123",
+        thread_id="thread_123",
+        draft_patch={"assistant_instructions": "Offer ceramic coating if the user asks."},
+    )
+    third = setup.preflight_current(customer_id="telegram_123", thread_id="thread_123")
+
+    assert third["preflight"]["status"] == "ready"
+    assert third["preflight"]["cache_hit"] is False
+    assert len(composio.calls) > first_call_count
+
+
 def test_workflow_setup_orchestrator_reports_active_and_paused_states(tmp_path: Path) -> None:
     setup, _, _ = _mk_setup_service(tmp_path)
     orchestrator = WorkflowSetupOrchestrator(setup_service=setup)
 
-    assert orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"] == "none"
+    assert (
+        orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"]
+        == "none"
+    )
 
     setup.begin_session(customer_id="telegram_123", thread_id="thread_123", mode="create")
-    assert orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"] == "active"
+    assert (
+        orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"]
+        == "active"
+    )
 
     setup.pause(customer_id="telegram_123", thread_id="thread_123")
-    assert orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"] == "paused"
+    assert (
+        orchestrator.thread_status(customer_id="telegram_123", thread_id="thread_123")["status"]
+        == "paused"
+    )
 
 
 def test_workflow_setup_orchestrator_marks_confirmable_proposal_reply(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes workflow setup durable enough for long preflight/proposal turns:

- Keeps slow workflow setup runs alive after Telegram returns a quick status reply.
- Sends the final proposal back to the chat when the background run completes.
- Avoids duplicate expensive preflight work by caching ready preflight state by draft hash.
- Prevents repeated impatient messages from starting new setup/preflight loops.
- Uses a small `z-ai/glm-5.1` classifier to distinguish status nudges from real workflow edits while setup is already running.
- Queues real setup edits and applies them after the current validation finishes.

## Behavior

If the user sends “what’s up?” during setup, they get a status update and no duplicate run starts.

If the user sends a real edit like required fields, sink/table details, or business rules, that message is queued and processed before the final proposal is delivered.

If the draft is unchanged and preflight is already ready, setup reuses the stored preflight instead of re-running Composio/knowledge validation.

## Verification

```bash
uv run ruff check src/opentulpa/agent/runtime.py src/opentulpa/core/config.py src/opentulpa/__main__.py src/opentulpa/intake/workflow_setup_service.py src/opentulpa/interfaces/telegram/chat_service.py src/opentulpa/interfaces/telegram/relay.py tests/test_telegram_stream_segments.py tests/test_workflow_setup_service.py tests/test_config_api_key_alias.py

uv run ruff format --check src/opentulpa/agent/runtime.py src/opentulpa/core/config.py src/opentulpa/__main__.py src/opentulpa/intake/workflow_setup_service.py src/opentulpa/interfaces/telegram/chat_service.py src/opentulpa/interfaces/telegram/relay.py tests/test_telegram_stream_segments.py tests/test_workflow_setup_service.py tests/test_config_api_key_alias.py

uv run pytest tests/test_runtime_reasoning_effort.py tests/test_runtime_structured_model.py tests/test_llm_call_tracing.py tests/test_workflow_setup_service.py tests/test_telegram_workflow_setup_mode.py tests/test_telegram_stream_segments.py tests/test_config_api_key_alias.py -q
```

Result: `75 passed`