### PR TITLE
Fix Telegram intake silence with queued status updates

### DIFF
--- a/src/opentulpa/agent/tools/core_tools.py
+++ b/src/opentulpa/agent/tools/core_tools.py
@@ -72,6 +72,24 @@ def _decorate_python_dependency_failure(payload: Any) -> Any:
     return safe_payload
 
 
+def _with_delivery_instruction(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+    if payload.get("delivered_to_chat") is not True:
+        return payload
+    safe_payload = dict(payload)
+    safe_payload["delivery_status"] = "delivered_to_telegram_chat"
+    safe_payload.setdefault(
+        "model_instruction",
+        (
+            "DELIVERED_TO_CHAT: The file has been sent to Telegram. "
+            "Do not call the file-send tool again for this file. "
+            "Continue with a short final confirmation only."
+        ),
+    )
+    return safe_payload
+
+
 def _trim_tool_text(value: Any, *, limit: int = 160) -> str:
     text = str(value or "").strip()
     if len(text) <= limit:
@@ -610,7 +628,7 @@ def register_core_tools(runtime: Any) -> dict[str, Any]:
         )
         if r.status_code != 200:
             return {"error": f"uploaded_file_send failed: {r.text}"}
-        return r.json()
+        return _with_delivery_instruction(r.json())
 
     @tool
     async def tulpa_file_send(
@@ -631,7 +649,7 @@ def register_core_tools(runtime: Any) -> dict[str, Any]:
         )
         if r.status_code != 200:
             return {"error": f"tulpa_file_send failed: {r.text}"}
-        return r.json()
+        return _with_delivery_instruction(r.json())
 
     @tool
     async def web_image_send(
@@ -656,7 +674,7 @@ def register_core_tools(runtime: Any) -> dict[str, Any]:
         )
         if r.status_code != 200:
             return {"error": f"web_image_send failed: {r.text}"}
