### PR TITLE
OPE-30 Fix Langfuse graph trace shape

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -1363,6 +1363,9 @@ def build_runtime_graph(runtime: Any):
                 "customer_id": customer_id,
                 "turn_mode": turn_mode,
                 "prompt_mode": prompt_mode,
+                "_langfuse_graph_callback_covers_call": bool(
+                    state.get("langfuse_graph_callback_attached")
+                ),
                 "prompt_sections": prompt_section_names,
                 "stable_prefix_count": stable_prefix_count,
                 "prompt_overhead_tokens": prompt_overhead_tokens,
@@ -1625,7 +1628,7 @@ def build_runtime_graph(runtime: Any):
                     scope_token = set_customer_scope(customer_id)
                 tool_span = None
                 span_factory = getattr(getattr(runtime, "_langfuse_tracer", None), "tool_span", None)
-                if callable(span_factory):
+                if callable(span_factory) and not bool(state.get("langfuse_graph_callback_attached")):
                     tool_span = span_factory(
                         trace_id=str(state.get("agent_trace_id", "")).strip() or None,
                         tool_name=call_name,

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1892,6 +1892,7 @@ class OpenTulpaLangGraphRuntime:
     def _normalize_llm_call_context(call_context: dict[str, Any] | None) -> dict[str, Any]:
         normalized = dict(call_context) if isinstance(call_context, dict) else {}
         normalized.pop("_langfuse_callback_attached", None)
+        normalized.pop("_langfuse_graph_callback_covers_call", None)
         prompt_sections = normalized.get("prompt_sections")
         if isinstance(prompt_sections, str):
             normalized["prompt_sections"] = [
@@ -1972,7 +1973,11 @@ class OpenTulpaLangGraphRuntime:
         tracer = getattr(self, "_langfuse_tracer", None)
         record_generation = getattr(tracer, "record_generation", None)
         callback_already_records = bool(
-            isinstance(call_context, dict) and call_context.get("_langfuse_callback_attached")
+            isinstance(call_context, dict)
+            and (
+                call_context.get("_langfuse_callback_attached")
+                or call_context.get("_langfuse_graph_callback_covers_call")
+            )
         )
         if callable(record_generation) and not callback_already_records:
             with suppress(Exception):
@@ -3263,6 +3268,7 @@ class OpenTulpaLangGraphRuntime:
             "final_response_text": "",
             "pending_context_summary": pending_context_summary,
             "agent_trace_id": trace_id,
+            "langfuse_graph_callback_attached": False,
             "tool_error_count": 0,
             "approval_handoff": False,
             "claim_check_retry_count": 0,
@@ -3351,6 +3357,9 @@ class OpenTulpaLangGraphRuntime:
                 "prompt_mode": str(prompt_mode or "").strip(),
             }
             config["tags"] = list(config["metadata"]["langfuse_tags"])
+            graph_langfuse_callback_attached = True
+        else:
+            graph_langfuse_callback_attached = False
         graph_input = self._build_graph_input(
             user_text=user_text,
             customer_id=customer_id,
@@ -3361,6 +3370,7 @@ class OpenTulpaLangGraphRuntime:
             trace_id=trace_id,
             skill_state=skill_state,
         )
+        graph_input["langfuse_graph_callback_attached"] = graph_langfuse_callback_attached
         return _PreparedTurnContext(
             through_id=through_id,
             config=config,
@@ -3404,6 +3414,8 @@ class OpenTulpaLangGraphRuntime:
         if model is None:
             return model
         context = dict(call_context or {})
+        if bool(context.get("_langfuse_graph_callback_covers_call")):
+            return model
         callbacks = self._build_langfuse_callbacks(
             customer_id=str(
                 context.get("customer_id") or self.get_active_customer_id() or ""

--- a/src/opentulpa/logging/langfuse.py
+++ b/src/opentulpa/logging/langfuse.py
@@ -513,14 +513,6 @@ class LangfuseTracer:
         start_observation = getattr(client, "start_observation", None)
         if trace_context and callable(start_observation):
             observation = start_observation(**kwargs)
-            use_span_context: Any = None
-            otel_span = getattr(observation, "_otel_span", None)
-            if otel_span is not None:
-                with suppress(Exception):
-                    from opentelemetry import trace as otel_trace
-
-                    use_span_context = otel_trace.use_span(otel_span, end_on_exit=False)
-                    use_span_context.__enter__()
             observation_id = _clean_text(
                 getattr(observation, "id", None) or getattr(observation, "observation_id", None)
             )
@@ -533,9 +525,6 @@ class LangfuseTracer:
                 if token is not None:
                     with suppress(Exception):
                         _ACTIVE_OBSERVATION_ID.reset(token)
-                if use_span_context is not None:
-                    with suppress(Exception):
-                        use_span_context.__exit__(None, None, None)
                 end = getattr(observation, "end", None)
                 if callable(end):
                     with suppress(Exception):

--- a/tests/test_langfuse_logging.py
+++ b/tests/test_langfuse_logging.py
@@ -20,9 +20,13 @@ class _FakeObservation:
         self.kwargs = kwargs
         self.id = "a" * 16
         self.updates: list[dict[str, Any]] = []
+        self.ended = False
 
     def update(self, **kwargs: Any) -> None:
         self.updates.append(kwargs)
+
+    def end(self) -> None:
+        self.ended = True
 
 
 class _FakeObservationContext:
@@ -54,6 +58,11 @@ class _FakeLangfuseClient:
 
     def start_as_current_observation(self, **kwargs: Any) -> _FakeObservationContext:
         return _FakeObservationContext(self, kwargs)
+
+    def start_observation(self, **kwargs: Any) -> _FakeObservation:
+        observation = _FakeObservation(kwargs)
+        self.observations.append(observation)
+        return observation
 
     def get_current_trace_id(self) -> str | None:
         return self.current_trace_id
@@ -230,6 +239,7 @@ def test_langfuse_trace_context_uses_deterministic_trace_id_and_deployment_tag()
     assert observation.kwargs["metadata"]["deployment_tag"] == "carwash-test"
     assert observation.kwargs["metadata"]["environment"] == "carwash-test"
     assert observation.kwargs["metadata"]["turn_mode"] == "interactive"
+    assert observation.ended is True
     assert "env:carwash-test" in tracer.tags(["interactive"])
 
 
@@ -472,6 +482,7 @@ async def test_prepare_turn_context_adds_langfuse_callbacks_to_graph_config() ->
 
     assert prepared is not None
     assert prepared.config["callbacks"] == ["langfuse-callback"]
+    assert prepared.graph_input["langfuse_graph_callback_attached"] is True
     assert runtime._langfuse_tracer.calls[0]["user_id"] == "telegram_test"
     assert runtime._langfuse_tracer.calls[0]["trace_id"] == "turn_test"
     assert runtime._langfuse_tracer.calls[0]["session_id"] == "chat_test"
@@ -507,3 +518,38 @@ async def test_ainvoke_model_attaches_langfuse_callbacks_with_with_config(tmp_pa
     assert runtime._langfuse_tracer.calls[0]["trace_id"] == "turn_test"
     assert runtime._langfuse_tracer.calls[0]["metadata"]["call_site"] == "graph_agent"
     assert runtime._langfuse_tracer.generations == []
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_model_skips_langfuse_cloud_when_graph_callback_covers_call(
+    tmp_path: Path,
+) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+    runtime._langfuse_tracer = _FakeCallbackTracer()
+    runtime._llm_call_trace_path = tmp_path / "llm_call_traces.jsonl"
+    model = _ConfigurableModel()
+
+    await runtime.ainvoke_model(
+        model,
+        [HumanMessage(content="hi")],
+        model_name="google/gemini-3-flash-preview",
+        call_context={
+            "call_site": "graph_agent",
+            "customer_id": "telegram_test",
+            "thread_id": "chat_test",
+            "trace_id": "turn_test",
+            "turn_mode": "interactive",
+            "prompt_mode": "literal_chat",
+            "_langfuse_graph_callback_covers_call": True,
+        },
+    )
+
+    assert model.configs == []
+    assert runtime._langfuse_tracer.calls == []
+    assert runtime._langfuse_tracer.generations == []
+    assert runtime._llm_call_trace_path.exists()

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -914,6 +914,7 @@ async def test_interactive_prompt_injects_memory_grounding_after_stable_prefix()
     assert grounding_index < last_human_index
     assert isinstance(captured["call_context"], dict)
     assert captured["call_context"]["call_site"] == "graph_agent"
+    assert captured["call_context"]["_langfuse_graph_callback_covers_call"] is False
     assert "memory_grounding" in captured["call_context"]["prompt_sections"]
 
 


### PR DESCRIPTION
## Summary
- mark LangGraph-covered turns so the graph callback owns graph/model/tool observations
- suppress duplicate manual `llm.graph_agent` generations and `tool.*` spans inside graph-covered loops while keeping local JSONL LLM logs
- remove async-unsafe manual OpenTelemetry `use_span` context attach/detach while preserving Langfuse root observation IDs for callback parenting

## Why
Live traces after OPE-29 still showed duplicated model/tool observations and root-ish rows, and Railway logs showed OpenTelemetry context token detach errors during streaming teardown.

## Tests
- uv run ruff check src/opentulpa/agent/runtime.py src/opentulpa/agent/graph_builder.py tests/test_langfuse_logging.py tests/test_runtime_pending_context_input.py
- uv run pytest -q tests/test_langfuse_logging.py tests/test_llm_call_tracing.py
- uv run pytest -q tests/test_runtime_pending_context_input.py
- uv run ruff check src/opentulpa/logging/langfuse.py tests/test_langfuse_logging.py
- uv run pytest -q tests/test_langfuse_logging.py tests/test_llm_call_tracing.py tests/test_runtime_pending_context_input.py

Linear: OPE-30