### PR TITLE
Unify uv-first startup entrypoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ LANGFUSE_CONTENT_LEVEL=full_debug
 OPENTULPA_DATA_ROOT=
 
 # Optional: Telegram bot
-TELEGRAM_BOT_TOKEN=...
+TELEGRAM_BOT_TOKEN=
 # Optional but recommended: Telegram webhook secret token validated on /webhook/telegram
 TELEGRAM_WEBHOOK_SECRET=
 # Optional public base URL for auto webhook registration on startup (cloud deploys)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,11 @@ RUN mkdir -p /app/tulpa_stuff \
     && uv sync --frozen --no-dev \
     && uv run playwright install --with-deps chromium
 
+COPY start.sh /app/start.sh
+
 ENV HOST=0.0.0.0
 ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["uv", "run", "python", "-m", "opentulpa"]
+CMD ["./start.sh", "run", "server"]

--- a/README.md
+++ b/README.md
@@ -253,27 +253,27 @@ No external database is required by default.
 
 ## Quick Start
 
-### Requirements
-
-- Python `3.12` for local startup. `./start.sh` asks uv for Python 3.12 by default.
-- [`uv`](https://docs.astral.sh/uv/) (`start.sh` can install it if missing)
-- an OpenAI-compatible API key
-
-### Run Locally
+### Local Telegram Mode
 
 ```bash
 git clone <repo-url>
 cd opentulpa
-cp .env.example .env
+./start.sh
 ```
 
-Set your model API key in `.env`:
+`./start.sh` is the normal local command. It checks for `uv`, installs it if missing, asks uv for Python 3.12, installs dependencies, creates `.env` from `.env.example` when needed, checks required settings, starts the app, starts a Cloudflare tunnel, and syncs the Telegram webhook.
 
-```bash
-OPENAI_COMPATIBLE_API_KEY=...
-```
+For local Telegram mode, set these in `.env` or enter them when the script prompts:
 
-Start the app:
+- `OPENAI_COMPATIBLE_API_KEY`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
+
+`COMPOSIO_API_KEY` is highly recommended for connector integrations such as Google Sheets and Instagram, but it is not required for startup.
+
+### Plain App Server
+
+Use server mode when you only want the FastAPI app without the local tunnel/webhook manager:
 
 ```bash
 ./start.sh server

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ For local Telegram mode, set these in `.env` or enter them when the script promp
 
 `COMPOSIO_API_KEY` is highly recommended for connector integrations such as Google Sheets and Instagram, but it is not required for startup.
 
+Model defaults live in `opentulpa.config.yaml`. If you do not use the default OpenRouter base URL, review the model settings there before startup, especially `multimodal_llm`; file, image, browser, and other multimodal functionality depends on it.
+
 ### Plain App Server
 
 Use server mode when you only want the FastAPI app without the local tunnel/webhook manager:

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ No external database is required by default.
 
 ### Requirements
 
-- Python `3.12+`
-- [`uv`](https://docs.astral.sh/uv/)
+- Python `3.12` for local startup. `./start.sh` asks uv for Python 3.12 by default.
+- [`uv`](https://docs.astral.sh/uv/) (`start.sh` can install it if missing)
 - an OpenAI-compatible API key
 
 ### Run Locally
@@ -276,7 +276,7 @@ OPENAI_COMPATIBLE_API_KEY=...
 Start the app:
 
 ```bash
-./start.sh --app
+./start.sh server
 ```
 
 Health checks:
@@ -319,10 +319,9 @@ Basic Telegram bot setup:
 
 1. Create a bot with `@BotFather`.
 2. Add `TELEGRAM_BOT_TOKEN` to `.env`.
-3. Install `cloudflared` if you want the quick-tunnel manager flow.
-4. Run `./start.sh`.
+3. Run `./start.sh local`.
 
-`start.sh` handles Python dependencies, Playwright Chromium, and tunnel setup.
+`start.sh local` handles Python dependencies, Playwright Chromium, Cloudflare tunnel setup, and Telegram webhook sync.
 
 Telegram Business intake setup:
 
@@ -353,6 +352,8 @@ Useful operational surfaces:
 - fake and live E2E scenarios for Telegram intake and workflow setup
 
 Support operators are trusted operators. They can bind to a customer tenant, debug or set up workflows with owner-level access, and keep their own support conversation history separate from the owner's chat. Customer-facing proactive events still go to the owner by default.
+
+Normal allowed Telegram users are configured with `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`. They are allowed to use the bot, but they are not automatically merged into one owner account; each normal Telegram chat gets its own owner session by default. Use support operators when multiple humans should work inside the same customer tenant without sharing the owner chat thread.
 
 ### Langfuse Observability
 
@@ -388,19 +389,17 @@ For external integrations, read [docs/EXTERNAL_TOOL_SAFETY_CHECKLIST.md](docs/EX
 ### Docker
 
 ```bash
-docker build -t opentulpa .
-docker run --rm -p 8000:8000 --env-file .env opentulpa
+docker compose up --build
 ```
 
-The image includes Python dependencies, Node.js/npm, and Playwright.
+Docker Compose is optional. It runs server mode, loads `.env`, maps port `8000`, and mounts a persistent volume at `/app/opentulpa_data`.
 
 ### Railway
 
 1. Create a Railway project from this repo.
 2. Add one volume at `/app/opentulpa_data`.
-3. Set `OPENAI_COMPATIBLE_API_KEY`, `TELEGRAM_BOT_TOKEN`, and `OPENTULPA_DATA_ROOT=/app/opentulpa_data`.
-4. Optionally set `TELEGRAM_WEBHOOK_SECRET` and `PUBLIC_BASE_URL`.
-5. Deploy.
+3. Set `OPENAI_COMPATIBLE_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `PUBLIC_BASE_URL`, `OPENTULPA_DATA_ROOT=/app/opentulpa_data`, and `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`.
+4. Deploy.
 
 See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full checklist.
 
@@ -461,17 +460,42 @@ COMPOSIO_DEFAULT_CALLBACK_URL=https://your-public-base/webhook/composio/callback
 
 | Command | Meaning |
 |---|---|
-| `./start.sh` | Install and run in quick-tunnel manager mode |
-| `./start.sh --app` | Install and run in direct app mode |
+| `./start.sh` | Install and run local Telegram mode |
+| `./start.sh local` | Install and run app + Cloudflare tunnel + Telegram webhook sync |
+| `./start.sh server` | Install and run the plain app server |
 | `./start.sh install` | Install only |
-| `./start.sh run --app` | Run only |
+| `./start.sh run server` | Run the plain app server without installing |
+| `./start.sh doctor` | Check local startup readiness |
 
 Useful `.env` knobs:
 
-- `START_MODE=auto|app|manager`
+- `START_MODE=local|server|auto`
 - `INSTALL_BROWSER_USE=1|0`
 - `INSTALL_CLOUDFLARED=auto|1|0`
+- `INSTALL_UV=1|auto|0` controls uv bootstrap; default `1` installs uv when missing after first checking `PATH`
+- `UV_PYTHON=3.12` controls the Python interpreter uv uses for local startup
 - `CAPSOLVER_API_KEY=...` enables an optional Browser Use CAPTCHA action for supported reCAPTCHA v2/v3 and Cloudflare Turnstile pages. When set, Browser Use tasks are told to call the solver if a supported CAPTCHA blocks progress. Leave it unset to keep CAPTCHA solving disabled.
+
+Required for local Telegram mode:
+
+- `OPENAI_COMPATIBLE_API_KEY`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
+
+Required for server mode:
+
+- `OPENAI_COMPATIBLE_API_KEY`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_WEBHOOK_SECRET`
+- `PUBLIC_BASE_URL`
+- `OPENTULPA_DATA_ROOT`
+- `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
+
+Highly recommended for full agent connector functionality:
+
+- `COMPOSIO_API_KEY`
+
+Compatibility aliases still work but are deprecated: `--app` maps to `server`, and `--manager` maps to `local`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Docker Compose is optional. It runs server mode, loads `.env`, maps port `8000`,
 
 1. Create a Railway project from this repo.
 2. Add one volume at `/app/opentulpa_data`.
-3. Set `OPENAI_COMPATIBLE_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `PUBLIC_BASE_URL`, `OPENTULPA_DATA_ROOT=/app/opentulpa_data`, and `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`.
+3. Set `OPENAI_COMPATIBLE_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `OPENTULPA_DATA_ROOT=/app/opentulpa_data`, and `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`. Set `PUBLIC_BASE_URL` if you do not want to rely on Railway's `RAILWAY_PUBLIC_DOMAIN` fallback.
 4. Deploy.
 
 See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full checklist.
@@ -489,7 +489,7 @@ Required for server mode:
 - `OPENAI_COMPATIBLE_API_KEY`
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_WEBHOOK_SECRET`
-- `PUBLIC_BASE_URL`
+- `PUBLIC_BASE_URL` or Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
 - `OPENTULPA_DATA_ROOT`
 - `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ For local Telegram mode, set these in `.env` or enter them when the script promp
 
 `COMPOSIO_API_KEY` is highly recommended for connector integrations such as Google Sheets and Instagram, but it is not required for startup.
 
-Model defaults live in `opentulpa.config.yaml`. If you do not use the default OpenRouter base URL, review the model settings there before startup, especially `multimodal_llm`; file, image, browser, and other multimodal functionality depends on it.
+Model defaults live in `opentulpa.config.yaml`. If you do not use the default OpenRouter base URL, review the model settings there before startup: `llm_model`, `wake_execution_model`, `workflow_setup_input_classifier_model`, `memory_llm_model`, `multimodal_llm`, `business_knowledge_oracle_model`, `openai_compatible_embedding_model`, and optional `browser_use_model`. File, image, browser, memory, workflow setup, and source-grounded knowledge features depend on these model roles being valid for your provider. When an API key is present, `start.sh` calls the OpenAI-compatible `/models` endpoint and warns if the configured model IDs are not listed.
 
 ### Plain App Server
 
@@ -307,7 +307,7 @@ This repo currently assumes:
 - `medium` reasoning effort for agent-owned LLM calls by default
 - `Gemini Flash` for memory extraction, multimodal work, and some test judging
 - `Gemini Flash Lite` for workflow business knowledge oracle queries over normalized uploaded files
-- `MULTIMODAL_LLM` should be set when your main model is not multimodal
+- `MULTIMODAL_LLM` should be set to a working multimodal model when your main model is not multimodal
 
 DeepSeek V4 Pro is still supported. When a DeepSeek model is used through OpenRouter, OpenTulpa routes it through the OpenRouter LangChain adapter so `reasoning_details` are preserved across tool-call loops, which DeepSeek thinking mode requires.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  opentulpa:
+    build:
+      context: .
+    env_file:
+      - .env
+    environment:
+      OPENTULPA_DATA_ROOT: /app/opentulpa_data
+    ports:
+      - "8000:8000"
+    volumes:
+      - opentulpa_data:/app/opentulpa_data
+    command: ["./start.sh", "run", "server"]
+
+volumes:
+  opentulpa_data:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,8 @@ The runtime should not treat a large spreadsheet, PDF, or policy dump as permane
 
 Support operators are trusted operators configured by `TELEGRAM_SUPPORT_USER_IDS` or `TELEGRAM_SUPPORT_USERNAMES`.
 
+Normal Telegram access is controlled separately by `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`. Those users are allowed to use the bot as owners/operators, but they do not automatically share one owner tenant. A normal allowed chat creates or reuses its own owner session and defaults to `customer_id=telegram_<user_id>` when no existing mapping is present.
+
 1. Support chat sends `/support_customers`
 2. Support binds to a customer with `/support_bind <number-or-customer_id>`
 3. Normal support messages run with `customer_id=<bound_customer_id>` and a support-specific `thread_id`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -182,7 +182,7 @@ Railway builds from the included `Dockerfile` and starts through the same server
 
 Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set.
 
-If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml` before startup. `multimodal_llm` must point at a working multimodal model or file, image, browser, and other multimodal features will not work correctly.
+If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml` before startup. The provider must have valid model IDs for `llm_model`, `wake_execution_model`, `workflow_setup_input_classifier_model`, `memory_llm_model`, `multimodal_llm`, `business_knowledge_oracle_model`, `openai_compatible_embedding_model`, and optional `browser_use_model`. File, image, browser, memory, workflow setup, and source-grounded knowledge features will not work correctly if those roles point at unavailable or incompatible models. When an API key is present, `start.sh` calls the provider's OpenAI-compatible `/models` endpoint and warns if configured model IDs are missing from the catalog; it still cannot infer capabilities such as multimodal support from providers that do not expose those flags.
 
 ### Optional settings
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -171,7 +171,7 @@ Railway builds from the included `Dockerfile` and starts through the same server
 - `OPENAI_COMPATIBLE_API_KEY`
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_WEBHOOK_SECRET`
-- `PUBLIC_BASE_URL=https://your-service.up.railway.app`
+- `PUBLIC_BASE_URL=https://your-service.up.railway.app` or Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
 - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
 - `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`
 
@@ -198,7 +198,7 @@ If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml
    - `OPENAI_COMPATIBLE_API_KEY`
    - `TELEGRAM_BOT_TOKEN`
    - `TELEGRAM_WEBHOOK_SECRET`
-   - `PUBLIC_BASE_URL`
+   - `PUBLIC_BASE_URL` if you do not want to rely on Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
    - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
    - `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
 4. Optionally set:
@@ -218,7 +218,7 @@ If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml
 ### Telegram Business notes for production
 
 - the business account owner must connect the bot inside Telegram after deploy
-- `PUBLIC_BASE_URL` should be set so webhook registration is correct
+- `PUBLIC_BASE_URL` should be set so webhook registration is explicit; when unset on Railway, OpenTulpa falls back to `RAILWAY_PUBLIC_DOMAIN`
 - the same deployed bot and webhook handle both ordinary Telegram chat and Telegram Business updates
 - OpenTulpa persists Telegram Business inbox state locally, so use persistent storage
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,7 +19,7 @@ OPENAI_COMPATIBLE_API_KEY=...
 Then run:
 
 ```bash
-./start.sh --app
+./start.sh server
 ```
 
 Health checks:
@@ -31,20 +31,20 @@ Health checks:
 
 `start.sh` supports two useful modes:
 
-- `--app`: run the FastAPI app directly
-- default manager mode: run the app through the quick-tunnel manager flow
+- `server`: run the FastAPI app directly
+- `local`: run the app through the Cloudflare tunnel and Telegram webhook sync flow
 
 In practice:
 
-- use `./start.sh --app` for direct local app runs
-- use `./start.sh` when you want the managed local Telegram flow with `cloudflared`
+- use `./start.sh server` for direct app server runs
+- use `./start.sh local` or `./start.sh` when you want the managed local Telegram flow with `cloudflared`
 
 ## Local setup
 
 Requirements:
 
-- Python `3.12+`
-- [`uv`](https://docs.astral.sh/uv/)
+- Python `3.12` for local startup. `./start.sh` asks uv for Python 3.12 by default.
+- [`uv`](https://docs.astral.sh/uv/) (`start.sh` can install it if missing)
 - an OpenAI-compatible API key
 
 Base setup:
@@ -64,7 +64,7 @@ OPENAI_COMPATIBLE_API_KEY=...
 Run locally:
 
 ```bash
-./start.sh --app
+./start.sh server
 ```
 
 ## Telegram setup
@@ -75,9 +75,9 @@ For local use:
 
 1. create a bot in `@BotFather`
 2. set `TELEGRAM_BOT_TOKEN` in `.env`
-3. run `./start.sh`
+3. run `./start.sh local`
 
-When you use the default manager flow, `start.sh` will also handle dependency setup for Playwright Chromium and `cloudflared` if needed.
+When you use local mode, `start.sh` will also handle dependency setup for Playwright Chromium and `cloudflared` if needed.
 
 ## Telegram Business intake
 
@@ -132,55 +132,60 @@ unchanged.
 
 | Command | Meaning |
 |---|---|
-| `./start.sh` | Install and run in manager mode |
-| `./start.sh --app` | Install and run in direct app mode |
+| `./start.sh` | Install and run local Telegram mode |
+| `./start.sh local` | Install and run app + Cloudflare tunnel + Telegram webhook sync |
+| `./start.sh server` | Install and run the plain app server |
 | `./start.sh install` | Install only |
-| `./start.sh run --app` | Run only |
+| `./start.sh run server` | Run the plain app server without installing |
+| `./start.sh doctor` | Check local startup readiness |
 
 Useful `.env` knobs:
 
-- `START_MODE=auto|app|manager`
+- `START_MODE=local|server|auto`
 - `INSTALL_BROWSER_USE=1|0`
 - `INSTALL_CLOUDFLARED=auto|1|0`
+- `INSTALL_UV=1|auto|0` controls uv bootstrap; default `1` installs uv when missing after first checking `PATH`
+- `UV_PYTHON=3.12` controls the Python interpreter uv uses for local startup
 - `AGENT_PROMPT_CACHING_ENABLED=1|0`
+
+Compatibility aliases still work but are deprecated: `--app` maps to `server`, and `--manager` maps to `local`.
 
 ## Docker
 
 The included `Dockerfile` already installs Python dependencies, Node.js/npm, and Playwright Chromium.
 
-Build and run:
+Run with Docker Compose:
 
 ```bash
-docker build -t opentulpa .
-docker run --rm -p 8000:8000 --env-file .env opentulpa
+docker compose up --build
 ```
 
-Use Docker for local API testing or as the base for cloud deployment.
+Compose is optional. It loads `.env`, maps port `8000`, mounts a persistent volume at `/app/opentulpa_data`, and starts `./start.sh run server` inside the container.
 
 ## Railway
 
-Railway builds from the included `Dockerfile`.
+Railway builds from the included `Dockerfile` and starts through the same server entrypoint: `./start.sh run server`.
 
 ### Required settings
 
 - `OPENAI_COMPATIBLE_API_KEY`
 - `TELEGRAM_BOT_TOKEN`
-
-### Recommended settings
-
 - `TELEGRAM_WEBHOOK_SECRET`
 - `PUBLIC_BASE_URL=https://your-service.up.railway.app`
 - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
+- `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`
+
+### Recommended settings
+
+- `COMPOSIO_API_KEY` for connector integrations such as Google Sheets and Instagram
 - Model defaults live in `opentulpa.config.yaml` (`LLM_MODEL=z-ai/glm-5.1`, `LLM_REASONING_EFFORT=medium`, `WAKE_EXECUTION_MODEL=z-ai/glm-5.1`, Gemini Flash for memory/media, Gemini Flash Lite for the business knowledge oracle)
 
 Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set.
 
 ### Optional settings
 
-- `COMPOSIO_API_KEY`
 - `COMPOSIO_DEFAULT_CALLBACK_URL`
 - `AGENT_PROMPT_CACHING_ENABLED=1|0`
-- `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`
 - `TELEGRAM_SUPPORT_USER_IDS` or `TELEGRAM_SUPPORT_USERNAMES`
 
 ### Railway setup checklist
@@ -190,13 +195,13 @@ Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set
 3. Set:
    - `OPENAI_COMPATIBLE_API_KEY`
    - `TELEGRAM_BOT_TOKEN`
-   - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
-4. Optionally set:
    - `TELEGRAM_WEBHOOK_SECRET`
    - `PUBLIC_BASE_URL`
+   - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
+   - `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
+4. Optionally set:
    - `COMPOSIO_API_KEY`
    - `COMPOSIO_DEFAULT_CALLBACK_URL`
-   - `TELEGRAM_ALLOWED_USERNAMES`
    - `TELEGRAM_SUPPORT_USER_IDS` or `TELEGRAM_SUPPORT_USERNAMES`
 5. Deploy
 
@@ -214,6 +219,12 @@ Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set
 - `PUBLIC_BASE_URL` should be set so webhook registration is correct
 - the same deployed bot and webhook handle both ordinary Telegram chat and Telegram Business updates
 - OpenTulpa persists Telegram Business inbox state locally, so use persistent storage
+
+## Telegram owner and support access
+
+`TELEGRAM_ALLOWED_USERNAMES` and `TELEGRAM_ALLOWED_USER_IDS` are the owner/operator allowlist for normal bot chat. Configure at least one of them.
+
+Allowed users are not automatically pooled into one owner tenant. Each normal allowed Telegram chat gets its own owner session by default, with a default `customer_id` shaped like `telegram_<user_id>`. If several humans should operate on the same customer tenant without sharing the owner's chat history, configure them as support operators instead and have them bind to that tenant.
 
 ## Support operator access
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -182,6 +182,8 @@ Railway builds from the included `Dockerfile` and starts through the same server
 
 Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set.
 
+If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml` before startup. `multimodal_llm` must point at a working multimodal model or file, image, browser, and other multimodal features will not work correctly.
+
 ### Optional settings
 
 - `COMPOSIO_DEFAULT_CALLBACK_URL`

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 builder = "DOCKERFILE"
 
 [deploy]
-startCommand = "uv run python -m opentulpa"
+startCommand = "./start.sh run server"
 healthcheckPath = "/healthz"
 healthcheckTimeout = 600
 restartPolicyType = "ON_FAILURE"

--- a/start.sh
+++ b/start.sh
@@ -126,6 +126,34 @@ yaml_value_is_set() {
   [[ -n "${value}" && "${value}" != "null" && "${value}" != "\"\"" && "${value}" != "''" ]]
 }
 
+yaml_value() {
+  local key="$1"
+  local line value
+  line="$(grep -E "^[[:space:]]*${key}:[[:space:]]*" "${REPO_ROOT}/opentulpa.config.yaml" 2>/dev/null | head -n 1 || true)"
+  [[ -n "${line}" ]] || return 0
+  value="${line#*:}"
+  value="${value%%#*}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  [[ "${value}" == "null" ]] && return 0
+  printf '%s\n' "${value}"
+}
+
+config_value() {
+  local env_key="$1"
+  local yaml_key="$2"
+  local value="${!env_key:-}"
+  if [[ -n "${value}" && "${value}" != "..." ]]; then
+    printf '%s\n' "${value}"
+    return 0
+  fi
+  yaml_value "${yaml_key}"
+}
+
 multimodal_model_is_set() {
   env_is_set "MULTIMODAL_LLM" || yaml_value_is_set "multimodal_llm"
 }
@@ -141,7 +169,93 @@ emit_model_config_notice() {
     log "warning: MULTIMODAL_LLM is not set and opentulpa.config.yaml has no multimodal_llm; image/file/browser functionality may not work."
   fi
   if ! openrouter_base_url_is_set; then
-    log "warning: OPENAI_COMPATIBLE_BASE_URL is not OpenRouter. Check opentulpa.config.yaml model settings, especially multimodal_llm, memory_llm_model, and business_knowledge_oracle_model."
+    log "warning: OPENAI_COMPATIBLE_BASE_URL is not OpenRouter. Check opentulpa.config.yaml model settings for this provider: llm_model, wake_execution_model, workflow_setup_input_classifier_model, memory_llm_model, multimodal_llm, business_knowledge_oracle_model, openai_compatible_embedding_model, and optional browser_use_model."
+  fi
+}
+
+check_model_catalog() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    return 0
+  fi
+  if ! env_is_set "OPENAI_COMPATIBLE_API_KEY"; then
+    return 0
+  fi
+  command -v curl >/dev/null 2>&1 || {
+    log "info: curl is not available; skipping OpenAI-compatible /models check."
+    return 0
+  }
+  command -v python3 >/dev/null 2>&1 || {
+    log "info: python3 is not available; skipping OpenAI-compatible /models check."
+    return 0
+  }
+
+  local base_url="${OPENAI_COMPATIBLE_BASE_URL:-${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}}"
+  base_url="${base_url%/}"
+
+  local -a role_specs=(
+    "llm_model|LLM_MODEL|llm_model"
+    "wake_execution_model|WAKE_EXECUTION_MODEL|wake_execution_model"
+    "workflow_setup_input_classifier_model|WORKFLOW_SETUP_INPUT_CLASSIFIER_MODEL|workflow_setup_input_classifier_model"
+    "memory_llm_model|MEMORY_LLM_MODEL|memory_llm_model"
+    "multimodal_llm|MULTIMODAL_LLM|multimodal_llm"
+    "business_knowledge_oracle_model|BUSINESS_KNOWLEDGE_ORACLE_MODEL|business_knowledge_oracle_model"
+    "openai_compatible_embedding_model|OPENAI_COMPATIBLE_EMBEDDING_MODEL|openai_compatible_embedding_model"
+    "browser_use_model|BROWSER_USE_MODEL|browser_use_model"
+  )
+  local expected_lines="" spec role env_key yaml_key model
+  for spec in "${role_specs[@]}"; do
+    IFS='|' read -r role env_key yaml_key <<<"${spec}"
+    model="$(config_value "${env_key}" "${yaml_key}")"
+    [[ -n "${model}" && "${model}" != "null" ]] || continue
+    expected_lines+="${role}|${model}"$'\n'
+  done
+  [[ -n "${expected_lines}" ]] || return 0
+
+  local catalog
+  if ! catalog="$(curl -fsS -H "Authorization: Bearer ${OPENAI_COMPATIBLE_API_KEY}" "${base_url}/models" 2>/dev/null)"; then
+    log "warning: could not fetch ${base_url}/models; verify opentulpa.config.yaml model IDs against your provider."
+    return 0
+  fi
+
+  local missing
+  missing="$(
+    EXPECTED_MODELS="${expected_lines}" python3 -c '
+import json
+import os
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+
+items = payload.get("data") if isinstance(payload, dict) else payload
+ids = set()
+if isinstance(items, list):
+    for item in items:
+        if isinstance(item, dict) and item.get("id"):
+            ids.add(str(item["id"]))
+        elif isinstance(item, str):
+            ids.add(item)
+
+missing = []
+for line in os.environ.get("EXPECTED_MODELS", "").splitlines():
+    if not line.strip() or "|" not in line:
+        continue
+    role, model = line.split("|", 1)
+    if model not in ids:
+        missing.append(f"{role}={model}")
+
+if missing:
+    print(", ".join(missing))
+' <<<"${catalog}" || printf '%s' "__parse_error__"
+  )"
+  if [[ "${missing}" == "__parse_error__" ]]; then
+    log "warning: ${base_url}/models returned an unexpected response; verify opentulpa.config.yaml model IDs manually."
+  elif [[ -n "${missing}" ]]; then
+    log "warning: ${base_url}/models did not list configured model(s): ${missing}. Update opentulpa.config.yaml or provider env overrides."
+  else
+    log "OpenAI-compatible /models check passed for configured model IDs."
   fi
 }
 
