### PR TITLE
Add Telegram owner reply context

### DIFF
--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -166,6 +166,77 @@ def _telegram_command_name(text: str) -> str:
     return head.split("@", 1)[0]
 
 
+def _telegram_reply_to_context(message: dict[str, Any]) -> str:
+    reply = message.get("reply_to_message")
+    if not isinstance(reply, dict):
+        return ""
+    author = reply.get("from")
+    if isinstance(author, dict) and author.get("is_bot") is not True:
+        return ""
+
+    message_id = reply.get("message_id")
+    lines = [
+        "Telegram reply context: the user replied to one of OpenTulpa's earlier messages.",
+    ]
+    if isinstance(message_id, int) and message_id > 0:
+        lines.append(f"- replied_message_id: {message_id}")
+
+    text = str(reply.get("text") or reply.get("caption") or "").strip()
+    if text:
+        lines.append(f"- replied_message_text_or_caption: {text[:2000]}")
+
+    photos = reply.get("photo")
+    if isinstance(photos, list) and photos:
+        chosen = None
+        for item in photos:
+            if isinstance(item, dict) and (
+                chosen is None
+                or int(item.get("file_size") or 0) >= int(chosen.get("file_size") or 0)
+            ):
+                chosen = item
+        if isinstance(chosen, dict):
+            file_unique_id = str(chosen.get("file_unique_id", "")).strip()
+            width = chosen.get("width")
+            height = chosen.get("height")
+            details = ["type=photo"]
+            if file_unique_id:
+                details.append(f"file_unique_id={file_unique_id}")
+            if isinstance(width, int) and isinstance(height, int):
+                details.append(f"size={width}x{height}")
+            lines.append(f"- replied_message_media: {' '.join(details)}")
+
+    document = reply.get("document")
+    if isinstance(document, dict):
+        name = str(document.get("file_name", "")).strip()
+        mime_type = str(document.get("mime_type", "")).strip()
+        file_unique_id = str(document.get("file_unique_id", "")).strip()
+        details = ["type=document"]
+        if name:
+            details.append(f"name={name}")
+        if mime_type:
+            details.append(f"mime_type={mime_type}")
+        if file_unique_id:
+            details.append(f"file_unique_id={file_unique_id}")
+        lines.append(f"- replied_message_media: {' '.join(details)}")
+
+    if len(lines) == 1:
+        lines.append("- replied_message_text_or_caption: unavailable")
+    lines.append(
+        "Use this as context for the user's current message; do not quote metadata verbatim."
+    )
+    return "\n".join(lines)
+
+
+def _inject_telegram_reply_context(text: str, reply_context: str) -> str:
+    clean_text = str(text or "").strip()
+    clean_context = str(reply_context or "").strip()
+    if not clean_context:
+        return clean_text
+    if clean_text:
+        return f"{clean_context}\n\nCurrent user message:\n{clean_text}"
+    return clean_context
+
+
 def support_bot_commands() -> list[dict[str, str]]:
     return [
         {"command": "support_customers", "description": "List customer tenants for support"},
@@ -795,6 +866,7 @@ async def _materialize_interactive_submission(
     session: InteractiveSession,
     submission: Any,
     text: str,
+    reply_context: str,
     caption: str | None,
     attachments: list[Any],
     bot_token: str,
@@ -822,6 +894,7 @@ async def _materialize_interactive_submission(
             attachments=attachments,
             ingested_files=ingested_files,
         )
+        fragment = _inject_telegram_reply_context(fragment, reply_context)
     except Exception as exc:
         logger.exception(
             "Telegram interactive materialization failed (chat_id=%s, thread_id=%s): %s",
@@ -1007,6 +1080,7 @@ async def handle_telegram_text(
 
     message = body.get("message") or body.get("edited_message") or {}
     caption = str(message.get("caption", "")).strip() or None
+    reply_context = _telegram_reply_to_context(message)
     attachments = extract_attachments(message)
     username = (message.get("from", {}) or {}).get("username")
     username = username.strip() or None if isinstance(username, str) else None
@@ -1212,6 +1286,7 @@ async def handle_telegram_text(
                 session=session,
                 submission=submission,
                 text=ctx.text,
+                reply_context=reply_context,
                 caption=caption,
                 attachments=attachments,
                 bot_token=bot_token,
@@ -1258,6 +1333,7 @@ async def handle_telegram_text(
         attachments=attachments,
         ingested_files=ingested_files,
     )
+    effective_text = _inject_telegram_reply_context(effective_text, reply_context)
     if direct_reply:
         return direct_reply
     if not effective_text:

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -230,11 +230,9 @@ def _telegram_reply_to_context(message: dict[str, Any]) -> str:
 def _inject_telegram_reply_context(text: str, reply_context: str) -> str:
     clean_text = str(text or "").strip()
     clean_context = str(reply_context or "").strip()
-    if not clean_context:
+    if not clean_context or not clean_text:
         return clean_text
-    if clean_text:
-        return f"{clean_context}\n\nCurrent user message:\n{clean_text}"
-    return clean_context
+    return f"{clean_context}\n\nCurrent user message:\n{clean_text}"
 
 
 def support_bot_commands() -> list[dict[str, str]]:

--- a/tests/test_telegram_interactive_mailbox.py
+++ b/tests/test_telegram_interactive_mailbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -150,6 +151,49 @@ async def test_telegram_interactive_owner_reply_to_bot_photo_adds_reply_context(
     assert "Generated hero image for the car wash workflow." in turn_text
     assert "type=photo file_unique_id=large_unique size=1024x768" in turn_text
     assert "Current user message:\nUse this image for the landing screen." in turn_text
+
+
+@pytest.mark.asyncio
+async def test_telegram_interactive_failed_voice_reply_does_not_stream_reply_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = chat_module.InteractiveSession(
+        chat_id=1,
+        customer_id="telegram_100",
+        thread_id="chat-1",
+    )
+    submission, _ = await session.enqueue()
+
+    async def _fake_ingest_attachments_with_typing(**kwargs: Any) -> list[dict[str, Any]]:
+        del kwargs
+        return []
+
+    monkeypatch.setattr(chat_module, "_ingest_attachments_with_typing", _fake_ingest_attachments_with_typing)
+
+    await chat_module._materialize_interactive_submission(
+        session=session,
+        submission=submission,
+        text="",
+        reply_context=(
+            "Context: the user replied to one of OpenTulpa's earlier messages.\n"
+            "- replied_message_id: 44"
+        ),
+        caption=None,
+        attachments=[SimpleNamespace(kind="voice")],
+        bot_token="123:abc",
+        file_vault=object(),
+        memory=None,
+        agent_runtime=object(),
+        customer_id="telegram_100",
+        chat_id=1,
+    )
+
+    [result] = await session.consume_ready_batch()
+    assert result.fragment is None
+    assert result.direct_reply == (
+        "I received your voice message but couldn't transcribe it. "
+        "Please resend a shorter/clearer voice note or send text."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_interactive_mailbox.py
+++ b/tests/test_telegram_interactive_mailbox.py
@@ -86,6 +86,73 @@ class _FakeTelegramClient:
 
 
 @pytest.mark.asyncio
+async def test_telegram_interactive_owner_reply_to_bot_photo_adds_reply_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
+    runtime = _InteractiveRuntime()
+    service = chat_module.TelegramChatService(
+        bot_token="123:abc",
+        file_vault=object(),
+        memory=None,
+    )
+    captured_turn_texts: list[str] = []
+
+    monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
+    monkeypatch.setattr(chat_module, "get_openai_compatible_api_key_from_env", lambda: "key")
+    monkeypatch.setattr(chat_module, "is_user_allowed", lambda **kwargs: True)
+
+    async def _fake_stream_langgraph_reply_to_telegram(**kwargs: Any) -> tuple[str | None, bool]:
+        captured_turn_texts.append(str(kwargs.get("text", "")))
+        return "done", False
+
+    monkeypatch.setattr(
+        chat_module, "stream_langgraph_reply_to_telegram", _fake_stream_langgraph_reply_to_telegram
+    )
+
+    result = await service.handle_update(
+        body={
+            "message": {
+                "chat": {"id": 1},
+                "from": {"id": 100},
+                "text": "Use this image for the landing screen.",
+                "reply_to_message": {
+                    "message_id": 44,
+                    "from": {"id": 200, "is_bot": True, "username": "OpenTulpaBot"},
+                    "caption": "Generated hero image for the car wash workflow.",
+                    "photo": [
+                        {
+                            "file_id": "small",
+                            "file_unique_id": "small_unique",
+                            "width": 90,
+                            "height": 90,
+                            "file_size": 100,
+                        },
+                        {
+                            "file_id": "large",
+                            "file_unique_id": "large_unique",
+                            "width": 1024,
+                            "height": 768,
+                            "file_size": 500,
+                        },
+                    ],
+                },
+            }
+        },
+        agent_runtime=runtime,
+    )
+
+    assert result is None
+    assert captured_turn_texts and len(captured_turn_texts) == 1
+    turn_text = captured_turn_texts[0]
+    assert "the user replied to one of OpenTulpa's earlier messages" in turn_text
+    assert "- replied_message_id: 44" in turn_text
+    assert "Generated hero image for the car wash workflow." in turn_text
+    assert "type=photo file_unique_id=large_unique size=1024x768" in turn_text
+    assert "Current user message:\nUse this image for the landing screen." in turn_text
+
+
+@pytest.mark.asyncio
 async def test_telegram_interactive_inbox_merges_slow_media_then_followup_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add Telegram owner-chat reply context when the user replies to an OpenTulpa bot message.
- Preserve replied bot text/caption and photo/document metadata in the agent turn.
- Cover bot-photo reply context with a focused interactive Telegram regression test.

## Why
Owner interactive chat previously kept only normal thread history. Telegram reply metadata was dropped, so “use this image” could not be tied to the specific bot message or image the user replied to.

## Validation
- `uv run ruff check src/opentulpa/interfaces/telegram/chat_service.py tests/test_telegram_interactive_mailbox.py`
- `uv run pytest tests/test_telegram_interactive_mailbox.py tests/test_telegram_media_typing.py tests/test_telegram_workflow_setup_mode.py -q`
- `git diff --check`