-        return r.json()
+        return _with_delivery_instruction(r.json())
 
     @tool
     async def uploaded_file_analyze(

--- a/src/opentulpa/api/routes/files.py
+++ b/src/opentulpa/api/routes/files.py
@@ -19,6 +19,20 @@ from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
 MAX_LOCAL_SEND_BYTES = 45_000_000
 
 
+def _telegram_delivery_payload(**fields: Any) -> dict[str, Any]:
+    payload = {
+        "ok": True,
+        "delivered_to_chat": True,
+        "model_instruction": (
+            "DELIVERED_TO_CHAT: The file has been sent to Telegram. "
+            "Do not call the file-send tool again for this file. "
+            "Continue with a short final confirmation only."
+        ),
+    }
+    payload.update(fields)
+    return payload
+
+
 def register_file_routes(
     app: FastAPI,
     *,
@@ -104,7 +118,7 @@ def register_file_routes(
         )
         if not sent:
             return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return {"ok": True, "file_id": file_id, "chat_id": chat_id}
+        return _telegram_delivery_payload(file_id=file_id, chat_id=chat_id)
 
     @app.post("/internal/files/send_local")
     async def internal_files_send_local(request: Request) -> Any:
@@ -166,7 +180,7 @@ def register_file_routes(
         )
         if not sent:
             return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return {"ok": True, "path": local_path, "chat_id": chat_id}
+        return _telegram_delivery_payload(path=local_path, chat_id=chat_id)
 
     @app.post("/internal/files/send_web_image")
     async def internal_files_send_web_image(request: Request) -> Any:
@@ -215,13 +229,12 @@ def register_file_routes(
         )
         if not sent:
             return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return {
-            "ok": True,
-            "chat_id": chat_id,
-            "url": str(downloaded["final_url"]),
-            "mime_type": str(downloaded["content_type"]),
-            "size_bytes": int(downloaded["size_bytes"]),
-        }
+        return _telegram_delivery_payload(
+            chat_id=chat_id,
+            url=str(downloaded["final_url"]),
+            mime_type=str(downloaded["content_type"]),
+            size_bytes=int(downloaded["size_bytes"]),
+        )
 
     @app.post("/internal/files/analyze")
     async def internal_files_analyze(request: Request) -> Any:

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -18,6 +18,7 @@ from opentulpa.context.file_vault import FileVaultService
 from opentulpa.core.ids import new_short_id
 from opentulpa.intake.workflow_skill import build_intake_workflow_skill, workflow_skill_name
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
+from opentulpa.interfaces.telegram.status_generation import generate_llm_status_message
 from opentulpa.persistence.sqlite import connect_sqlite
 from opentulpa.scheduler.models import Routine
 
@@ -29,9 +30,11 @@ _DEFAULT_EDIT_WINDOW = timedelta(hours=2)
 _MAX_LATEST_INBOUND_AGE = timedelta(minutes=1)
 _MAX_DECISION_RECOVERY_ATTEMPTS = 2
 _TELEGRAM_BUSINESS_WEBHOOK_DEBOUNCE_SECONDS = 1.5
-_TELEGRAM_BUSINESS_WEBHOOK_SETTLE_SECONDS = 0.0
+_TELEGRAM_BUSINESS_WEBHOOK_SETTLE_SECONDS = 5.0
 _TELEGRAM_BUSINESS_STALE_REQUEUE_SECONDS = 3.0
 _TELEGRAM_BUSINESS_SETTLED_EVENT_TYPE = "telegram_business_webhook_settled"
+_TELEGRAM_BUSINESS_INTERIM_STATUS_DELAY_SECONDS = 20.0
+_TELEGRAM_BUSINESS_INTERIM_STATUS_TIMEOUT_SECONDS = 8.0
 _PENDING_RUN_POLL_SECONDS = 0.2
 _PENDING_RUN_MAX_CONCURRENCY = 4
 _BUSINESS_FACTS_MAX_KEYS = 32
@@ -771,6 +774,15 @@ class IntakeWorkflowService:
         owner_chat_id = str(row.get("owner_chat_id", "") or "").strip()
         generation = int(row.get("generation") or 0)
         result: dict[str, Any]
+        interim_task = asyncio.create_task(
+            self._send_pending_run_interim_status_after_delay(
+                workflow_id=workflow_id,
+                conversation_id=conversation_id,
+                customer_id=customer_id,
+                generation=generation,
+            ),
+            name=f"opentulpa-intake-interim-status-{workflow_id}-{conversation_id}",
+        )
         try:
             result = await self.run_workflow(
                 customer_id=customer_id,
@@ -783,6 +795,10 @@ class IntakeWorkflowService:
                 "workflow_id": workflow_id,
                 "summary": f"Intake workflow {workflow_id} failed: {exc}",
             }
+        finally:
+            interim_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await interim_task
         if (
             not bool(result.get("ok", False))
             and owner_chat_id
@@ -797,6 +813,112 @@ class IntakeWorkflowService:
             workflow_id=workflow_id,
             conversation_id=conversation_id,
             generation=generation,
+        )
+
+    def _pending_run_is_still_running(
+        self,
+        *,
+        workflow_id: str,
+        conversation_id: str,
+        generation: int,
+    ) -> bool:
+        with self._conn() as conn:
+            row = conn.execute(
+                """
+                SELECT status, running_generation
+                FROM intake_pending_runs
+                WHERE workflow_id = ? AND conversation_id = ?
+                """,
+                (workflow_id, conversation_id),
+            ).fetchone()
+        if row is None:
+            return False
+        return (
+            str(row["status"] or "").strip() == "running"
+            and int(row["running_generation"] or 0) == int(generation or 0)
+        )
+
+    async def _send_pending_run_interim_status_after_delay(
+        self,
+        *,
+        workflow_id: str,
+        conversation_id: str,
+        customer_id: str,
+        generation: int,
+    ) -> None:
+        await asyncio.sleep(max(0.0, float(_TELEGRAM_BUSINESS_INTERIM_STATUS_DELAY_SECONDS)))
+        if not self._pending_run_is_still_running(
+            workflow_id=workflow_id,
+            conversation_id=conversation_id,
+            generation=generation,
+        ):
+            return
+        workflow = self.get_workflow(customer_id=customer_id, workflow_id=workflow_id)
+        if workflow is None:
+            return
+        summary, refresh_error = self._reload_conversation_summary(
+            workflow=workflow,
+            conversation_id=conversation_id,
+            fallback={},
+        )
+        if refresh_error:
+            self._emit_observability(
+                event="intake.interim_status.error",
+                workflow=workflow,
+                conversation_summary={"conversation_id": conversation_id},
+                phase="conversation_refresh",
+                error=refresh_error,
+            )
+            return
+        runtime = self._runtime_for_observability()
+        if runtime is None:
+            return
+        text = await generate_llm_status_message(
+            runtime=runtime,
+            customer_id=customer_id,
+            thread_id=self._intake_thread_id(workflow=workflow, conversation_summary=summary),
+            context={
+                "event": "telegram_business_intake_processing",
+                "workflow_name": str(workflow.get("name", "") or "").strip(),
+                "latest_customer_message": str(
+                    summary.get("latest_inbound_message_text_preview", "") or ""
+                ).strip()[:1000],
+            },
+            language="Russian",
+            timeout_seconds=_TELEGRAM_BUSINESS_INTERIM_STATUS_TIMEOUT_SECONDS,
+        )
+        if not text:
+            self._emit_observability(
+                event="intake.interim_status.skipped",
+                workflow=workflow,
+                conversation_summary=summary,
+                reason="llm_status_generation_failed",
+            )
+            return
+        if not self._pending_run_is_still_running(
+            workflow_id=workflow_id,
+            conversation_id=conversation_id,
+            generation=generation,
+        ):
+            return
+        reply_error = await self._send_source_reply(
+            workflow=workflow,
+            conversation_summary=summary,
+            reply_text=text,
+        )
+        if reply_error:
+            self._emit_observability(
+                event="intake.interim_status.error",
+                workflow=workflow,
+                conversation_summary=summary,
+                phase="reply_execution",
+                error=reply_error,
+            )
+            return
+        self._emit_observability(
+            event="intake.interim_status.sent",
+            workflow=workflow,
+            conversation_summary=summary,
         )
 
     async def _notify_pending_run_owner(self, *, owner_chat_id: str, summary: str) -> None:

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -22,6 +22,7 @@ from opentulpa.agent.turn_policy import normalize_turn_mode
 from opentulpa.core.ids import new_short_id
 from opentulpa.interfaces.telegram.client import TelegramClient
 from opentulpa.interfaces.telegram.constants import DEBUG_LOG_PATH, LOW_SIGNAL_REPLIES
+from opentulpa.interfaces.telegram.status_generation import generate_llm_status_message
 
 logger = logging.getLogger(__name__)
 NO_NOTIFY_TOKEN = "__NO_NOTIFY__"
@@ -346,6 +347,8 @@ async def stream_langgraph_reply_to_telegram(
     stream_idle_retry_timeout_s = 240.0
     consecutive_timeouts = 0
     max_consecutive_timeouts = 2
+    timeout_failed_without_reply = False
+    interim_status_sent = False
     stream_started_at = time.monotonic()
     final_only = normalize_turn_mode(turn_mode) == "workflow_setup"
     next_chunk_task: asyncio.Task[Any] | None = None
@@ -451,6 +454,48 @@ async def stream_langgraph_reply_to_telegram(
         delivered_any = True
         live_delivery_text = current
         live_delivery_at = now
+
+    async def _send_llm_status_update(*, stage: str) -> None:
+        nonlocal delivered_any, interim_status_sent
+        if interim_status_sent or last_streamed:
+            return
+        status_text = await generate_llm_status_message(
+            runtime=agent_runtime,
+            customer_id=customer_id,
+            thread_id=thread_id,
+            context={
+                "event": "telegram_owner_stream_waiting",
+                "stage": stage,
+                "turn_mode": normalize_turn_mode(turn_mode),
+                "latest_user_message": str(text or "").strip()[:1000],
+            },
+            language="Russian",
+        )
+        if not status_text:
+            logger.warning(
+                "telegram.stream status_generation_skipped chat_id=%s thread_id=%s customer_id=%s stage=%s",
+                chat_id,
+                thread_id,
+                customer_id,
+                stage,
+            )
+            return
+        sent = await client.send_message(
+            chat_id=chat_id,
+            text=status_text,
+            parse_mode="HTML",
+        )
+        if sent:
+            delivered_any = True
+            interim_status_sent = True
+            logger.info(
+                "telegram.stream status_generation_sent chat_id=%s thread_id=%s customer_id=%s stage=%s chars=%s",
+                chat_id,
+                thread_id,
+                customer_id,
+                stage,
+                len(status_text),
+            )
 
     try:
         if final_only:
@@ -608,13 +653,16 @@ async def stream_langgraph_reply_to_telegram(
                 except TimeoutError:
                     consecutive_timeouts += 1
                     if consecutive_timeouts < max_consecutive_timeouts:
+                        stage = "first_token" if not last_streamed else "idle"
                         logger.warning(
                             "telegram.stream timeout_retry chat_id=%s thread_id=%s customer_id=%s stage=%s",
                             chat_id,
                             thread_id,
                             customer_id,
-                            "first_token" if not last_streamed else "idle",
+                            stage,
                         )
+                        if not last_streamed:
+                            await _send_llm_status_update(stage=stage)
                         continue
                     if next_chunk_task is not None and not next_chunk_task.done():
                         next_chunk_task.cancel()
@@ -633,9 +681,7 @@ async def stream_langgraph_reply_to_telegram(
                         )
                         final_reply = recovered_text
                         break
-                    timeout_text = (
-                        "Still working, but the model response timed out. Please retry in a moment."
-                    )
+                    timeout_failed_without_reply = True
                     logger.error(
                         "telegram.stream timeout_fail chat_id=%s thread_id=%s customer_id=%s stage=%s",
                         chat_id,
@@ -643,7 +689,6 @@ async def stream_langgraph_reply_to_telegram(
                         customer_id,
                         "first_token" if not last_streamed else "idle",
                     )
-                    final_reply = timeout_text
                     break
                 if stream_status == "done":
                     next_chunk_task = None
@@ -706,6 +751,8 @@ async def stream_langgraph_reply_to_telegram(
         typing_stop.set()
     with suppress(Exception):
         await typing_task
+    if not suppressed and not final_reply and timeout_failed_without_reply:
+        suppressed = True
     if not suppressed and not final_reply:
         logger.error(
             "telegram.stream no_final_reply chat_id=%s thread_id=%s customer_id=%s",

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -348,6 +348,7 @@ async def stream_langgraph_reply_to_telegram(
     consecutive_timeouts = 0
     max_consecutive_timeouts = 2
     timeout_failed_without_reply = False
+    timeout_failure_stage = ""
     interim_status_sent = False
     stream_started_at = time.monotonic()
     final_only = normalize_turn_mode(turn_mode) == "workflow_setup"
@@ -682,12 +683,13 @@ async def stream_langgraph_reply_to_telegram(
                         final_reply = recovered_text
                         break
                     timeout_failed_without_reply = True
+                    timeout_failure_stage = "first_token" if not last_streamed else "idle"
                     logger.error(
                         "telegram.stream timeout_fail chat_id=%s thread_id=%s customer_id=%s stage=%s",
                         chat_id,
                         thread_id,
                         customer_id,
-                        "first_token" if not last_streamed else "idle",
+                        timeout_failure_stage,
                     )
                     break
                 if stream_status == "done":
@@ -752,6 +754,16 @@ async def stream_langgraph_reply_to_telegram(
     with suppress(Exception):
         await typing_task
     if not suppressed and not final_reply and timeout_failed_without_reply:
+        logger.error(
+            "telegram.stream silent_timeout_suppressed chat_id=%s thread_id=%s customer_id=%s stage=%s "
+            "interim_status_sent=%s delivered_any=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+            timeout_failure_stage,
+            interim_status_sent,
+            delivered_any,
+        )
         suppressed = True
     if not suppressed and not final_reply:
         logger.error(

--- a/src/opentulpa/interfaces/telegram/status_generation.py
+++ b/src/opentulpa/interfaces/telegram/status_generation.py
@@ -1,0 +1,112 @@
+"""LLM-generated Telegram status updates."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
+
+logger = logging.getLogger(__name__)
+
+
+class _StatusMessageDecision(BaseModel):
+    ok: bool = False
+    text: str = ""
+
+
+def _status_model(runtime: Any) -> tuple[Any, str]:
+    for model_attr, name_attr in (
+        ("_workflow_setup_input_classifier_model", "_workflow_setup_input_classifier_model_name"),
+        ("_wake_classifier_model", "_wake_classifier_model_name"),
+        ("_model", "model_name"),
+    ):
+        model = getattr(runtime, model_attr, None)
+        if model is None:
+            continue
+        return model, str(getattr(runtime, name_attr, "") or "").strip()
+    return None, ""
+
+
+def _clean_status_text(value: Any) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if len(text) > 160:
+        text = text[:157].rstrip() + "..."
+    return text
+
+
+async def generate_llm_status_message(
+    *,
+    runtime: Any,
+    customer_id: str,
+    thread_id: str,
+    context: dict[str, Any],
+    language: str = "Russian",
+    timeout_seconds: float = 8.0,
+) -> str | None:
+    """Return LLM-generated visible status text, or None on any failure."""
+
+    direct = getattr(runtime, "generate_status_message", None)
+    if callable(direct):
+        try:
+            result = await direct(
+                customer_id=customer_id,
+                thread_id=thread_id,
+                context=dict(context),
+                language=language,
+            )
+        except Exception:
+            logger.exception("telegram.status_generation direct generator failed")
+            return None
+        if isinstance(result, dict) and not bool(result.get("ok", False)):
+            return None
+        text = _clean_status_text(result.get("text") if isinstance(result, dict) else result)
+        return text or None
+
+    invoke_structured = getattr(runtime, "_invoke_structured_model", None)
+    if not callable(invoke_structured):
+        return None
+    model, model_name = _status_model(runtime)
+    if model is None:
+        return None
+    safe_context = json.dumps(dict(context), ensure_ascii=False)[:4000]
+    try:
+        decision, error = await asyncio.wait_for(
+            invoke_structured(
+                model=model,
+                model_name=model_name or None,
+                schema=_StatusMessageDecision,
+                messages=[
+                    SystemMessage(
+                        content=(
+                            "Generate one short visible Telegram status update while the assistant is still working.\n"
+                            "Return strict JSON only with keys: ok, text.\n"
+                            f"Write text in {language}. One sentence, under 90 characters.\n"
+                            "Do not answer the user's business question. Do not invent prices, availability, "
+                            "booking facts, or completion. Only say that the answer is being checked or prepared.\n"
+                            "If a useful status update is not appropriate, set ok=false and text=\"\"."
+                        )
+                    ),
+                    HumanMessage(content=f"context={safe_context}"),
+                ],
+                call_context={
+                    "call_site": "telegram_status_generation",
+                    "customer_id": str(customer_id or "").strip(),
+                    "thread_id": str(thread_id or "").strip(),
+                },
+            ),
+            timeout=max(0.1, float(timeout_seconds)),
+        )
+    except Exception:
+        logger.exception("telegram.status_generation structured generator failed")
+        return None
+    if error or decision is None or not isinstance(decision, _StatusMessageDecision):
+        return None
+    if not bool(decision.ok):
+        return None
+    text = _clean_status_text(decision.text)
+    return text or None

--- a/tests/test_file_send_routes.py
+++ b/tests/test_file_send_routes.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opentulpa.api.routes import files as file_routes
+from opentulpa.api.routes.files import register_file_routes
+
+
+class _UnusedVault:
+    pass
+
+
+class _FakeTelegramChat:
+    def find_session_slots(self, customer_id: str) -> list[dict[str, Any]]:
+        assert customer_id == "telegram_123"
+        return [{"chat_id": 12345}]
+
+
+class _RecordingTelegramClient:
+    def __init__(self) -> None:
+        self.sent_files: list[dict[str, Any]] = []
+
+    async def send_file(self, **kwargs: Any) -> bool:
+        self.sent_files.append(kwargs)
+        return True
+
+
+def test_send_local_returns_delivery_marker_after_telegram_accepts_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    tulpa_stuff = tmp_path / "tulpa_stuff"
+    tulpa_stuff.mkdir()
+    local_file = tulpa_stuff / "sample_delivery_report.txt"
+    local_file.write_text("done", encoding="utf-8")
+
+    monkeypatch.setattr(file_routes, "TULPA_STUFF_DIR", tulpa_stuff.resolve())
+
+    app = FastAPI()
+    telegram_client = _RecordingTelegramClient()
+    register_file_routes(
+        app,
+        get_file_vault=lambda: _UnusedVault(),
+        get_telegram_chat=lambda: _FakeTelegramChat(),
+        get_telegram_client=lambda: telegram_client,
+        get_agent_runtime=lambda: object(),
+        telegram_enabled=True,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/internal/files/send_local",
+            json={
+                "customer_id": "telegram_123",
+                "path": "tulpa_stuff/sample_delivery_report.txt",
+                "caption": "Sample delivery report",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["delivered_to_chat"] is True
+    assert payload["path"] == "tulpa_stuff/sample_delivery_report.txt"
+    assert payload["chat_id"] == 12345
+    assert "DELIVERED_TO_CHAT" in payload["model_instruction"]
+    assert "Do not call the file-send tool again" in payload["model_instruction"]
+    assert telegram_client.sent_files == [
+        {
+            "chat_id": 12345,
+            "filename": "sample_delivery_report.txt",
+            "raw_bytes": b"done",
+            "kind": "document",
+            "mime_type": "text/plain",
+            "caption": "Sample delivery report",
+            "parse_mode": "HTML",
+        }
+    ]

--- a/tests/test_intake_tools.py
+++ b/tests/test_intake_tools.py
@@ -240,6 +240,42 @@ async def test_uploaded_file_inspect_structure_posts_expected_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tulpa_file_send_marks_delivered_file_for_agent() -> None:
+    runtime = DummyRuntime(
+        [
+            Response(
+                200,
+                {
+                    "ok": True,
+                    "path": "tulpa_stuff/sample_delivery_report.txt",
+                    "chat_id": 12345,
+                    "delivered_to_chat": True,
+                },
+            )
+        ]
+    )
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["tulpa_file_send"].ainvoke(
+        {
+            "path": "tulpa_stuff/sample_delivery_report.txt",
+            "caption": "Sample delivery report",
+        }
+    )
+
+    assert result["delivered_to_chat"] is True
+    assert result["delivery_status"] == "delivered_to_telegram_chat"
+    assert "DELIVERED_TO_CHAT" in result["model_instruction"]
+    assert "Do not call the file-send tool again" in result["model_instruction"]
+    assert runtime.calls[0][1] == "/internal/files/send_local"
+    assert runtime.calls[0][2]["json_body"] == {
+        "path": "tulpa_stuff/sample_delivery_report.txt",
+        "customer_id": "telegram_123",
+        "caption": "Sample delivery report",
+    }
+
+
+@pytest.mark.asyncio
 async def test_business_knowledge_index_posts_expected_payload() -> None:
     runtime = DummyRuntime(
         [

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -73,9 +73,16 @@ def _instagram_conversation(
 
 
 class _FakeRuntime:
-    def __init__(self, decisions: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        decisions: list[dict[str, Any]],
+        *,
+        status_messages: list[Any] | None = None,
+    ) -> None:
         self.decisions = list(decisions)
+        self.status_messages = list(status_messages or [])
         self.calls: list[dict[str, Any]] = []
+        self.status_calls: list[dict[str, Any]] = []
         self.behavior_events: list[dict[str, Any]] = []
 
     async def decide_intake_workflow(self, **kwargs: Any) -> dict[str, Any]:
@@ -83,6 +90,15 @@ class _FakeRuntime:
         if not self.decisions:
             raise RuntimeError("unexpected intake decision call")
         return self.decisions.pop(0)
+
+    async def generate_status_message(self, **kwargs: Any) -> Any:
+        self.status_calls.append(kwargs)
+        if not self.status_messages:
+            return None
+        result = self.status_messages.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
 
     def log_behavior_event(self, *, event: str, **fields: Any) -> None:
         self.behavior_events.append({"event": event, **fields})
@@ -2211,6 +2227,175 @@ async def test_telegram_business_workflow_suppresses_stale_reply_and_requeues(
     sent = telegram_business.client.sent_messages[0]
     assert sent["reply_to_message_id"] == 11
     assert "Rolls-Royce Cullinan" in sent["text"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_business_pending_run_sends_one_llm_generated_interim_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_TELEGRAM_BUSINESS_INTERIM_STATUS_DELAY_SECONDS",
+        0.01,
+    )
+    runtime = _DelayedRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.9,
+                "conversation_summary": "Customer asks for wash pricing.",
+                "extracted_fields": {"telegram_username": "alice"},
+                "missing_fields": ["car_model"],
+                "reply_action": "send_reply",
+                "reply_text": "Какая у вас машина?",
+                "ready_to_save": False,
+                "booking_action": "create_new_booking",
+                "save_payload": {},
+                "reason": "Need car model.",
+            }
+        ],
+        delay_seconds=0.05,
+    )
+    runtime.status_messages.append({"ok": True, "text": "Уточняю детали и скоро отвечу."})
+    service, _, _, telegram_business, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=_FakeComposio({}, {}),
+    )
+    telegram_business.upsert_connection(
+        {
+            "id": "bc_123",
+            "user_chat_id": 777,
+            "is_enabled": True,
+            "user": {"id": 123, "is_bot": False, "first_name": "Kim"},
+            "rights": {"can_reply": True},
+        }
+    )
+    telegram_business.upsert_message(
+        business_connection_id="bc_123",
+        customer_id="telegram_123",
+        message={
+            "business_connection_id": "bc_123",
+            "message_id": 10,
+            "date": 1_775_552_400,
+            "chat": {"id": 555, "type": "private", "username": "alice"},
+            "from": {"id": 999, "is_bot": False, "username": "alice"},
+            "text": "Сколько стоит мойка?",
+        },
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Telegram Booking",
+        channel="telegram_business_dm",
+        provider="telegram_bot_api",
+        source_config={"business_connection_id": "bc_123"},
+        intent_description="Handle Telegram Business appointment requests.",
+        required_fields=["telegram_username", "car_model"],
+        assistant_instructions="Ask for car model.",
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+    service._queue_pending_run(  # noqa: SLF001
+        workflow=workflow,
+        conversation_id="555",
+        event_type="telegram_business_webhook_settled",
+        delay_seconds=0.0,
+    )
+
+    drained = await service.drain_due_pending_runs()
+
+    assert drained == 1
+    assert len(runtime.status_calls) == 1
+    assert [item["text"] for item in telegram_business.client.sent_messages] == [
+        "Уточняю детали и скоро отвечу.",
+        "Какая у вас машина?",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_business_pending_run_sends_no_hardcoded_interim_on_generation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_TELEGRAM_BUSINESS_INTERIM_STATUS_DELAY_SECONDS",
+        0.01,
+    )
+    runtime = _DelayedRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.9,
+                "conversation_summary": "Customer asks for wash pricing.",
+                "extracted_fields": {"telegram_username": "alice"},
+                "missing_fields": ["car_model"],
+                "reply_action": "send_reply",
+                "reply_text": "Какая у вас машина?",
+                "ready_to_save": False,
+                "booking_action": "create_new_booking",
+                "save_payload": {},
+                "reason": "Need car model.",
+            }
+        ],
+        delay_seconds=0.05,
+    )
+    runtime.status_messages.append({"ok": False, "text": ""})
+    service, _, _, telegram_business, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=_FakeComposio({}, {}),
+    )
+    telegram_business.upsert_connection(
+        {
+            "id": "bc_123",
+            "user_chat_id": 777,
+            "is_enabled": True,
+            "user": {"id": 123, "is_bot": False, "first_name": "Kim"},
+            "rights": {"can_reply": True},
+        }
+    )
+    telegram_business.upsert_message(
+        business_connection_id="bc_123",
+        customer_id="telegram_123",
+        message={
+            "business_connection_id": "bc_123",
+            "message_id": 10,
+            "date": 1_775_552_400,
+            "chat": {"id": 555, "type": "private", "username": "alice"},
+            "from": {"id": 999, "is_bot": False, "username": "alice"},
+            "text": "Сколько стоит мойка?",
+        },
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Telegram Booking",
+        channel="telegram_business_dm",
+        provider="telegram_bot_api",
+        source_config={"business_connection_id": "bc_123"},
+        intent_description="Handle Telegram Business appointment requests.",
+        required_fields=["telegram_username", "car_model"],
+        assistant_instructions="Ask for car model.",
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+    service._queue_pending_run(  # noqa: SLF001
+        workflow=workflow,
+        conversation_id="555",
+        event_type="telegram_business_webhook_settled",
+        delay_seconds=0.0,
+    )
+
+    drained = await service.drain_due_pending_runs()
+
+    assert drained == 1
+    assert len(runtime.status_calls) == 1
+    assert [item["text"] for item in telegram_business.client.sent_messages] == [
+        "Какая у вас машина?",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_stream_timeout.py
+++ b/tests/test_telegram_stream_timeout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -116,6 +117,56 @@ async def test_stream_timeout_returns_user_visible_timeout(monkeypatch: pytest.M
     assert calls["count"] >= 2
     assert ("Уточняю детали и скоро отвечу." in [text for _, text, _ in fake_client.message_calls])
     assert fake_client.chat_actions
+
+
+@pytest.mark.asyncio
+async def test_stream_timeout_logs_silent_suppression_when_status_generation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_client = _FakeTelegramClient("dummy")
+    monkeypatch.setattr(relay_module, "TelegramClient", lambda token: fake_client)
+    runtime = _NeverYieldsRuntime(status=None)
+    caplog.set_level(logging.WARNING, logger=relay_module.__name__)
+
+    original_wait_for = relay_module.asyncio.wait_for
+    calls = {"count": 0}
+
+    async def _fast_timeout(awaitable, timeout):
+        if asyncio.iscoroutine(awaitable):
+            code = getattr(awaitable, "cr_code", None)
+            if getattr(code, "co_name", "") == "wait":
+                return await original_wait_for(awaitable, timeout)
+            awaitable.close()
+        calls["count"] += 1
+        raise TimeoutError()
+
+    monkeypatch.setattr(relay_module.asyncio, "wait_for", _fast_timeout)
+    try:
+        final, suppressed = await relay_module.stream_langgraph_reply_to_telegram(
+            agent_runtime=runtime,
+            thread_id="chat-1",
+            customer_id="telegram_1",
+            text="hello",
+            bot_token="dummy",
+            chat_id=1,
+        )
+    finally:
+        monkeypatch.setattr(relay_module.asyncio, "wait_for", original_wait_for)
+
+    assert suppressed is True
+    assert final is None
+    assert runtime.status_calls == 1
+    assert fake_client.message_calls == []
+    assert calls["count"] >= 2
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("telegram.stream status_generation_skipped" in message for message in messages)
+    assert any(
+        "telegram.stream silent_timeout_suppressed" in message
+        and "interim_status_sent=False" in message
+        and "delivered_any=False" in message
+        for message in messages
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_stream_timeout.py
+++ b/tests/test_telegram_stream_timeout.py
@@ -8,10 +8,20 @@ from opentulpa.interfaces.telegram import relay as relay_module
 
 
 class _NeverYieldsRuntime:
+    def __init__(self, status: str | None = None) -> None:
+        self.status = status
+        self.status_calls = 0
+
     async def astream_text(self, **kwargs):
         while True:
             await asyncio.sleep(10.0)
             yield ""
+
+    async def generate_status_message(self, **kwargs):
+        self.status_calls += 1
+        if not self.status:
+            return None
+        return {"ok": True, "text": self.status}
 
 
 class _NeverYieldsWithFallbackRuntime:
@@ -69,6 +79,7 @@ class _FakeTelegramClient:
 async def test_stream_timeout_returns_user_visible_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_client = _FakeTelegramClient("dummy")
     monkeypatch.setattr(relay_module, "TelegramClient", lambda token: fake_client)
+    runtime = _NeverYieldsRuntime(status="Уточняю детали и скоро отвечу.")
 
     # Force timeout path quickly.
     original_wait_for = relay_module.asyncio.wait_for
@@ -81,13 +92,14 @@ async def test_stream_timeout_returns_user_visible_timeout(monkeypatch: pytest.M
             code = getattr(awaitable, "cr_code", None)
             if getattr(code, "co_name", "") == "wait":
                 return await original_wait_for(awaitable, timeout)
+            awaitable.close()
         calls["count"] += 1
         raise TimeoutError()
 
     monkeypatch.setattr(relay_module.asyncio, "wait_for", _fast_timeout)
     try:
         final, suppressed = await relay_module.stream_langgraph_reply_to_telegram(
-            agent_runtime=_NeverYieldsRuntime(),
+            agent_runtime=runtime,
             thread_id="chat-1",
             customer_id="telegram_1",
             text="hello",
@@ -97,14 +109,12 @@ async def test_stream_timeout_returns_user_visible_timeout(monkeypatch: pytest.M
     finally:
         monkeypatch.setattr(relay_module.asyncio, "wait_for", original_wait_for)
 
-    assert suppressed is False
-    assert isinstance(final, str)
-    assert "timed out" in final.lower()
+    assert suppressed is True
+    assert final is None
+    assert runtime.status_calls == 1
     # One automatic retry is attempted before surfacing timeout.
     assert calls["count"] >= 2
-    assert any("timed out" in text.lower() for _, _, text, _, _ in fake_client.draft_calls) or any(
-        "timed out" in text.lower() for _, text, _ in fake_client.message_calls
-    )
+    assert ("Уточняю детали и скоро отвечу." in [text for _, text, _ in fake_client.message_calls])
     assert fake_client.chat_actions
 
 
@@ -125,6 +135,8 @@ async def test_stream_timeout_uses_non_stream_recovery_when_available(
                 return await original_wait_for(awaitable, timeout)
         calls["count"] += 1
         if calls["count"] <= 2:
+            if asyncio.iscoroutine(awaitable):
+                awaitable.close()
             raise TimeoutError()
         return await original_wait_for(awaitable, timeout)
 


### PR DESCRIPTION
## Summary

Fixes Telegram Business intake silence/race behavior by leaning on the existing SQLite pending-run queue instead of adding new queue infrastructure.

## What changed

- Keeps one pending intake row per workflow/conversation and increases Telegram Business settle delay so rapid customer messages coalesce before processing.
- Adds an LLM-generated interim Telegram status path for slow intake runs. The visible waiting copy is generated through a structured `{ ok, text }` response; if generation fails, nothing is sent.
- Keeps stale-guard behavior so an old run suppresses its reply and requeues the latest conversation before final reply or sink write.
- Adds the same LLM-generated status idea to owner Telegram first-token stream delays and removes the hardcoded visible timeout fallback.
- Includes the prior file-send delivery-marker commit so agents know when a Telegram file send already succeeded and should not resend it.

## Why

The carwash test deployment showed long model/knowledge runs plus split customer messages. Older runs could become stale, skip a reply, and rely on a later/manual run before answering the newest customer message. Owner chat also had a separate first-token timeout path that could look stalled while intake still worked.

## Validation

- `uv run pytest -q tests/test_intake_tools.py tests/test_file_send_routes.py tests/test_intake_workflow_service.py` -> `65 passed`
- `uv run pytest -q tests/test_intake_workflow_service.py tests/test_telegram_stream_timeout.py` -> `49 passed`
- `uv run pytest -q tests/e2e/scenarios/test_telegram_intake_debounce.py --run-e2e` -> `3 passed, 1 skipped`
- `uv run ruff check src/opentulpa/interfaces/telegram/status_generation.py src/opentulpa/intake/service.py src/opentulpa/interfaces/telegram/relay.py tests/test_intake_workflow_service.py tests/test_telegram_stream_timeout.py` -> passed

## Notes

Not yet live-validated on Railway. Langfuse broken-trace warnings are separate observability-context propagation work and are not fixed here.