@@ -415,6 +529,7 @@ ensure_required_env() {
     log "warning: COMPOSIO_API_KEY is not set; connector integrations such as Google Sheets and Instagram will be unavailable."
   fi
   emit_model_config_notice
+  check_model_catalog
 
   if [[ "${#missing[@]}" -eq 0 ]]; then
     return 0
@@ -550,6 +665,8 @@ run_doctor() {
   else
     echo "[doctor] warn: COMPOSIO_API_KEY is not set; connector integrations such as Google Sheets and Instagram will be unavailable"
   fi
+  emit_model_config_notice
+  check_model_catalog
   if [[ "${runtime}" == "server" ]]; then
     doctor_check "TELEGRAM_WEBHOOK_SECRET is set" "$(env_is_set "TELEGRAM_WEBHOOK_SECRET" && echo 1 || echo 0)" "set a stable TELEGRAM_WEBHOOK_SECRET in .env" || failures=$((failures + 1))
     doctor_check "PUBLIC_BASE_URL is set" "$(env_is_set "PUBLIC_BASE_URL" && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL" || failures=$((failures + 1))

--- a/start.sh
+++ b/start.sh
@@ -7,11 +7,136 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}" && pwd)"
 cd "${REPO_ROOT}"
 
 MODE="up"
-RUNTIME_MODE="${START_MODE:-auto}"
+RUNTIME_MODE="${START_MODE:-local}"
 INSTALL_BROWSER_USE="${INSTALL_BROWSER_USE:-1}"
 INSTALL_CLOUDFLARED="${INSTALL_CLOUDFLARED:-auto}"
+INSTALL_UV="${INSTALL_UV:-1}"
+UV_PYTHON="${UV_PYTHON:-3.12}"
+export UV_PYTHON
+ASSUME_YES=0
+NO_INSTALL_UV=0
 DRY_RUN=0
+UV_BOOTSTRAPPED=0
 PASSTHRU=()
+
+usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  ./start.sh [local|server|install|run|doctor] [options] [-- extra-args]
+
+Commands:
+  local                 Install, then run local Telegram mode: app + Cloudflare tunnel + webhook sync (default)
+  server                Install, then run the plain app server
+  install               Install/setup only
+  run [local|server]    Run only, without installing
+  doctor [local|server] Check startup readiness
+
+Compatibility aliases:
+  up                    Same as local
+  --manager             Deprecated alias for local mode
+  --app                 Deprecated alias for server mode
+  --install-only        Same as install
+  --run-only            Same as run
+
+Options:
+  --local               Force local Telegram mode
+  --server              Force plain app server mode
+  --browser-use         Install Browser Use Chromium
+  --no-browser-use      Skip Browser Use Chromium install
+  --cloudflared         Install cloudflared when local mode needs it
+  --no-cloudflared      Never install cloudflared automatically
+  --yes, -y             Answer yes to installer prompts
+  --no-install-uv       Never install uv automatically
+  --dry-run             Print commands without running them
+  -h, --help            Show this help
+
+.env knobs:
+  START_MODE=local|server|auto  (app and manager are deprecated aliases)
+  INSTALL_BROWSER_USE=1|0
+  INSTALL_CLOUDFLARED=auto|1|0
+  INSTALL_UV=1|auto|0       (default: 1, bootstrap uv when missing)
+  UV_PYTHON=3.12            (default: 3.12)
+EOF_USAGE
+}
+
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_falsey() {
+  case "${1:-}" in
+    0|false|FALSE|no|NO|off|OFF) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_interactive() {
+  [[ -t 0 && -t 1 ]]
+}
+
+log() {
+  echo "[start] $*"
+}
+
+warn() {
+  echo "[start] warning: $*" >&2
+}
+
+die() {
+  echo "[start] error: $*" >&2
+  exit 1
+}
+
+run_cmd() {
+  log "$*"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+append_env_value() {
+  local key="$1"
+  local value="$2"
+  printf '\n%s=%s\n' "${key}" "${value}" >> "${REPO_ROOT}/.env"
+}
+
+env_is_set() {
+  local key="$1"
+  local value="${!key:-}"
+  [[ -n "${value}" && "${value}" != "..." ]]
+}
+
+telegram_allowlist_is_set() {
+  env_is_set "TELEGRAM_ALLOWED_USERNAMES" || env_is_set "TELEGRAM_ALLOWED_USER_IDS"
+}
+
+prompt_env_value() {
+  local key="$1"
+  local prompt="$2"
+  local secret="${3:-0}"
+  local default_value="${4:-}"
+  local value
+
+  if [[ "${secret}" == "1" ]]; then
+    read -r -s -p "${prompt}: " value
+    printf '\n'
+  elif [[ -n "${default_value}" ]]; then
+    read -r -p "${prompt} [${default_value}]: " value
+    value="${value:-${default_value}}"
+  else
+    read -r -p "${prompt}: " value
+  fi
+
+  value="${value//[$'\r\n']/}"
+  [[ -n "${value}" ]] || die "${key} cannot be blank"
+  append_env_value "${key}" "${value}"
+  export "${key}=${value}"
+  log "saved ${key} to .env"
+}
 
 load_dotenv() {
   if [[ -f "${REPO_ROOT}/.env" ]]; then
@@ -34,71 +159,57 @@ load_dotenv() {
   fi
 }
 
-usage() {
-  cat <<'EOF'
-Usage:
-  ./start.sh [up|install|run] [--app|--manager] [options] [-- extra-args]
-
-Defaults:
-  - mode: up      (install, then run)
-  - runtime: auto (app when PUBLIC_BASE_URL/RAILWAY_PUBLIC_DOMAIN is set, otherwise manager)
-
-Options:
-  --app                 Force direct app mode
-  --manager             Force quick-tunnel manager mode
-  --browser-use         Install Browser Use Chromium
-  --no-browser-use      Skip Browser Use Chromium install
-  --cloudflared         Install cloudflared when manager mode needs it
-  --no-cloudflared      Never install cloudflared automatically
-  --install-only        Install/setup only
-  --run-only            Run only
-  --dry-run             Print commands without running them
-  -h, --help            Show this help
-
-.env knobs:
-  START_MODE=auto|app|manager
-  INSTALL_BROWSER_USE=1|0
-  INSTALL_CLOUDFLARED=auto|1|0
-EOF
-}
-
-is_truthy() {
+normalize_runtime_mode() {
   case "${1:-}" in
-    1|true|TRUE|yes|YES|on|ON) return 0 ;;
-    *) return 1 ;;
+    local|server|auto|"")
+      printf '%s\n' "${1:-local}"
+      ;;
+    app)
+      warn "START_MODE=app is deprecated; use START_MODE=server."
+      printf '%s\n' "server"
+      ;;
+    manager)
+      warn "START_MODE=manager is deprecated; use START_MODE=local."
+      printf '%s\n' "local"
+      ;;
+    *)
+      die "invalid START_MODE/runtime mode: ${1}"
+      ;;
   esac
