### PR TITLE
OPE-24 Make routine wake delivery durable

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -371,6 +371,13 @@ def _validate_model_tool_call(
                 "(example: use `python3 tg_login.py`, not `python3 tulpa_stuff/tg_login.py`)."
             )
 
+    if call_name == "send_owner_update" and _normalize_turn_mode(turn_mode) == "routine_wake":
+        return (
+            "TOOL_VALIDATION_ERROR: send_owner_update is only for live owner/support turns. "
+            "For routine_wake, put the user-visible routine notification or blocker summary "
+            "in the final assistant response so the wake orchestrator can deliver it."
+        )
+
     if call_name in {"tulpa_read_file", "tulpa_write_file", "tulpa_validate_file", "tulpa_file_send"}:
         path_arg = str(args.get("path", "")).strip()
         duplicate_prefix = _has_duplicate_allowed_root_prefix(path_arg)
@@ -1324,10 +1331,9 @@ def build_runtime_graph(runtime: Any):
             update["active_invoked_skill_context"] = invoked_skill_context
             update["active_invoked_skill_names"] = invoked_skill_names
             update["active_skill_context"] = invoked_skill_context
-        goto: Literal["validate_tools", "claim_check"] = (
-            "validate_tools"
-            if isinstance(response, AIMessage) and bool(getattr(response, "tool_calls", []))
-            else "claim_check"
+        has_tool_calls = isinstance(response, AIMessage) and bool(getattr(response, "tool_calls", []))
+        goto: Literal["validate_tools", "claim_check", "finalize_turn"] = (
+            "validate_tools" if has_tool_calls else ("finalize_turn" if turn_mode == "routine_wake" else "claim_check")
         )
         if (
             turn_mode == "workflow_setup"

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1584,6 +1584,17 @@ class OpenTulpaLangGraphRuntime:
             return self._wake_execution_model_with_tools
         return self._model_with_tools
 
+    def tools_for_turn_mode(self, turn_mode: str) -> list[Any]:
+        normalized_turn_mode = str(turn_mode or "").strip().lower()
+        blocked_tools: set[str] = set()
+        if normalized_turn_mode == "routine_wake":
+            blocked_tools.add("send_owner_update")
+        return [
+            tool
+            for name, tool in self._tools.items()
+            if str(name or "").strip() not in blocked_tools
+        ]
+
     def prepare_messages_for_prompt_cache(
         self,
         messages: list[Any],
@@ -2172,6 +2183,11 @@ class OpenTulpaLangGraphRuntime:
                 "status",
                 "action_name",
                 "execution_ok",
+                "execution_status",
+                "execution_summary",
+                "execution_error",
+                "notification_status",
+                "notification_error",
                 "retryable",
                 "event_label",
                 "routine_id",
@@ -3162,13 +3178,10 @@ class OpenTulpaLangGraphRuntime:
             if asyncio.iscoroutine(maybe_coro):
                 await maybe_coro
         self._register_tools()
-        self._model_with_tools = self._model.bind_tools(list(self._tools.values()))
-        if self._wake_execution_model is self._model:
-            self._wake_execution_model_with_tools = self._model_with_tools
-        else:
-            self._wake_execution_model_with_tools = self._wake_execution_model.bind_tools(
-                list(self._tools.values())
-            )
+        self._model_with_tools = self._model.bind_tools(self.tools_for_turn_mode("interactive"))
+        self._wake_execution_model_with_tools = self._wake_execution_model.bind_tools(
+            self.tools_for_turn_mode("routine_wake")
+        )
         self._graph = self._build_graph()
         manager = self.get_browser_use_local_manager()
         with suppress(Exception):

--- a/src/opentulpa/agent/turn_policy.py
+++ b/src/opentulpa/agent/turn_policy.py
@@ -59,6 +59,7 @@ def build_turn_mode_system_message(turn_mode: str | None) -> SystemMessage:
                 "This is a scheduled routine execution, not an interactive user turn.\n"
                 "Execute autonomously using tools and skills as needed.\n"
                 "Do not stop to ask clarifying questions unless the instruction is materially blocked or missing a required dependency.\n"
+                "Return the user-visible routine notification or blocker summary as the final answer.\n"
                 "Focus on doing the work, then return a concise outcome summary."
             )
         )

--- a/src/opentulpa/application/wake_orchestrator.py
+++ b/src/opentulpa/application/wake_orchestrator.py
@@ -41,6 +41,36 @@ class WakeOrchestrator:
             payload=payload,
         )
 
