### PR TITLE
OPE-41 stabilize Telegram Business webhook diagnostics

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -1,5 +1,6 @@
 """OpenTulpa entry point."""
 
+import json
 import os
 import secrets
 import shutil
@@ -26,6 +27,17 @@ from opentulpa.memory.service import MemoryService
 from opentulpa.scheduler.service import SchedulerService
 from opentulpa.skills.service import SkillStoreService
 from opentulpa.tasks.service import TaskService
+
+TELEGRAM_WEBHOOK_ALLOWED_UPDATES = [
+    "message",
+    "edited_message",
+    "callback_query",
+    "my_chat_member",
+    "business_connection",
+    "business_message",
+    "edited_business_message",
+    "deleted_business_messages",
+]
 
 
 async def _wake_callback(payload: dict) -> None:
@@ -201,7 +213,11 @@ def _auto_configure_telegram_webhook(settings: Any) -> None:
         return
     webhook_secret = _ensure_telegram_webhook_secret(settings)
     webhook_url = f"{public_base_url}/webhook/telegram"
-    payload = {"url": webhook_url, "secret_token": webhook_secret}
+    payload = {
+        "url": webhook_url,
+        "secret_token": webhook_secret,
+        "allowed_updates": json.dumps(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+    }
     try:
         import httpx
 
@@ -218,7 +234,10 @@ def _auto_configure_telegram_webhook(settings: Any) -> None:
             return
         data = response.json() if response.content else {}
         if bool(data.get("ok")):
-            print(f"Telegram webhook configured: {webhook_url}")
+            print(
+                "Telegram webhook configured: "
+                f"{webhook_url} allowed_updates={','.join(TELEGRAM_WEBHOOK_ALLOWED_UPDATES)}"
+            )
         else:
             print(
                 f"Telegram webhook auto-config failed: {data.get('description', 'unknown error')}",

--- a/src/opentulpa/api/routes/telegram_webhook.py
+++ b/src/opentulpa/api/routes/telegram_webhook.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import json
 import logging
 from collections.abc import Callable
 from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
@@ -17,8 +20,42 @@ from opentulpa.interfaces.telegram.client import (
     parse_telegram_update,
 )
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
+from opentulpa.tasks.sandbox import PROJECT_ROOT
 
 logger = logging.getLogger(__name__)
+_TELEGRAM_BUSINESS_UPDATE_KEYS = (
+    "business_connection",
+    "business_message",
+    "edited_business_message",
+    "deleted_business_messages",
+)
+
+
+def _telegram_webhook_log_path(*, now: datetime | None = None) -> Path:
+    stamp = (now or datetime.now(UTC)).astimezone(UTC).date().isoformat()
+    return (
+        PROJECT_ROOT / ".opentulpa" / "logs" / "webhooks" / f"telegram-webhook-{stamp}.jsonl"
+    ).resolve()
+
+
+def _top_level_update_keys(body: dict[str, Any]) -> list[str]:
+    return sorted(str(key) for key in body if key != "message")
+
+
+def _write_telegram_webhook_event(event: str, **fields: Any) -> None:
+    payload = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event": event,
+        **fields,
+    }
+    try:
+        path = _telegram_webhook_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+    except Exception:
+        logger.debug("failed to write telegram webhook diagnostic event", exc_info=True)
 
 
 def _track_background_task(app: FastAPI, task: asyncio.Task[Any]) -> None:
@@ -65,8 +102,27 @@ def register_telegram_webhook_routes(
             )
         incoming_secret = str(request.headers.get("x-telegram-bot-api-secret-token", "") or "").strip()
         if not hmac.compare_digest(incoming_secret, expected_secret):
+            _write_telegram_webhook_event(
+                "rejected_invalid_secret",
+                has_secret_header=bool(incoming_secret),
+                client_host=str(getattr(request.client, "host", "") or ""),
+            )
+            logger.warning(
+                "telegram webhook rejected invalid secret: has_secret_header=%s client_host=%s",
+                bool(incoming_secret),
+                str(getattr(request.client, "host", "") or ""),
+            )
             return JSONResponse(status_code=403, content={"detail": "invalid telegram secret"})
         body = await request.json()
+        update_keys = _top_level_update_keys(body) if isinstance(body, dict) else []
+        _write_telegram_webhook_event(
+            "accepted",
+            update_id=body.get("update_id") if isinstance(body, dict) else None,
+            update_keys=update_keys,
+            has_business_update=any(key in body for key in _TELEGRAM_BUSINESS_UPDATE_KEYS)
+            if isinstance(body, dict)
+            else False,
+        )
 
         # Return 200 before long-running agent work so Telegram does not retry the same update.
         _track_background_task(app, asyncio.create_task(_telegram_background_handler(body=body)))
@@ -75,6 +131,24 @@ def register_telegram_webhook_routes(
     async def _telegram_background_handler(body: dict[str, Any]) -> None:
         business_result = get_telegram_business().ingest_update(body)
         if bool(business_result.get("handled")):
+            _write_telegram_webhook_event(
+                "business_update_handled",
+                update_id=body.get("update_id"),
+                kind=str(business_result.get("kind", "") or ""),
+                business_connection_id=str(business_result.get("business_connection_id", "") or ""),
+                customer_id=str(business_result.get("customer_id", "") or ""),
+                chat_id=str(business_result.get("chat_id", "") or ""),
+                message_id=str(business_result.get("message_id", "") or ""),
+                trigger_workflows=bool(business_result.get("trigger_workflows")),
+            )
+            logger.info(
+                "telegram business update handled: kind=%s business_connection_id=%s "
+                "customer_id=%s trigger_workflows=%s",
+                str(business_result.get("kind", "") or ""),
+                str(business_result.get("business_connection_id", "") or ""),
+                str(business_result.get("customer_id", "") or ""),
+                bool(business_result.get("trigger_workflows")),
+            )
             if bool(business_result.get("trigger_workflows")):
                 customer_id = str(business_result.get("customer_id", "") or "").strip()
                 business_connection_id = str(
@@ -87,6 +161,7 @@ def register_telegram_webhook_routes(
                         customer_id=customer_id,
                         include_disabled=False,
                     )
+                    matched_workflows = 0
                     for workflow in workflows:
                         if str(workflow.get("channel", "")).strip() != "telegram_business_dm":
                             continue
@@ -98,6 +173,7 @@ def register_telegram_webhook_routes(
                             conversation_id=conversation_id,
                         ):
                             continue
+                        matched_workflows += 1
                         intake_workflows = get_intake_workflows()
                         enqueue_run = getattr(
                             intake_workflows,
@@ -119,6 +195,16 @@ def register_telegram_webhook_routes(
                                 event_type="telegram_business_webhook",
                             )
                         summary = str(result.get("summary", "") or "").strip()
+                        _write_telegram_webhook_event(
+                            "business_workflow_run",
+                            update_id=body.get("update_id"),
+                            workflow_id=str(workflow.get("workflow_id", "") or "").strip(),
+                            customer_id=customer_id,
+                            business_connection_id=business_connection_id,
+                            conversation_id=conversation_id,
+                            ok=bool(result.get("ok", False)),
+                            has_summary=bool(summary),
+                        )
                         if (
                             not bool(result.get("ok", False))
                             and owner_chat_id
@@ -131,6 +217,15 @@ def register_telegram_webhook_routes(
                                     text=f"Telegram Business workflow issue: {summary}",
                                     parse_mode="HTML",
                                 )
+                    _write_telegram_webhook_event(
+                        "business_workflow_match_summary",
+                        update_id=body.get("update_id"),
+                        customer_id=customer_id,
+                        business_connection_id=business_connection_id,
+                        conversation_id=conversation_id,
+                        workflow_count=len(workflows),
+                        matched_workflow_count=matched_workflows,
+                    )
             return
 
         callback_id, _callback_user_id, callback_chat_id, _callback_data, _callback_message_id = (

--- a/tests/test_main_bootstrap.py
+++ b/tests/test_main_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import types
@@ -104,6 +105,55 @@ def test_ensure_telegram_webhook_secret_generates_when_missing(monkeypatch) -> N
     generated = entry._ensure_telegram_webhook_secret(settings)
     assert generated
     assert os.environ.get("TELEGRAM_WEBHOOK_SECRET") == generated
+
+
+def test_auto_configure_telegram_webhook_posts_secret_and_business_updates(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _Resp:
+        status_code = 200
+        content = b'{"ok":true}'
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"ok": True}
+
+    class _Client:
+        def __init__(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, data: dict[str, object] | None = None) -> _Resp:
+            calls.append({"url": url, "data": data or {}})
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.com/")
+    settings = SimpleNamespace(
+        telegram_bot_token="123:abc",
+        telegram_webhook_secret="settings-secret",
+    )
+
+    entry._auto_configure_telegram_webhook(settings)
+
+    assert len(calls) == 1
+    assert str(calls[0]["url"]).endswith("/setWebhook")
+    payload = calls[0]["data"]
+    assert isinstance(payload, dict)
+    assert payload["url"] == "https://example.com/webhook/telegram"
+    assert payload["secret_token"] == "settings-secret"
+    allowed_updates = json.loads(str(payload["allowed_updates"]))
+    assert "business_connection" in allowed_updates
+    assert "business_message" in allowed_updates
+    assert "edited_business_message" in allowed_updates
+    assert "deleted_business_messages" in allowed_updates
 
 
 def test_telegram_bot_commands_include_debug_logs() -> None:

--- a/tests/test_telegram_business_webhook.py
+++ b/tests/test_telegram_business_webhook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -7,6 +8,7 @@ from types import SimpleNamespace
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from opentulpa.api.routes import telegram_webhook as telegram_webhook_module
 from opentulpa.api.routes.telegram_webhook import register_telegram_webhook_routes
 from opentulpa.interfaces.telegram.business import TelegramBusinessService
 
@@ -142,3 +144,69 @@ def test_business_message_webhook_triggers_matching_workflow_and_notifies_owner(
     ]
     assert telegram_client.messages[0]["chat_id"] == "777"
     assert "Telegram Business workflow issue: send failed" in str(telegram_client.messages[0]["text"])
+
+
+def test_telegram_webhook_writes_debug_log_events_for_secret_and_business_updates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(telegram_webhook_module, "PROJECT_ROOT", tmp_path)
+    app = FastAPI()
+    telegram_client = _RecordingTelegramClient()
+    telegram_business = TelegramBusinessService(db_path=tmp_path / "telegram_business.db")
+    settings = SimpleNamespace(
+        telegram_bot_token="bot-token",
+        telegram_webhook_secret="secret-token",
+        telegram_allowed_user_ids=None,
+        telegram_allowed_usernames=None,
+    )
+
+    register_telegram_webhook_routes(
+        app,
+        settings=settings,
+        get_telegram_client=lambda: telegram_client,
+        get_telegram_business=lambda: telegram_business,
+        get_intake_workflows=lambda: _FakeIntakeWorkflows(),
+        get_telegram_chat=lambda: _FakeTelegramChat(),
+        get_agent_runtime=lambda: object(),
+    )
+
+    with TestClient(app) as client:
+        rejected = client.post(
+            "/webhook/telegram",
+            json={"update_id": 1},
+            headers={"x-telegram-bot-api-secret-token": "wrong"},
+        )
+        accepted = client.post(
+            "/webhook/telegram",
+            json={
+                "update_id": 2,
+                "business_connection": {
+                    "id": "bc_456",
+                    "user_chat_id": 888,
+                    "is_enabled": True,
+                    "user": {"id": 456, "is_bot": False, "first_name": "Lee"},
+                    "rights": {"can_reply": True},
+                },
+            },
+            headers={"x-telegram-bot-api-secret-token": "secret-token"},
+        )
+        _wait_for_webhook_tasks(app)
+
+    assert rejected.status_code == 403
+    assert accepted.status_code == 200
+
+    log_paths = sorted((tmp_path / ".opentulpa" / "logs" / "webhooks").glob("telegram-webhook-*.jsonl"))
+    assert len(log_paths) == 1
+    events = [json.loads(line) for line in log_paths[0].read_text(encoding="utf-8").splitlines()]
+    assert [event["event"] for event in events] == [
+        "rejected_invalid_secret",
+        "accepted",
+        "business_update_handled",
+    ]
+    assert events[0]["has_secret_header"] is True
+    assert events[1]["update_id"] == 2
+    assert events[1]["has_business_update"] is True
+    assert events[1]["update_keys"] == ["business_connection", "update_id"]
+    assert events[2]["kind"] == "business_connection"
+    assert events[2]["business_connection_id"] == "bc_456"


### PR DESCRIPTION
## Summary
- register Telegram webhook with explicit Business allowed_updates while preserving secret_token
- write privacy-safe Telegram webhook JSONL diagnostics under .opentulpa/logs/webhooks for /debug_logs
- cover webhook registration and diagnostics with focused tests

## Verification
- uv run ruff check src/opentulpa/__main__.py src/opentulpa/api/routes/telegram_webhook.py tests/test_main_bootstrap.py tests/test_telegram_business_webhook.py
- uv run pytest tests/test_main_bootstrap.py tests/test_telegram_business_webhook.py tests/test_core_debug_logs.py