-}
-
-is_falsey() {
-  case "${1:-}" in
-    0|false|FALSE|no|NO|off|OFF) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-log() {
-  echo "[start] $*"
-}
-
-die() {
-  echo "[start] error: $*" >&2
-  exit 1
-}
-
-run_cmd() {
-  log "$*"
-  if [[ "${DRY_RUN}" == "1" ]]; then
-    return 0
-  fi
-  "$@"
 }
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      up|install|run)
-        MODE="$1"
+      local|server)
+        RUNTIME_MODE="$1"
+        MODE="up"
         shift
+        ;;
+      up)
+        MODE="up"
+        RUNTIME_MODE="${RUNTIME_MODE:-local}"
+        shift
+        ;;
+      install)
+        MODE="install"
+        shift
+        ;;
+      run)
+        MODE="run"
+        shift
+        if [[ $# -gt 0 && ( "$1" == "local" || "$1" == "server" ) ]]; then
+          RUNTIME_MODE="$1"
+          shift
+        fi
+        ;;
+      doctor)
+        MODE="doctor"
+        shift
+        if [[ $# -gt 0 && ( "$1" == "local" || "$1" == "server" ) ]]; then
+          RUNTIME_MODE="$1"
+          shift
+        fi
         ;;
       --install-only)
         MODE="install"
@@ -108,12 +219,22 @@ parse_args() {
         MODE="run"
         shift
         ;;
+      --local)
+        RUNTIME_MODE="local"
+        shift
+        ;;
+      --server)
+        RUNTIME_MODE="server"
+        shift
+        ;;
       --app)