+    def _record_routine_execution(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        notification_status: str,
+        notification_error: str = "",
+        notified_chat_ids: list[int] | None = None,
+    ) -> None:
+        event_payload: dict[str, Any] = {
+            "routine_id": str(payload.get("routine_id", "") or "").strip(),
+            "routine_name": str(payload.get("routine_name", "") or "").strip(),
+            "execution_status": str(payload.get("execution_status", "") or "").strip(),
+            "execution_summary": str(payload.get("execution_summary", "") or "").strip()[:1200],
+            "execution_error": str(payload.get("execution_error", "") or "").strip()[:500],
+            "notify_user": bool(payload.get("notify_user", False)),
+            "notification_status": str(notification_status or "").strip(),
+            "notification_error": str(notification_error or "").strip()[:500],
+        }
+        if notified_chat_ids:
+            event_payload["notified_chat_ids"] = [int(chat_id) for chat_id in notified_chat_ids[:5]]
+        with suppress(Exception):
+            self._backlog(
+                customer_id=customer_id,
+                source="routine",
+                event_type=event_type,
+                payload={key: value for key, value in event_payload.items() if value not in ("", None)},
+            )
+
     @staticmethod
     def _compact_payload_summary(payload: dict[str, Any]) -> str:
         if not isinstance(payload, dict) or not payload:
@@ -268,11 +298,18 @@ class WakeOrchestrator:
                     or "workflow execution failed"
                 )
             if not notify_user or not self._settings.telegram_bot_token or execution_summary == NO_NOTIFY_TOKEN:
-                self._backlog(
+                self._record_routine_execution(
                     customer_id=customer_id,
-                    source="routine",
                     event_type=event_type,
                     payload=queue_payload,
+                    notification_status="skipped",
+                    notification_error=(
+                        "notify_user=false"
+                        if not notify_user
+                        else "telegram_bot_token_missing"
+                        if not self._settings.telegram_bot_token
+                        else "no_notify_token"
+                    ),
                 )
                 return
             slots: list[dict[str, Any]] = []
@@ -281,13 +318,15 @@ class WakeOrchestrator:
             owner_slots = [slot for slot in slots if str(slot.get("role", "")).strip() != "support"]
             slots = owner_slots or slots[:1]
             if not slots:
-                self._backlog(
+                self._record_routine_execution(
                     customer_id=customer_id,
-                    source="routine",
                     event_type=event_type,
                     payload=queue_payload,
+                    notification_status="backlogged",
+                    notification_error="no_telegram_session_slots",
                 )
                 return
+            notified_chat_ids: list[int] = []
             for slot in slots:
                 chat_id = int(slot["chat_id"])
                 await self._get_telegram_client().send_message(
@@ -298,6 +337,14 @@ class WakeOrchestrator:
                 with suppress(Exception):
                     self._get_telegram_chat().touch_assistant_message(chat_id)
                 await self._flush_deferred_challenges(chat_id=chat_id)
+                notified_chat_ids.append(chat_id)
+            self._record_routine_execution(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=queue_payload,
+                notification_status="sent",
+                notified_chat_ids=notified_chat_ids,
+            )
             return
 
         routine_instruction = str(payload.get("instruction", "")).strip()
@@ -354,19 +401,23 @@ class WakeOrchestrator:
         queue_payload["execution_summary"] = execution_summary[:2000]
 
         if not notify_user:
-            self._backlog(
+            self._record_routine_execution(
                 customer_id=customer_id,
-                source="routine",
                 event_type=event_type,
                 payload=queue_payload,
+                notification_status="skipped",
+                notification_error="notify_user=false",
             )
             return
         if not self._settings.telegram_bot_token or execution_summary == NO_NOTIFY_TOKEN:
-            self._backlog(
+            self._record_routine_execution(
                 customer_id=customer_id,
-                source="routine",
                 event_type=event_type,
                 payload=queue_payload,
+                notification_status="skipped",
+                notification_error=(
+                    "telegram_bot_token_missing" if not self._settings.telegram_bot_token else "no_notify_token"
+                ),
             )
             return
 
@@ -374,14 +425,16 @@ class WakeOrchestrator:
         with suppress(Exception):
             slots = self._get_telegram_chat().find_session_slots(customer_id)
         if not slots:
-            self._backlog(
+            self._record_routine_execution(
                 customer_id=customer_id,
-                source="routine",
                 event_type=event_type,
                 payload=queue_payload,
+                notification_status="backlogged",
+                notification_error="no_telegram_session_slots",
             )
             return
 
+        notified_chat_ids: list[int] = []
         for slot in slots:
             chat_id = int(slot["chat_id"])
             await self._get_telegram_client().send_message(
@@ -392,6 +445,14 @@ class WakeOrchestrator:
             with suppress(Exception):
                 self._get_telegram_chat().touch_assistant_message(chat_id)
             await self._flush_deferred_challenges(chat_id=chat_id)
+            notified_chat_ids.append(chat_id)
+        self._record_routine_execution(
+            customer_id=customer_id,
+            event_type=event_type,
+            payload=queue_payload,
+            notification_status="sent",
+            notified_chat_ids=notified_chat_ids,
+        )
 
 
 def _safe_error_list(value: Any) -> list[str]:

--- a/tests/test_prompt_policy_hardening.py
+++ b/tests/test_prompt_policy_hardening.py
@@ -117,6 +117,7 @@ def test_turn_mode_policy_messages_are_mode_specific() -> None:
     assert "Do not persist the workflow until the user has seen a proposal and explicitly confirmed it." in workflow_setup
     assert "scheduled routine execution" in routine_wake
     assert "execute autonomously using tools and skills as needed" in routine_wake.lower()
+    assert "Return the user-visible routine notification" in routine_wake
     assert "previously approved action" in approval_recovery
     assert "continuation of the approved execution" in approval_recovery
     assert "background event/status notification" in event_notification
@@ -495,6 +496,20 @@ def test_validate_model_tool_call_allows_routine_create_during_routine_wake() ->
         forbidden_tool_args={"routine_create": {"customer_id", "message"}},
     )
     assert err is None
+
+
+def test_validate_model_tool_call_rejects_owner_update_during_routine_wake() -> None:
+    err = _validate_model_tool_call(
+        call_name="send_owner_update",
+        args={"message": "Still working."},
+        latest_user_text="System update: a scheduled routine fired.",
+        turn_mode="routine_wake",
+        required_args={"send_owner_update": ("message",)},
+        forbidden_tool_args={},
+    )
+    assert err is not None
+    assert "send_owner_update is only for live owner/support turns" in err
+    assert "routine_wake" in err
 
 
 def test_validate_model_tool_call_rejects_routine_create_during_event_notification() -> None:

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -285,6 +285,54 @@ async def test_graph_claim_check_repairs_false_success_claim() -> None:
 
 
 @pytest.mark.asyncio
+async def test_graph_routine_wake_skips_claim_check() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    behavior_events: list[str] = []
+    call_count = 0
+
+    async def _ainvoke_model(
+        model: Any,
+        messages: list[Any],
+        *,
+        stable_prefix_count: int = 0,
+        **kwargs: Any,
+    ) -> AIMessage:
+        del model, messages, stable_prefix_count, kwargs
+        nonlocal call_count
+        call_count += 1
+        return AIMessage(content="Routine complete. 3 stories sent.")
+
+    async def _verify_completion_claim(**kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        raise AssertionError("routine_wake should not invoke claim-check")
+
+    _install_minimal_graph_runtime_stubs(
+        runtime,
+        ainvoke_model=_ainvoke_model,
+        verify_completion_claim=_verify_completion_claim,
+        behavior_events=behavior_events,
+    )
+    graph = build_runtime_graph(runtime)
+    result = await graph.ainvoke(
+        {
+            "messages": [HumanMessage(content="System update: a scheduled routine fired.")],
+            "customer_id": "telegram_test",
+            "thread_id": "routine_rtn_test_wake_123",
+            "turn_mode": "routine_wake",
+            "turn_status": "running",
+            "final_response_text": "",
+            "pending_context_summary": "",
+            "agent_trace_id": "turn_routine_skip_claim",
+        },
+        config={"configurable": {"thread_id": "routine_rtn_test_wake_123"}, "recursion_limit": 8},
+    )
+
+    assert call_count == 1
+    assert result["final_response_text"] == "Routine complete. 3 stories sent."
+    assert "graph.claim_check.start" not in behavior_events
+
+
+@pytest.mark.asyncio
 async def test_graph_claim_check_repairs_empty_output() -> None:
     runtime = object.__new__(OpenTulpaLangGraphRuntime)
     call_count = 0
@@ -320,6 +368,30 @@ async def test_graph_claim_check_repairs_empty_output() -> None:
     )
     assert call_count == 2
     assert result["final_response_text"] == "Here is the answer."
+
+
+def test_pending_context_surfaces_routine_execution_summary() -> None:
+    text = OpenTulpaLangGraphRuntime._format_pending_context(
+        [
+            {
+                "source": "routine",
+                "event_type": "scheduled",
+                "payload": {
+                    "routine_id": "rtn_mtsb77",
+                    "routine_name": "daily-ai-oss-briefing",
+                    "execution_status": "executed",
+                    "execution_summary": "Briefing sent with three fresh stories.",
+                    "notification_status": "sent",
+                },
+            }
+        ]
+    )
+
+    assert "[routine/scheduled]" in text
+    assert "routine_id=rtn_mtsb77" in text
+    assert "execution_status=executed" in text
+    assert "Briefing sent with three fresh stories" in text
+    assert "notification_status=sent" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_structured_model.py
+++ b/tests/test_runtime_structured_model.py
@@ -55,6 +55,19 @@ class _BrokenStructuredThenFallbackModel(_FallbackModel):
         raise RuntimeError("structured_unavailable")
 
 
+def test_tools_for_routine_wake_excludes_interactive_owner_update_tool() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    send_owner_update = object()
+    tulpa_read_file = object()
+    runtime._tools = {
+        "send_owner_update": send_owner_update,
+        "tulpa_read_file": tulpa_read_file,
+    }
+
+    assert runtime.tools_for_turn_mode("interactive") == [send_owner_update, tulpa_read_file]
+    assert runtime.tools_for_turn_mode("routine_wake") == [tulpa_read_file]
+
+
 class _ProviderAwareStructuredRunner:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []

--- a/tests/test_wake_orchestrator.py
+++ b/tests/test_wake_orchestrator.py
@@ -175,6 +175,12 @@ async def test_routine_event_flushes_deferred_approval_challenges() -> None:
     assert client.sent
     assert runtime.calls
     assert runtime.calls[0]["turn_mode"] == "routine_wake"
+    assert context_events.events
+    payload = context_events.events[-1]["payload"]
+    assert payload["routine_id"] == "rtn_123"
+    assert payload["execution_status"] == "executed"
+    assert payload["execution_summary"] == "routine done"
+    assert payload["notification_status"] == "sent"
 
 
 @pytest.mark.asyncio
@@ -219,6 +225,7 @@ async def test_routine_event_silent_mode_still_executes_and_backlogs() -> None:
     assert queued["event_type"] == "scheduled"
     payload = queued["payload"]
     assert payload["execution_status"] == "executed"
+    assert payload["notification_status"] == "skipped"
     assert "updated timelog" in payload["execution_summary"]
 
 


### PR DESCRIPTION
Linear: OPE-24

## Summary
- remove interactive `send_owner_update` from routine-wake tool binding and block it in model tool validation as a backstop
- bypass claim-check for background routine final text so the wake orchestrator sends the model's routine notification/blocker summary directly
- persist compact routine execution records with notification status so recent routine outcomes can surface in normal chat context

## Root Cause
Routine wakes were allowed to use an interactive owner-update tool, then claim-check retried the background completion path and could degrade the final notification into generic chat text. Recent routine execution/notification status was also not consistently recorded for later chat turns.

## Checks
- `uv run pytest tests/test_wake_orchestrator.py tests/test_runtime_pending_context_input.py tests/test_prompt_policy_hardening.py tests/test_claim_check_retry_limit.py tests/test_core_tools.py tests/test_runtime_structured_model.py`
- `uv run ruff check src/opentulpa/agent/runtime.py src/opentulpa/agent/graph_builder.py src/opentulpa/agent/turn_policy.py src/opentulpa/application/wake_orchestrator.py tests/test_runtime_structured_model.py tests/test_runtime_pending_context_input.py tests/test_prompt_policy_hardening.py tests/test_wake_orchestrator.py`
- `git diff --check`