### PR TITLE
Define file analysis boundary

### DIFF
--- a/docs/file-analysis-boundary.md
+++ b/docs/file-analysis-boundary.md
@@ -1,0 +1,54 @@
+# File Analysis Boundary
+
+## Decision
+
+Keep `src/opentulpa/agent/file_analysis.py` as a cohesive runtime-facing module for now.
+
+The file is large, but it still has one clear responsibility: turn uploaded file bytes into text or concise analysis that the agent runtime can store, cite, or use to answer a user. Splitting it today would mostly move private helpers around without reducing a current behavioral risk.
+
+## Current Boundary
+
+`file_analysis.py` owns uploaded-file analysis helpers that need direct access to raw bytes:
+
+* document and spreadsheet text extraction
+* short audio transcription
+* image summarization
+* video segmentation and synthesis
+* the runtime compatibility functions imported by `runtime.py`
+
+The runtime should keep calling these public helpers instead of reaching into media-specific internals:
+
+* `extract_uploaded_text(...)`
+* `summarize_uploaded_blob(...)`
+* `transcribe_audio_blob(...)`
+* `analyze_uploaded_file(...)`
+
+Private helpers, including video segment helpers and media-model selection helpers, are implementation details of this module.
+
+## What Does Not Belong Here
+
+Do not add workflow policy, Telegram routing, storage writes, tool registration, or user-context persistence to `file_analysis.py`.
+
+Those concerns should stay with the runtime, Telegram attachment handling, tool modules, or the relevant service layer. This module should only receive bytes plus file metadata and return extracted text or analysis.
+
+## Split Trigger
+
+Split the module only when one of these becomes true:
+
+* document extraction and media analysis need separate test fixtures or dependency gates
+* media-specific code grows enough that reviewing document extraction requires loading unrelated audio/video prompts
+* another caller needs a media-specific helper as a public API
+* optional dependencies or provider behavior diverge enough that a single module makes startup or testing brittle
+
+When splitting, keep `file_analysis.py` as a compatibility layer until callers are migrated. `runtime.py` imports should continue to work through the existing public helper names.
+
+## Preferred Future Shape
+
+If a split becomes necessary, use narrow modules:
+
+* `file_text_extraction.py` for text, PDF, DOCX, and XLSX extraction
+* `file_audio_analysis.py` for audio format inference and transcription
+* `file_media_analysis.py` for image and video analysis
+* `file_analysis.py` as the public aggregator during migration
+
+Avoid behavior changes in the same patch as the split unless a test first exposes the behavior gap.

--- a/src/opentulpa/agent/file_analysis.py
+++ b/src/opentulpa/agent/file_analysis.py
@@ -1,4 +1,8 @@
-"""Uploaded file extraction and analysis helpers for the runtime."""
+"""Uploaded file extraction and analysis helpers for the runtime.
+
+Boundary decision: keep this module as the compatibility surface for runtime
+file analysis until a split is needed. See docs/file-analysis-boundary.md.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

This documents the `file_analysis.py` module boundary for OPE-13 and keeps the current runtime import path intact.

Changes:
- Added `docs/file-analysis-boundary.md` with the decision to keep `src/opentulpa/agent/file_analysis.py` cohesive for now.
- Documented the public runtime-facing helper names, non-goals, split triggers, and preferred future module shape if the file later needs splitting.
- Added a short module docstring pointer in `file_analysis.py` so future edits can find the boundary decision.

## Behavioral regression review

Expected runtime behavior change: none.

The shape of this PR is documentation-only plus a docstring edit. It does not change function bodies, imports, tool registration, runtime wrappers, Telegram attachment handling, user-context preparation, prompt text, provider/model selection, storage writes, or public helper signatures.

Reviewed regression surfaces:
- `OpenTulpaLangGraphRuntime` still imports and exposes the same file-analysis wrappers: `_extract_uploaded_text`, `_summarize_uploaded_blob`, `_transcribe_audio_blob`, and `_analyze_uploaded_file`.
- Telegram attachment ingestion still calls `runtime.transcribe_audio_blob(...)` for voice notes and `runtime.summarize_uploaded_blob(...)` for media/file summaries.
- User-context file preparation still routes through `runtime.summarize_uploaded_blob(...)`.
- Existing tests still cover text extraction, audio format/transcription path, video segmentation/synthesis, and Telegram media-model routing.

Main residual risk:
- The document could become stale if future work splits `file_analysis.py` without updating the compatibility guidance. The module docstring pointer is intended to make that harder to miss.

## Verification

- `git diff --cached --check`
- `git show --check HEAD`
- `uv run pytest -q tests/test_file_knowledge_prep.py tests/test_voice_message_support.py tests/test_video_file_analysis.py tests/test_telegram_media_model_routing.py`

Result: 15 passed.