-        RUNTIME_MODE="app"
+        warn "--app is deprecated; use server or --server."
+        RUNTIME_MODE="server"
         shift
         ;;
       --manager)
-        RUNTIME_MODE="manager"
+        warn "--manager is deprecated; use local or --local."
+        RUNTIME_MODE="local"
         shift
         ;;
       --browser-use)
@@ -130,6 +251,15 @@ parse_args() {
         ;;
       --no-cloudflared)
         INSTALL_CLOUDFLARED="0"
+        shift
+        ;;
+      --yes|-y)
+        ASSUME_YES="1"
+        shift
+        ;;
+      --no-install-uv)
+        NO_INSTALL_UV="1"
+        INSTALL_UV="0"
         shift
         ;;
       --dry-run)
@@ -154,25 +284,131 @@ parse_args() {
 }
 
 resolve_runtime_mode() {
-  case "${RUNTIME_MODE}" in
-    app|manager)
-      printf '%s\n' "${RUNTIME_MODE}"
+  local normalized
+  normalized="$(normalize_runtime_mode "${RUNTIME_MODE}")"
+  case "${normalized}" in
+    local|server)
+      printf '%s\n' "${normalized}"
       ;;
-    auto|"")
+    auto)
       if [[ -n "${PUBLIC_BASE_URL:-}" || -n "${RAILWAY_PUBLIC_DOMAIN:-}" ]]; then
