### PR TITLE
OPE-29 Clean up Langfuse trace structure

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -292,6 +292,14 @@ def main() -> None:
         environment=settings.langfuse_environment,
         content_level=settings.langfuse_content_level,
     )
+    if langfuse_tracer is not None:
+        print(
+            "Langfuse observability enabled: "
+            f"environment={langfuse_tracer.environment or 'unset'} "
+            f"deployment_tag={langfuse_tracer.deployment_tag or 'unset'} "
+            f"base_url={langfuse_tracer.base_url}",
+            file=sys.stderr,
+        )
     openai_compatible_api_key = (
         settings.openai_compatible_api_key or get_openai_compatible_api_key_from_env()
     )

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -516,6 +516,23 @@ def _maybe_int(value: Any) -> int | None:
         return None
 
 
+def _maybe_float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _first_float(mapping: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _maybe_float(mapping.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def _usage_object_to_dict(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return dict(value)
@@ -597,17 +614,41 @@ def _extract_response_usage_fields(response: Any) -> dict[str, Any]:
         fields["native_tokens_cache_write"] = cache_write_tokens
     if reasoning_tokens is not None:
         fields["native_tokens_reasoning"] = reasoning_tokens
-    with suppress(Exception):
-        if cost not in (None, ""):
-            fields["native_cost_usd"] = float(cost)
+    total_cost = _maybe_float(cost)
     if cost_details:
         fields["native_cost_details"] = cost_details
-        with suppress(Exception):
-            if cost_details.get("prompt") not in (None, ""):
-                fields["native_cost_prompt_usd"] = float(cost_details.get("prompt"))
-        with suppress(Exception):
-            if cost_details.get("completion") not in (None, ""):
-                fields["native_cost_completion_usd"] = float(cost_details.get("completion"))
+        total_cost = total_cost or _first_float(
+            cost_details,
+            "total",
+            "cost",
+            "total_cost",
+            "upstream_inference_cost",
+        )
+        prompt_cost = _first_float(
+            cost_details,
+            "prompt",
+            "input",
+            "prompt_cost",
+            "input_cost",
+            "upstream_inference_prompt_cost",
+        )
+        completion_cost = _first_float(
+            cost_details,
+            "completion",
+            "completions",
+            "output",
+            "completion_cost",
+            "completions_cost",
+            "output_cost",
+            "upstream_inference_completion_cost",
+            "upstream_inference_completions_cost",
+        )
+        if prompt_cost is not None:
+            fields["native_cost_prompt_usd"] = prompt_cost
+        if completion_cost is not None:
+            fields["native_cost_completion_usd"] = completion_cost
+    if total_cost is not None:
+        fields["native_cost_usd"] = total_cost
     return fields
 
 
@@ -1850,6 +1891,7 @@ class OpenTulpaLangGraphRuntime:
     @staticmethod
     def _normalize_llm_call_context(call_context: dict[str, Any] | None) -> dict[str, Any]:
         normalized = dict(call_context) if isinstance(call_context, dict) else {}
+        normalized.pop("_langfuse_callback_attached", None)
         prompt_sections = normalized.get("prompt_sections")
         if isinstance(prompt_sections, str):
             normalized["prompt_sections"] = [
@@ -1929,7 +1971,10 @@ class OpenTulpaLangGraphRuntime:
             self._write_llm_call_trace(record)
         tracer = getattr(self, "_langfuse_tracer", None)
         record_generation = getattr(tracer, "record_generation", None)
-        if callable(record_generation):
+        callback_already_records = bool(
+            isinstance(call_context, dict) and call_context.get("_langfuse_callback_attached")
+        )
+        if callable(record_generation) and not callback_already_records:
             with suppress(Exception):
                 record_generation(record)
 
@@ -3292,6 +3337,20 @@ class OpenTulpaLangGraphRuntime:
         )
         if callbacks:
             config["callbacks"] = callbacks
+            config["metadata"] = {
+                "langfuse_user_id": str(customer_id or "").strip(),
+                "langfuse_session_id": str(thread_id or "").strip(),
+                "langfuse_tags": [
+                    item
+                    for item in (str(turn_mode or "").strip(), str(prompt_mode or "").strip())
+                    if item
+                ],
+                "opentulpa_trace_id": str(trace_id or "").strip(),
+                "thread_id": str(thread_id or "").strip(),
+                "turn_mode": str(turn_mode or "").strip(),
+                "prompt_mode": str(prompt_mode or "").strip(),
+            }
+            config["tags"] = list(config["metadata"]["langfuse_tags"])
         graph_input = self._build_graph_input(
             user_text=user_text,
             customer_id=customer_id,
@@ -3365,7 +3424,36 @@ class OpenTulpaLangGraphRuntime:
         if not callable(with_config):
             return model
         try:
-            return with_config({"callbacks": callbacks})
+            metadata = {
+                "langfuse_user_id": str(
+                    context.get("customer_id") or self.get_active_customer_id() or ""
+                ).strip(),
+                "langfuse_session_id": str(context.get("thread_id") or "").strip(),
+                "langfuse_tags": [
+                    item
+                    for item in (
+                        str(context.get("turn_mode") or "").strip(),
+                        str(context.get("prompt_mode") or "").strip(),
+                    )
+                    if item
+                ],
+                "opentulpa_trace_id": str(context.get("trace_id") or "").strip(),
+                "thread_id": str(context.get("thread_id") or "").strip(),
+                "turn_mode": str(context.get("turn_mode") or "").strip(),
+                "prompt_mode": str(context.get("prompt_mode") or "").strip(),
+                "call_site": str(context.get("call_site") or "").strip()
+                or "runtime_model_invoke",
+            }
+            configured_model = with_config(
+                {
+                    "callbacks": callbacks,
+                    "metadata": metadata,
+                    "tags": list(metadata["langfuse_tags"]),
+                }
+            )
+            if isinstance(call_context, dict):
+                call_context["_langfuse_callback_attached"] = True
+            return configured_model
         except Exception:
             logger.exception("Failed to attach Langfuse callbacks to model invocation.")
             return model

--- a/src/opentulpa/logging/langfuse.py
+++ b/src/opentulpa/logging/langfuse.py
@@ -26,6 +26,10 @@ _ACTIVE_TOOL_SPAN: contextvars.ContextVar[_LangfuseToolSpan | None] = contextvar
     "opentulpa_langfuse_active_tool_span",
     default=None,
 )
+_ACTIVE_OBSERVATION_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "opentulpa_langfuse_active_observation_id",
+    default=None,
+)
 
 
 class _NoopContext:
@@ -143,6 +147,14 @@ def _float_value(value: Any) -> float | None:
         return None
 
 
+def _first_float(mapping: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _float_value(mapping.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def _usage_details(record: dict[str, Any]) -> dict[str, int]:
     details: dict[str, int] = {}
     mapping = {
@@ -199,9 +211,32 @@ def _cost_details(record: dict[str, Any]) -> dict[str, float]:
             details[langfuse_key] = value
     native_cost_details = record.get("native_cost_details")
     if isinstance(native_cost_details, dict):
-        prompt = _float_value(native_cost_details.get("prompt"))
-        completion = _float_value(native_cost_details.get("completion"))
-        total = _float_value(native_cost_details.get("total"))
+        prompt = _first_float(
+            native_cost_details,
+            "prompt",
+            "input",
+            "prompt_cost",
+            "input_cost",
+            "upstream_inference_prompt_cost",
+        )
+        completion = _first_float(
+            native_cost_details,
+            "completion",
+            "completions",
+            "output",
+            "completion_cost",
+            "completions_cost",
+            "output_cost",
+            "upstream_inference_completion_cost",
+            "upstream_inference_completions_cost",
+        )
+        total = _first_float(
+            native_cost_details,
+            "total",
+            "cost",
+            "total_cost",
+            "upstream_inference_cost",
+        )
         if prompt is not None:
             details.setdefault("input", prompt)
         if completion is not None:
@@ -215,9 +250,32 @@ def _cost_details(record: dict[str, Any]) -> dict[str, float]:
             details.setdefault("total", cost)
         usage_cost_details = usage.get("cost_details")
         if isinstance(usage_cost_details, dict):
-            prompt = _float_value(usage_cost_details.get("prompt"))
-            completion = _float_value(usage_cost_details.get("completion"))
-            total = _float_value(usage_cost_details.get("total"))
+            prompt = _first_float(
+                usage_cost_details,
+                "prompt",
+                "input",
+                "prompt_cost",
+                "input_cost",
+                "upstream_inference_prompt_cost",
+            )
+            completion = _first_float(
+                usage_cost_details,
+                "completion",
+                "completions",
+                "output",
+                "completion_cost",
+                "completions_cost",
+                "output_cost",
+                "upstream_inference_completion_cost",
+                "upstream_inference_completions_cost",
+            )
+            total = _first_float(
+                usage_cost_details,
+                "total",
+                "cost",
+                "total_cost",
+                "upstream_inference_cost",
+            )
             if prompt is not None:
                 details.setdefault("input", prompt)
             if completion is not None:
@@ -449,6 +507,56 @@ class LangfuseTracer:
                 resolved.append(text)
         return resolved
 
+    @contextmanager
+    def _observation_context(self, client: Any, kwargs: dict[str, Any]) -> Any:
+        trace_context = kwargs.get("trace_context")
+        start_observation = getattr(client, "start_observation", None)
+        if trace_context and callable(start_observation):
+            observation = start_observation(**kwargs)
+            use_span_context: Any = None
+            otel_span = getattr(observation, "_otel_span", None)
+            if otel_span is not None:
+                with suppress(Exception):
+                    from opentelemetry import trace as otel_trace
+
+                    use_span_context = otel_trace.use_span(otel_span, end_on_exit=False)
+                    use_span_context.__enter__()
+            observation_id = _clean_text(
+                getattr(observation, "id", None) or getattr(observation, "observation_id", None)
+            )
+            token: contextvars.Token[Any] | None = None
+            if observation_id:
+                token = _ACTIVE_OBSERVATION_ID.set(observation_id)
+            try:
+                yield observation
+            finally:
+                if token is not None:
+                    with suppress(Exception):
+                        _ACTIVE_OBSERVATION_ID.reset(token)
+                if use_span_context is not None:
+                    with suppress(Exception):
+                        use_span_context.__exit__(None, None, None)
+                end = getattr(observation, "end", None)
+                if callable(end):
+                    with suppress(Exception):
+                        end()
+            return
+
+        observation_context = client.start_as_current_observation(**kwargs)
+        observation = observation_context.__enter__()
+        observation_id = _clean_text(
+            getattr(observation, "id", None) or getattr(observation, "observation_id", None)
+        )
+        token = _ACTIVE_OBSERVATION_ID.set(observation_id) if observation_id else None
+        try:
+            yield observation
+        finally:
+            if token is not None:
+                with suppress(Exception):
+                    _ACTIVE_OBSERVATION_ID.reset(token)
+            with suppress(Exception):
+                observation_context.__exit__(None, None, None)
+
     def _propagate_attributes(
         self,
         *,
@@ -498,7 +606,7 @@ class LangfuseTracer:
         if trace_context:
             kwargs["trace_context"] = trace_context
         try:
-            observation_context = client.start_as_current_observation(**kwargs)
+            observation_context = self._observation_context(client, kwargs)
             observation = observation_context.__enter__()
         except Exception:
             logger.exception("Failed to create Langfuse trace context.")
@@ -529,7 +637,7 @@ class LangfuseTracer:
         metadata: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> list[Any]:
-        _ = trace_id, session_id, metadata, tags
+        _ = user_id, session_id, metadata, tags
         if not self.enabled:
             return []
         self._install_env()
@@ -544,7 +652,15 @@ class LangfuseTracer:
                 logger.exception("Failed to import Langfuse LangChain callback handler.")
                 return []
         try:
-            return [callback_cls()]
+            active_observation_id = _clean_text(_ACTIVE_OBSERVATION_ID.get())
+            if not active_observation_id:
+                logger.debug("Skipping Langfuse callback handler without active root observation.")
+                return []
+            trace_context = self.trace_context_payload(trace_id)
+            if trace_context:
+                trace_context = {**trace_context, "parent_span_id": active_observation_id}
+            kwargs = {"trace_context": trace_context} if trace_context else {}
+            return [callback_cls(**kwargs)]
         except Exception:
             logger.exception("Failed to build Langfuse callback handler.")
             return []
@@ -583,10 +699,16 @@ class LangfuseTracer:
         if callable(current_trace):
             with suppress(Exception):
                 current_trace_id = current_trace()
+        if not trace_context and not current_trace_id:
+            logger.debug(
+                "Skipping Langfuse generation without trace context for call_site=%s.",
+                call_site,
+            )
+            return
         if trace_context and not current_trace_id:
             kwargs["trace_context"] = trace_context
         try:
-            with client.start_as_current_observation(**kwargs):
+            with self._observation_context(client, kwargs):
                 return
         except Exception:
             logger.exception("Failed to record Langfuse generation.")
@@ -624,7 +746,7 @@ class LangfuseTracer:
         if trace_context and not current_trace_id:
             kwargs["trace_context"] = trace_context
         try:
-            with client.start_as_current_observation(**kwargs):
+            with self._observation_context(client, kwargs):
                 return
         except Exception:
             logger.exception("Failed to record Langfuse span '%s'.", name)

--- a/tests/test_langfuse_logging.py
+++ b/tests/test_langfuse_logging.py
@@ -18,6 +18,7 @@ from opentulpa.logging.langfuse import (
 class _FakeObservation:
     def __init__(self, kwargs: dict[str, Any]) -> None:
         self.kwargs = kwargs
+        self.id = "a" * 16
         self.updates: list[dict[str, Any]] = []
 
     def update(self, **kwargs: Any) -> None:
@@ -66,9 +67,11 @@ class _FakeLangfuseClient:
 
 class _FakeCallbackHandler:
     instances = 0
+    init_kwargs: list[dict[str, Any]] = []
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         type(self).instances += 1
+        type(self).init_kwargs.append(dict(kwargs))
 
 
 def test_create_langfuse_tracer_requires_full_config() -> None:
@@ -117,12 +120,45 @@ def test_langfuse_environment_defaults_to_railway_service_name(monkeypatch) -> N
 def test_langfuse_environment_override_is_normalized_and_installed(monkeypatch) -> None:
     monkeypatch.delenv("LANGFUSE_TRACING_ENVIRONMENT", raising=False)
     _FakeCallbackHandler.instances = 0
+    _FakeCallbackHandler.init_kwargs = []
     tracer = LangfuseTracer(
         public_key="pk",
         secret_key="sk",
         base_url="https://cloud.langfuse.com",
         deployment_tag="ignored",
         environment="LANGFUSE Prod!",
+        client=_FakeLangfuseClient(),
+        callback_handler_cls=_FakeCallbackHandler,
+    )
+
+    with tracer.trace_context(
+        name="opentulpa.turn.interactive",
+        trace_id="turn_1",
+        user_id="cust_1",
+        session_id="thread_1",
+    ):
+        callbacks = tracer.build_callbacks(
+            user_id="cust_1",
+            trace_id="turn_1",
+            session_id="thread_1",
+            metadata=None,
+            tags=None,
+        )
+
+    assert callbacks
+    assert tracer.environment == "env-langfuse-prod"
+    assert os.environ["LANGFUSE_TRACING_ENVIRONMENT"] == "env-langfuse-prod"
+    assert _FakeCallbackHandler.init_kwargs[0]["trace_context"]["trace_id"]
+
+
+def test_langfuse_callbacks_skip_without_active_root_span() -> None:
+    _FakeCallbackHandler.instances = 0
+    _FakeCallbackHandler.init_kwargs = []
+    tracer = LangfuseTracer(
+        public_key="pk",
+        secret_key="sk",
+        base_url="https://cloud.langfuse.com",
+        client=_FakeLangfuseClient(),
         callback_handler_cls=_FakeCallbackHandler,
     )
 
@@ -130,13 +166,43 @@ def test_langfuse_environment_override_is_normalized_and_installed(monkeypatch) 
         user_id="cust_1",
         trace_id="turn_1",
         session_id="thread_1",
-        metadata=None,
-        tags=None,
+        metadata={"call_site": "graph_agent"},
+        tags=["interactive"],
     )
 
+    assert callbacks == []
+    assert _FakeCallbackHandler.init_kwargs == []
+
+
+def test_langfuse_callbacks_attach_to_active_root_span() -> None:
+    _FakeCallbackHandler.instances = 0
+    _FakeCallbackHandler.init_kwargs = []
+    tracer = LangfuseTracer(
+        public_key="pk",
+        secret_key="sk",
+        base_url="https://cloud.langfuse.com",
+        client=_FakeLangfuseClient(),
+        callback_handler_cls=_FakeCallbackHandler,
+    )
+
+    with tracer.trace_context(
+        name="opentulpa.turn.interactive",
+        trace_id="turn_1",
+        user_id="cust_1",
+        session_id="thread_1",
+    ):
+        callbacks = tracer.build_callbacks(
+            user_id="cust_1",
+            trace_id="turn_1",
+            session_id="thread_1",
+            metadata=None,
+            tags=["interactive"],
+        )
+
     assert callbacks
-    assert tracer.environment == "env-langfuse-prod"
-    assert os.environ["LANGFUSE_TRACING_ENVIRONMENT"] == "env-langfuse-prod"
+    assert _FakeCallbackHandler.init_kwargs == [
+        {"trace_context": {"trace_id": "f" * 32, "parent_span_id": "a" * 16}}
+    ]
 
 
 def test_langfuse_trace_context_uses_deterministic_trace_id_and_deployment_tag() -> None:
@@ -207,6 +273,55 @@ def test_record_generation_captures_usage_and_cost() -> None:
         "reasoning_output_tokens": 2,
     }
     assert observation.kwargs["cost_details"] == {"input": 0.01, "output": 0.02, "total": 0.03}
+
+
+def test_record_generation_maps_openrouter_upstream_cost_details() -> None:
+    client = _FakeLangfuseClient()
+    tracer = LangfuseTracer(
+        public_key="pk",
+        secret_key="sk",
+        base_url="https://cloud.langfuse.com",
+        client=client,
+    )
+
+    tracer.record_generation(
+        {
+            "model_name": "z-ai/glm-5.1",
+            "call_site": "graph_agent",
+            "trace_id": "turn_1",
+            "prompt_messages": [{"role": "user", "text": "hi"}],
+            "response_text": "hello",
+            "native_cost_details": {
+                "upstream_inference_prompt_cost": 0.004,
+                "upstream_inference_completions_cost": 0.006,
+                "upstream_inference_cost": 0.01,
+            },
+        }
+    )
+
+    observation = client.observations[0]
+    assert observation.kwargs["cost_details"] == {"input": 0.004, "output": 0.006, "total": 0.01}
+
+
+def test_record_generation_skips_without_trace_context() -> None:
+    client = _FakeLangfuseClient()
+    tracer = LangfuseTracer(
+        public_key="pk",
+        secret_key="sk",
+        base_url="https://cloud.langfuse.com",
+        client=client,
+    )
+
+    tracer.record_generation(
+        {
+            "model_name": "z-ai/glm-5.1",
+            "call_site": "runtime_model_invoke",
+            "prompt_messages": [{"role": "user", "text": "hi"}],
+            "response_text": "hello",
+        }
+    )
+
+    assert client.observations == []
 
 
 def test_tool_span_captures_status_error_approval_and_side_effects() -> None:
@@ -281,6 +396,7 @@ def test_redaction_covers_secrets_and_inline_media() -> None:
 class _FakeCallbackTracer:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.generations: list[dict[str, Any]] = []
 
     def build_callbacks(
         self,
@@ -301,6 +417,9 @@ class _FakeCallbackTracer:
             }
         )
         return ["langfuse-callback"]
+
+    def record_generation(self, record: dict[str, Any]) -> None:
+        self.generations.append(record)
 
 
 class _ConfigurableModel:
@@ -385,3 +504,6 @@ async def test_ainvoke_model_attaches_langfuse_callbacks_with_with_config(tmp_pa
 
     assert model.configs
     assert model.configs[0]["callbacks"] == ["langfuse-callback"]
+    assert runtime._langfuse_tracer.calls[0]["trace_id"] == "turn_test"
+    assert runtime._langfuse_tracer.calls[0]["metadata"]["call_site"] == "graph_agent"
+    assert runtime._langfuse_tracer.generations == []

--- a/tests/test_llm_call_tracing.py
+++ b/tests/test_llm_call_tracing.py
@@ -35,6 +35,27 @@ class _TraceModel:
         return _TraceResponse()
 
 
+class _OpenRouterCostResponse(_TraceResponse):
+    def __init__(self) -> None:
+        super().__init__()
+        self.usage = {
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "total_tokens": 125,
+            "cost_details": {
+                "upstream_inference_prompt_cost": 0.004,
+                "upstream_inference_completions_cost": 0.006,
+                "upstream_inference_cost": 0.01,
+            },
+        }
+
+
+class _OpenRouterCostModel(_TraceModel):
+    async def ainvoke(self, messages: object, **kwargs: object) -> _OpenRouterCostResponse:
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return _OpenRouterCostResponse()
+
+
 @pytest.mark.asyncio
 async def test_ainvoke_model_writes_full_llm_call_trace(tmp_path: Path) -> None:
     runtime = OpenTulpaLangGraphRuntime(
@@ -93,6 +114,29 @@ async def test_ainvoke_model_writes_full_llm_call_trace(tmp_path: Path) -> None:
     assert len(record["prompt_messages"]) == 2
     assert record["prompt_messages"][0]["role"] == "system"
     assert record["prompt_messages"][1]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_model_extracts_openrouter_upstream_cost_details(tmp_path: Path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+
+    await runtime.ainvoke_model(
+        _OpenRouterCostModel(),
+        [HumanMessage(content="cost please")],
+        model_name="google/gemini-3-flash-preview",
+        call_context={"call_site": "graph_agent", "trace_id": "turn_trace_test"},
+    )
+
+    record = json.loads(runtime._llm_call_trace_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert record["native_cost_usd"] == 0.01
+    assert record["native_cost_prompt_usd"] == 0.004
+    assert record["native_cost_completion_usd"] == 0.006
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- nest LangChain/LangGraph callbacks under the active OpenTulpa root observation via deterministic trace context and parent span IDs
- skip manual Langfuse generations when callbacks already capture the model call, and avoid detached manual generations without trace context
- map OpenRouter upstream cost fields and log the resolved Langfuse environment at startup

## Tests
- uv run ruff check src/opentulpa/logging/langfuse.py src/opentulpa/agent/runtime.py src/opentulpa/__main__.py tests/test_langfuse_logging.py tests/test_llm_call_tracing.py
- uv run pytest -q tests/test_langfuse_logging.py
- uv run pytest -q tests/test_llm_call_tracing.py
- uv run pytest -q tests/test_config_api_key_alias.py tests/test_main_bootstrap.py

Linear: OPE-29