-        printf '%s\n' "app"
+        printf '%s\n' "server"
       else
-        printf '%s\n' "manager"
+        printf '%s\n' "local"
       fi
       ;;
     *)
-      die "invalid START_MODE/runtime mode: ${RUNTIME_MODE}"
+      die "invalid runtime mode: ${normalized}"
       ;;
   esac
 }
 
+install_uv() {
+  if [[ "${DRY_RUN}" != "1" ]]; then
+    command -v curl >/dev/null 2>&1 || die "curl is required to install uv. Install uv manually: curl -LsSf https://astral.sh/uv/install.sh | sh"
+  fi
+  run_cmd sh -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
+  export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
+  UV_BOOTSTRAPPED=1
+}
+
 ensure_uv() {
-  command -v uv >/dev/null 2>&1 || die "uv is required but was not found in PATH"
+  if command -v uv >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ "${UV_BOOTSTRAPPED}" == "1" ]]; then
+    return 0
+  fi
+
+  if [[ "${NO_INSTALL_UV}" == "1" ]] || is_falsey "${INSTALL_UV}"; then
+    die "uv is required but was not found in PATH. Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+  fi
+
+  if is_truthy "${INSTALL_UV}" || [[ "${ASSUME_YES}" == "1" ]]; then
+    log "uv was not found in PATH; bootstrapping uv."
+    install_uv
+  elif is_interactive; then
+    read -r -p "uv is required and was not found. Install it now? [Y/n] " reply
+    case "${reply:-Y}" in
+      y|Y|yes|YES) install_uv ;;
+      *) die "uv is required. Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh" ;;
+    esac
+  else
+    die "uv is required but was not found in PATH. Re-run with --yes to install it, or install manually: curl -LsSf https://astral.sh/uv/install.sh | sh"
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    return 0
+  fi
+  command -v uv >/dev/null 2>&1 || die "uv install completed but uv is still not in PATH. Try opening a new shell or add ~/.local/bin to PATH."
+}
+
+ensure_env_file() {
+  if [[ -f "${REPO_ROOT}/.env" ]]; then
+    return 0
+  fi
+  [[ -f "${REPO_ROOT}/.env.example" ]] || die ".env is missing and .env.example was not found"
+  run_cmd cp "${REPO_ROOT}/.env.example" "${REPO_ROOT}/.env"
+}
+
+ensure_required_env() {
+  local runtime="$1"
+  local missing=()
+
+  if [[ "${MODE}" == "install" ]]; then
+    return 0
+  fi
+  ensure_env_file
+  load_dotenv
+
+  env_is_set "OPENAI_COMPATIBLE_API_KEY" || missing+=("OPENAI_COMPATIBLE_API_KEY")
+
+  if [[ "${runtime}" == "local" ]]; then
+    env_is_set "TELEGRAM_BOT_TOKEN" || missing+=("TELEGRAM_BOT_TOKEN")
+    if ! telegram_allowlist_is_set; then
+      missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
+    fi
+  fi
+
+  if [[ "${runtime}" == "server" ]]; then
+    env_is_set "TELEGRAM_BOT_TOKEN" || missing+=("TELEGRAM_BOT_TOKEN")
+    env_is_set "TELEGRAM_WEBHOOK_SECRET" || missing+=("TELEGRAM_WEBHOOK_SECRET")
+    env_is_set "PUBLIC_BASE_URL" || missing+=("PUBLIC_BASE_URL")
+    env_is_set "OPENTULPA_DATA_ROOT" || missing+=("OPENTULPA_DATA_ROOT")
+    if ! telegram_allowlist_is_set; then
+      missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
+    fi
+  fi
+
+  if ! env_is_set "COMPOSIO_API_KEY"; then
+    log "warning: COMPOSIO_API_KEY is not set; connector integrations such as Google Sheets and Instagram will be unavailable."
+  fi
+
+  if [[ "${#missing[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    log "required .env value(s) missing for ${runtime}: ${missing[*]}"
+    return 0
+  fi
+
+  if ! is_interactive; then
+    die "required .env value(s) missing for ${runtime}: ${missing[*]}. Set them in .env or run interactively to enter them."
+  fi
+
+  env_is_set "OPENAI_COMPATIBLE_API_KEY" || prompt_env_value "OPENAI_COMPATIBLE_API_KEY" "OPENAI_COMPATIBLE_API_KEY" 1
+  if [[ "${runtime}" == "local" || "${runtime}" == "server" ]]; then
+    env_is_set "TELEGRAM_BOT_TOKEN" || prompt_env_value "TELEGRAM_BOT_TOKEN" "TELEGRAM_BOT_TOKEN" 1
+    if ! telegram_allowlist_is_set; then
+      prompt_env_value "TELEGRAM_ALLOWED_USERNAMES" "TELEGRAM_ALLOWED_USERNAMES (comma-separated, no @)"
+    fi
+  fi
+  if [[ "${runtime}" == "server" ]]; then
+    env_is_set "TELEGRAM_WEBHOOK_SECRET" || prompt_env_value "TELEGRAM_WEBHOOK_SECRET" "TELEGRAM_WEBHOOK_SECRET" 1
+    env_is_set "PUBLIC_BASE_URL" || prompt_env_value "PUBLIC_BASE_URL" "PUBLIC_BASE_URL"
+    env_is_set "OPENTULPA_DATA_ROOT" || prompt_env_value "OPENTULPA_DATA_ROOT" "OPENTULPA_DATA_ROOT" 0 "/app/opentulpa_data"
+  fi
 }
 
 install_python_deps() {
@@ -219,7 +455,7 @@ ensure_cloudflared() {
     return 0
   fi
   if is_falsey "${INSTALL_CLOUDFLARED}"; then
-    die "cloudflared is required for manager mode but is not installed"
+    die "cloudflared is required for local mode but is not installed"
   fi
   case "$(uname -s)" in
     Darwin)
@@ -235,6 +471,7 @@ ensure_cloudflared() {
 }
 
 run_app() {
+  ensure_uv
   if ((${#PASSTHRU[@]})); then
     run_cmd uv run python -m opentulpa "${PASSTHRU[@]}"
     return 0
@@ -243,6 +480,7 @@ run_app() {
 }
 
 run_manager() {
+  ensure_uv
   if ((${#PASSTHRU[@]})); then
     run_cmd uv run python scripts/manager.py "${PASSTHRU[@]}"
     return 0
@@ -250,17 +488,101 @@ run_manager() {
   run_cmd uv run python scripts/manager.py
 }
 
-main() {
+doctor_check() {
+  local label="$1"
+  local ok="$2"
+  local fix="${3:-}"
+  if [[ "${ok}" == "1" ]]; then
+    echo "[doctor] ok: ${label}"
+  else
+    echo "[doctor] fail: ${label}"
+    if [[ -n "${fix}" ]]; then
+      echo "[doctor] fix: ${fix}"
+    fi
+    return 1
+  fi
+}
+
+run_doctor() {
+  local runtime="$1"
+  local failures=0
+
+  doctor_check "uv is available" "$(command -v uv >/dev/null 2>&1 && echo 1 || echo 0)" "curl -LsSf https://astral.sh/uv/install.sh | sh" || failures=$((failures + 1))
+  doctor_check ".env exists" "$([[ -f "${REPO_ROOT}/.env" ]] && echo 1 || echo 0)" "cp .env.example .env and set required values" || failures=$((failures + 1))
   load_dotenv
+  doctor_check "OPENAI_COMPATIBLE_API_KEY is set" "$(env_is_set "OPENAI_COMPATIBLE_API_KEY" && echo 1 || echo 0)" "set OPENAI_COMPATIBLE_API_KEY in .env" || failures=$((failures + 1))
+  doctor_check "TELEGRAM_BOT_TOKEN is set" "$(env_is_set "TELEGRAM_BOT_TOKEN" && echo 1 || echo 0)" "set TELEGRAM_BOT_TOKEN in .env" || failures=$((failures + 1))
+  doctor_check "Telegram allowlist is set" "$(telegram_allowlist_is_set && echo 1 || echo 0)" "set TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS in .env" || failures=$((failures + 1))
+  if env_is_set "COMPOSIO_API_KEY"; then
+    echo "[doctor] ok: COMPOSIO_API_KEY is set"
+  else
+    echo "[doctor] warn: COMPOSIO_API_KEY is not set; connector integrations such as Google Sheets and Instagram will be unavailable"
+  fi
+  if [[ "${runtime}" == "server" ]]; then
+    doctor_check "TELEGRAM_WEBHOOK_SECRET is set" "$(env_is_set "TELEGRAM_WEBHOOK_SECRET" && echo 1 || echo 0)" "set a stable TELEGRAM_WEBHOOK_SECRET in .env" || failures=$((failures + 1))
+    doctor_check "PUBLIC_BASE_URL is set" "$(env_is_set "PUBLIC_BASE_URL" && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL" || failures=$((failures + 1))
+    doctor_check "OPENTULPA_DATA_ROOT is set" "$(env_is_set "OPENTULPA_DATA_ROOT" && echo 1 || echo 0)" "set OPENTULPA_DATA_ROOT=/app/opentulpa_data and mount persistent storage there" || failures=$((failures + 1))
+    if env_is_set "OPENTULPA_DATA_ROOT"; then
+      doctor_check "OPENTULPA_DATA_ROOT is writable" "$(mkdir -p "${OPENTULPA_DATA_ROOT}" 2>/dev/null && [[ -w "${OPENTULPA_DATA_ROOT}" ]] && echo 1 || echo 0)" "mount a writable persistent volume at OPENTULPA_DATA_ROOT" || failures=$((failures + 1))
+    fi
+  fi
+  doctor_check ".opentulpa is writable" "$(mkdir -p "${REPO_ROOT}/.opentulpa" 2>/dev/null && [[ -w "${REPO_ROOT}/.opentulpa" ]] && echo 1 || echo 0)" "make .opentulpa writable" || failures=$((failures + 1))
+  doctor_check "tulpa_stuff is writable" "$(mkdir -p "${REPO_ROOT}/tulpa_stuff" 2>/dev/null && [[ -w "${REPO_ROOT}/tulpa_stuff" ]] && echo 1 || echo 0)" "make tulpa_stuff writable" || failures=$((failures + 1))
+
+  if command -v lsof >/dev/null 2>&1; then
+    local listeners
+    listeners="$(lsof -t -iTCP:"${PORT:-8000}" -sTCP:LISTEN 2>/dev/null || true)"
+    if [[ -n "${listeners}" ]]; then
+      echo "[doctor] info: port ${PORT:-8000} is already in use by PID(s): ${listeners//$'\n'/,}"
+    else
+      echo "[doctor] ok: port ${PORT:-8000} is free"
+    fi
+  else
+    echo "[doctor] info: lsof not available; skipping port check"
+  fi
+
+  if [[ "${runtime}" == "local" ]]; then
+    doctor_check "cloudflared is available for local mode" "$(command -v cloudflared >/dev/null 2>&1 && echo 1 || echo 0)" "install cloudflared or run ./start.sh server" || failures=$((failures + 1))
+  fi
+
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsS "http://127.0.0.1:${PORT:-8000}/healthz" >/dev/null 2>&1; then
+      echo "[doctor] ok: /healthz is responding"
+    else
+      echo "[doctor] info: /healthz is not responding; app may not be running"
+    fi
+    if curl -fsS "http://127.0.0.1:${PORT:-8000}/agent/healthz" >/dev/null 2>&1; then
+      echo "[doctor] ok: /agent/healthz is responding"
+    else
+      echo "[doctor] info: /agent/healthz is not responding; app may not be running"
+    fi
+  else
+    echo "[doctor] info: curl not available; skipping health endpoint checks"
+  fi
+
+  if [[ "${failures}" -gt 0 ]]; then
+    die "doctor found ${failures} problem(s)"
+  fi
+  log "doctor checks passed."
+}
+
+main() {
   parse_args "$@"
+  RUNTIME_MODE="$(normalize_runtime_mode "${RUNTIME_MODE}")"
+  load_dotenv
 
   local runtime
   runtime="$(resolve_runtime_mode)"
 
+  if [[ "${MODE}" == "doctor" ]]; then
+    run_doctor "${runtime}"
+    return 0
+  fi
+
   if [[ "${MODE}" != "run" ]]; then
     install_python_deps
     install_browser_use_deps
-    if [[ "${runtime}" == "manager" ]]; then
+    if [[ "${runtime}" == "local" ]]; then
       ensure_cloudflared
     fi
   fi
@@ -269,13 +591,15 @@ main() {
     return 0
   fi
 
-  if [[ "${runtime}" == "app" ]]; then
-    log "running direct app mode."
+  ensure_required_env "${runtime}"
+
+  if [[ "${runtime}" == "server" ]]; then
+    log "running server mode."
     run_app
     return 0
   fi
 
-  log "running quick-tunnel manager mode."
+  log "running local Telegram mode."
   run_manager
 }
 

--- a/start.sh
+++ b/start.sh
@@ -114,6 +114,10 @@ telegram_allowlist_is_set() {
   env_is_set "TELEGRAM_ALLOWED_USERNAMES" || env_is_set "TELEGRAM_ALLOWED_USER_IDS"
 }
 
+public_base_url_is_set() {
+  env_is_set "PUBLIC_BASE_URL" || env_is_set "RAILWAY_PUBLIC_DOMAIN"
+}
+
 yaml_value_is_set() {
   local key="$1"
   local line value
@@ -492,7 +496,7 @@ ensure_env_file() {
   if [[ -f "${REPO_ROOT}/.env" ]]; then
     return 0
   fi
-  [[ -f "${REPO_ROOT}/.env.example" ]] || die ".env is missing and .env.example was not found"
+  [[ -f "${REPO_ROOT}/.env.example" ]] || return 1
   run_cmd cp "${REPO_ROOT}/.env.example" "${REPO_ROOT}/.env"
 }
 
@@ -503,7 +507,7 @@ ensure_required_env() {
   if [[ "${MODE}" == "install" ]]; then
     return 0
   fi
-  ensure_env_file
+  ensure_env_file || true
   load_dotenv
 
   env_is_set "OPENAI_COMPATIBLE_API_KEY" || missing+=("OPENAI_COMPATIBLE_API_KEY")
@@ -518,7 +522,7 @@ ensure_required_env() {
   if [[ "${runtime}" == "server" ]]; then
     env_is_set "TELEGRAM_BOT_TOKEN" || missing+=("TELEGRAM_BOT_TOKEN")
     env_is_set "TELEGRAM_WEBHOOK_SECRET" || missing+=("TELEGRAM_WEBHOOK_SECRET")
-    env_is_set "PUBLIC_BASE_URL" || missing+=("PUBLIC_BASE_URL")
+    public_base_url_is_set || missing+=("PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN")
     env_is_set "OPENTULPA_DATA_ROOT" || missing+=("OPENTULPA_DATA_ROOT")
     if ! telegram_allowlist_is_set; then
       missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
@@ -553,7 +557,7 @@ ensure_required_env() {
   fi
   if [[ "${runtime}" == "server" ]]; then
     env_is_set "TELEGRAM_WEBHOOK_SECRET" || prompt_env_value "TELEGRAM_WEBHOOK_SECRET" "TELEGRAM_WEBHOOK_SECRET" 1
-    env_is_set "PUBLIC_BASE_URL" || prompt_env_value "PUBLIC_BASE_URL" "PUBLIC_BASE_URL"
+    public_base_url_is_set || prompt_env_value "PUBLIC_BASE_URL" "PUBLIC_BASE_URL"
     env_is_set "OPENTULPA_DATA_ROOT" || prompt_env_value "OPENTULPA_DATA_ROOT" "OPENTULPA_DATA_ROOT" 0 "/app/opentulpa_data"
   fi
 }
@@ -655,7 +659,11 @@ run_doctor() {
   local failures=0
 
   doctor_check "uv is available" "$(command -v uv >/dev/null 2>&1 && echo 1 || echo 0)" "curl -LsSf https://astral.sh/uv/install.sh | sh" || failures=$((failures + 1))
-  doctor_check ".env exists" "$([[ -f "${REPO_ROOT}/.env" ]] && echo 1 || echo 0)" "cp .env.example .env and set required values" || failures=$((failures + 1))
+  if [[ -f "${REPO_ROOT}/.env" ]]; then
+    echo "[doctor] ok: .env exists"
+  else
+    echo "[doctor] info: .env is missing; relying on process environment variables"
+  fi
   load_dotenv
   doctor_check "OPENAI_COMPATIBLE_API_KEY is set" "$(env_is_set "OPENAI_COMPATIBLE_API_KEY" && echo 1 || echo 0)" "set OPENAI_COMPATIBLE_API_KEY in .env" || failures=$((failures + 1))
   doctor_check "TELEGRAM_BOT_TOKEN is set" "$(env_is_set "TELEGRAM_BOT_TOKEN" && echo 1 || echo 0)" "set TELEGRAM_BOT_TOKEN in .env" || failures=$((failures + 1))
@@ -669,7 +677,7 @@ run_doctor() {
   check_model_catalog
   if [[ "${runtime}" == "server" ]]; then
     doctor_check "TELEGRAM_WEBHOOK_SECRET is set" "$(env_is_set "TELEGRAM_WEBHOOK_SECRET" && echo 1 || echo 0)" "set a stable TELEGRAM_WEBHOOK_SECRET in .env" || failures=$((failures + 1))
-    doctor_check "PUBLIC_BASE_URL is set" "$(env_is_set "PUBLIC_BASE_URL" && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL" || failures=$((failures + 1))
+    doctor_check "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN is set" "$(public_base_url_is_set && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL, or rely on Railway's RAILWAY_PUBLIC_DOMAIN" || failures=$((failures + 1))
     doctor_check "OPENTULPA_DATA_ROOT is set" "$(env_is_set "OPENTULPA_DATA_ROOT" && echo 1 || echo 0)" "set OPENTULPA_DATA_ROOT=/app/opentulpa_data and mount persistent storage there" || failures=$((failures + 1))
     if env_is_set "OPENTULPA_DATA_ROOT"; then
       doctor_check "OPENTULPA_DATA_ROOT is writable" "$(mkdir -p "${OPENTULPA_DATA_ROOT}" 2>/dev/null && [[ -w "${OPENTULPA_DATA_ROOT}" ]] && echo 1 || echo 0)" "mount a writable persistent volume at OPENTULPA_DATA_ROOT" || failures=$((failures + 1))

--- a/start.sh
+++ b/start.sh
@@ -114,6 +114,37 @@ telegram_allowlist_is_set() {
   env_is_set "TELEGRAM_ALLOWED_USERNAMES" || env_is_set "TELEGRAM_ALLOWED_USER_IDS"
 }
 
+yaml_value_is_set() {
+  local key="$1"
+  local line value
+  line="$(grep -E "^[[:space:]]*${key}:[[:space:]]*" "${REPO_ROOT}/opentulpa.config.yaml" 2>/dev/null | head -n 1 || true)"
+  [[ -n "${line}" ]] || return 1
+  value="${line#*:}"
+  value="${value%%#*}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  [[ -n "${value}" && "${value}" != "null" && "${value}" != "\"\"" && "${value}" != "''" ]]
+}
+
+multimodal_model_is_set() {
+  env_is_set "MULTIMODAL_LLM" || yaml_value_is_set "multimodal_llm"
+}
+
+openrouter_base_url_is_set() {
+  local base="${OPENAI_COMPATIBLE_BASE_URL:-${OPENROUTER_BASE_URL:-}}"
+  base="$(printf '%s' "${base}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${base}" == *"openrouter.ai"* ]]
+}
+
+emit_model_config_notice() {
+  if ! multimodal_model_is_set; then
+    log "warning: MULTIMODAL_LLM is not set and opentulpa.config.yaml has no multimodal_llm; image/file/browser functionality may not work."
+  fi
+  if ! openrouter_base_url_is_set; then
+    log "warning: OPENAI_COMPATIBLE_BASE_URL is not OpenRouter. Check opentulpa.config.yaml model settings, especially multimodal_llm, memory_llm_model, and business_knowledge_oracle_model."
+  fi
+}
+
 prompt_env_value() {
   local key="$1"
   local prompt="$2"
@@ -383,6 +414,7 @@ ensure_required_env() {
   if ! env_is_set "COMPOSIO_API_KEY"; then
     log "warning: COMPOSIO_API_KEY is not set; connector integrations such as Google Sheets and Instagram will be unavailable."
   fi
+  emit_model_config_notice
 
   if [[ "${#missing[@]}" -eq 0 ]]; then
     return 0

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -54,7 +54,7 @@ def test_start_script_dry_run_server_mode() -> None:
     assert "required .env value(s) missing for server:" in result.stdout
     assert "OPENAI_COMPATIBLE_API_KEY" in result.stdout
     assert "TELEGRAM_WEBHOOK_SECRET" in result.stdout
-    assert "PUBLIC_BASE_URL" in result.stdout
+    assert "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN" in result.stdout
     assert "OPENTULPA_DATA_ROOT" in result.stdout
     assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" in result.stdout
     assert "warning: COMPOSIO_API_KEY is not set" in result.stdout
@@ -204,3 +204,47 @@ exit 22
     assert "memory_llm_model=google/gemini-3-flash-preview" in result.stdout
     assert "multimodal_llm=google/gemini-3-flash-preview" in result.stdout
     assert "openai_compatible_embedding_model=openai/text-embedding-3-small" in result.stdout
+
+
+def test_start_script_run_server_accepts_platform_env_without_dotenv(tmp_path: Path) -> None:
+    script = tmp_path / "start.sh"
+    script.write_text((REPO_ROOT / "start.sh").read_text(encoding="utf-8"), encoding="utf-8")
+    script.chmod(0o755)
+    env = {
+        "OPENAI_COMPATIBLE_API_KEY": "test-key",
+        "OPENAI_COMPATIBLE_BASE_URL": "https://openrouter.ai/api/v1",
+        "TELEGRAM_BOT_TOKEN": "test-token",
+        "TELEGRAM_WEBHOOK_SECRET": "test-secret",
+        "RAILWAY_PUBLIC_DOMAIN": "opentulpa.example.railway.app",
+        "OPENTULPA_DATA_ROOT": str(tmp_path / "data"),
+        "TELEGRAM_ALLOWED_USERNAMES": "owner",
+        "TELEGRAM_ALLOWED_USER_IDS": "",
+        "COMPOSIO_API_KEY": "",
+    }
+
+    result = subprocess.run(
+        ["bash", "./start.sh", "run", "server", "--dry-run"],
+        cwd=tmp_path,
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert ".env is missing" not in result.stderr
+    assert ".env.example was not found" not in result.stderr
+    assert "required .env value(s) missing" not in result.stdout
+    assert "uv run python -m opentulpa" in result.stdout
+
+
+def test_start_script_server_accepts_railway_public_domain_fallback() -> None:
+    env = {
+        **EMPTY_REQUIRED_ENV,
+        "RAILWAY_PUBLIC_DOMAIN": "opentulpa.example.railway.app",
+    }
+
+    result = _run_start("server", "--dry-run", env=env)
+
+    assert result.returncode == 0
+    assert "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN" not in result.stdout

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -161,4 +161,46 @@ def test_start_script_warns_when_base_url_is_not_openrouter() -> None:
     assert result.returncode == 0
     assert "OPENAI_COMPATIBLE_BASE_URL is not OpenRouter" in result.stdout
     assert "opentulpa.config.yaml model settings" in result.stdout
+    assert "llm_model" in result.stdout
+    assert "wake_execution_model" in result.stdout
+    assert "workflow_setup_input_classifier_model" in result.stdout
+    assert "memory_llm_model" in result.stdout
     assert "multimodal_llm" in result.stdout
+    assert "business_knowledge_oracle_model" in result.stdout
+    assert "openai_compatible_embedding_model" in result.stdout
+    assert "browser_use_model" in result.stdout
+
+
+def test_start_script_doctor_warns_for_configured_models_missing_from_catalog(tmp_path: Path) -> None:
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+if [[ "$*" == *"/models"* ]]; then
+  printf '%s\n' '{"data":[{"id":"z-ai/glm-5.1"}]}'
+  exit 0
+fi
+exit 22
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = {
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "OPENAI_COMPATIBLE_API_KEY": "test-key",
+        "OPENAI_COMPATIBLE_BASE_URL": "https://provider.example/v1",
+        "TELEGRAM_BOT_TOKEN": "test-token",
+        "TELEGRAM_WEBHOOK_SECRET": "test-secret",
+        "PUBLIC_BASE_URL": "https://app.example",
+        "OPENTULPA_DATA_ROOT": str(tmp_path / "data"),
+        "TELEGRAM_ALLOWED_USERNAMES": "owner",
+        "TELEGRAM_ALLOWED_USER_IDS": "",
+        "COMPOSIO_API_KEY": "",
+    }
+
+    result = _run_start("doctor", "server", env=env)
+
+    assert result.returncode == 0
+    assert "https://provider.example/v1/models did not list configured model(s)" in result.stdout
+    assert "memory_llm_model=google/gemini-3-flash-preview" in result.stdout
+    assert "multimodal_llm=google/gemini-3-flash-preview" in result.stdout
+    assert "openai_compatible_embedding_model=openai/text-embedding-3-small" in result.stdout

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -14,6 +14,7 @@ EMPTY_REQUIRED_ENV = {
     "COMPOSIO_API_KEY": "",
     "TELEGRAM_ALLOWED_USERNAMES": "",
     "TELEGRAM_ALLOWED_USER_IDS": "",
+    "OPENAI_COMPATIBLE_BASE_URL": "https://openrouter.ai/api/v1",
 }
 
 
@@ -144,3 +145,20 @@ def test_start_script_missing_uv_dry_run_bootstraps_by_default_then_syncs() -> N
     assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in result.stdout
     assert "[start] uv sync" in result.stdout
     assert "uv run python -m opentulpa" in result.stdout
+
+
+def test_start_script_warns_when_base_url_is_not_openrouter() -> None:
+    env = {
+        **EMPTY_REQUIRED_ENV,
+        "OPENAI_COMPATIBLE_BASE_URL": "https://api.openai.com/v1",
+    }
+    result = _run_start(
+        "server",
+        "--dry-run",
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "OPENAI_COMPATIBLE_BASE_URL is not OpenRouter" in result.stdout
+    assert "opentulpa.config.yaml model settings" in result.stdout
+    assert "multimodal_llm" in result.stdout

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -5,6 +5,16 @@ import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+EMPTY_REQUIRED_ENV = {
+    "OPENAI_COMPATIBLE_API_KEY": "",
+    "TELEGRAM_BOT_TOKEN": "",
+    "TELEGRAM_WEBHOOK_SECRET": "",
+    "PUBLIC_BASE_URL": "",
+    "OPENTULPA_DATA_ROOT": "",
+    "COMPOSIO_API_KEY": "",
+    "TELEGRAM_ALLOWED_USERNAMES": "",
+    "TELEGRAM_ALLOWED_USER_IDS": "",
+}
 
 
 def _run_start(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -25,30 +35,55 @@ def test_start_script_help_shows_install_and_runtime_flags() -> None:
     result = _run_start("--help")
 
     assert result.returncode == 0
-    assert "up|install|run" in result.stdout
-    assert "--app" in result.stdout
-    assert "--manager" in result.stdout
+    assert "local|server|install|run|doctor" in result.stdout
+    assert "--yes" in result.stdout
+    assert "--no-install-uv" in result.stdout
     assert "--browser-use" in result.stdout
+    assert "UV_PYTHON=3.12" in result.stdout
 
 
-def test_start_script_dry_run_direct_app_mode() -> None:
+def test_start_script_dry_run_server_mode() -> None:
     result = _run_start(
+        "server",
         "--dry-run",
-        "--run-only",
-        env={"PUBLIC_BASE_URL": "https://example.com"},
+        env=EMPTY_REQUIRED_ENV,
     )
 
     assert result.returncode == 0
-    assert "[start] running direct app mode." in result.stdout
+    assert "required .env value(s) missing for server:" in result.stdout
+    assert "OPENAI_COMPATIBLE_API_KEY" in result.stdout
+    assert "TELEGRAM_WEBHOOK_SECRET" in result.stdout
+    assert "PUBLIC_BASE_URL" in result.stdout
+    assert "OPENTULPA_DATA_ROOT" in result.stdout
+    assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" in result.stdout
+    assert "warning: COMPOSIO_API_KEY is not set" in result.stdout
+    assert "[start] running server mode." in result.stdout
     assert "uv run python -m opentulpa" in result.stdout
     assert "scripts/manager.py" not in result.stdout
+
+
+def test_start_script_dry_run_local_mode() -> None:
+    result = _run_start(
+        "local",
+        "--dry-run",
+        env=EMPTY_REQUIRED_ENV,
+    )
+
+    assert result.returncode == 0
+    assert "required .env value(s) missing for local:" in result.stdout
+    assert "TELEGRAM_BOT_TOKEN" in result.stdout
+    assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" in result.stdout
+    assert "warning: COMPOSIO_API_KEY is not set" in result.stdout
+    assert "OPENTULPA_DATA_ROOT" not in result.stdout
+    assert "[start] running local Telegram mode." in result.stdout
+    assert "uv run python scripts/manager.py" in result.stdout
 
 
 def test_start_script_dry_run_install_only_skips_browser_use_when_disabled() -> None:
     result = _run_start(
         "--dry-run",
         "--install-only",
-        "--app",
+        "--server",
         "--no-browser-use",
     )
 
@@ -56,3 +91,56 @@ def test_start_script_dry_run_install_only_skips_browser_use_when_disabled() -> 
     assert "[start] uv sync" in result.stdout
     assert "skipping Browser Use Chromium install." in result.stdout
     assert "playwright install chromium" not in result.stdout
+
+
+def test_start_script_deprecated_app_alias_maps_to_server_mode() -> None:
+    result = _run_start(
+        "--dry-run",
+        "--run-only",
+        "--app",
+    )
+
+    assert result.returncode == 0
+    assert "--app is deprecated" in result.stderr
+    assert "[start] running server mode." in result.stdout
+    assert "uv run python -m opentulpa" in result.stdout
+
+
+def test_start_script_deprecated_manager_alias_maps_to_local_mode() -> None:
+    result = _run_start(
+        "--dry-run",
+        "--run-only",
+        "--manager",
+    )
+
+    assert result.returncode == 0
+    assert "--manager is deprecated" in result.stderr
+    assert "[start] running local Telegram mode." in result.stdout
+    assert "uv run python scripts/manager.py" in result.stdout
+
+
+def test_start_script_missing_uv_with_no_install_fails_with_install_command() -> None:
+    result = _run_start(
+        "server",
+        "--dry-run",
+        "--no-install-uv",
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert result.returncode != 0
+    assert "uv is required but was not found in PATH" in result.stderr
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in result.stderr
+
+
+def test_start_script_missing_uv_dry_run_bootstraps_by_default_then_syncs() -> None:
+    result = _run_start(
+        "server",
+        "--dry-run",
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert result.returncode == 0
+    assert "uv was not found in PATH; bootstrapping uv." in result.stdout
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in result.stdout
+    assert "[start] uv sync" in result.stdout
+    assert "uv run python -m opentulpa" in result.stdout


### PR DESCRIPTION
## Summary

Implements Linear issue [OPE-38](https://linear.app/opentulpa/issue/OPE-38/unify-opentulpa-install-and-startup-entrypoint) by making `./start.sh` the canonical uv-first install/start entrypoint for OpenTulpa.

## What changed

- Adds clear startup modes:
  - `./start.sh local` for app + Cloudflare tunnel + Telegram webhook sync
  - `./start.sh server` for plain app server startup
  - `./start.sh run server` for already-built environments such as Railway/Docker
  - `./start.sh doctor` for readiness diagnostics
- Keeps deprecated aliases working:
  - `--manager` -> `local`
  - `--app` -> `server`
- Bootstraps `uv` by default when missing, after checking `PATH` first.
- Pins local uv startup to Python 3.12 via `UV_PYTHON=3.12` to match Docker/Railway more closely.
- Copies `.env.example` to `.env` when missing and reports exactly which required values are absent.
- Makes Telegram allowlist explicit as `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`.
- Treats `COMPOSIO_API_KEY` as highly recommended, not required, with a clear warning when missing.
- Adds optional Docker Compose server mode with a persistent `/app/opentulpa_data` volume.
- Moves Railway to the server entrypoint via `./start.sh run server`.
- Documents support-operator access and clarifies that normal allowed Telegram users are not automatically merged into one owner tenant.

## Required env behavior

Local mode requires:

- `OPENAI_COMPATIBLE_API_KEY`
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`

Server mode requires:

- `OPENAI_COMPATIBLE_API_KEY`
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_WEBHOOK_SECRET`
- `PUBLIC_BASE_URL`
- `OPENTULPA_DATA_ROOT`
- `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`

`COMPOSIO_API_KEY` now warns when absent because Google Sheets, Instagram, and other connector integrations will be unavailable, but it does not block startup.

## Validation

- `bash -n start.sh`
- `uv run pytest tests/test_start_script.py -q`
- `docker compose config --quiet`
- Fresh sandbox dry-runs for missing envs and missing uv
- Fresh sandbox server smoke test with `/healthz` and `/agent/healthz`