### PR TITLE
Allow intake agents to upsert partial sink rows

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -508,6 +508,8 @@ class _IntakeWorkflowDecision(BaseModel):
     ready_to_save: bool = False
     booking_action: str = "ignore"
     save_payload: dict[str, Any] = Field(default_factory=dict)
+    sink_action: str = "none"
+    sink_payload: dict[str, Any] = Field(default_factory=dict)
     sink_arguments: dict[str, Any] = Field(default_factory=dict)
     needs_business_knowledge: bool = False
     business_knowledge_query: str = ""
@@ -534,7 +536,8 @@ def _build_intake_workflow_system_prompt() -> str:
         "matches_workflow (bool), confidence (0..1), conversation_summary (string), "
         "extracted_fields (object), missing_fields (string array), reply_action (string), "
         "reply_text (string), ready_to_save (bool), booking_action (string), "
-        "save_payload (object), sink_arguments (object), needs_business_knowledge (bool), "
+        "save_payload (object), sink_action (string), sink_payload (object), "
+        "sink_arguments (object), needs_business_knowledge (bool), "
         "business_knowledge_query (string), knowledge_source_refs (string array), "
         "grounding_status (string), reason (string).\n\n"
         "Allowed booking_action values: ignore, update_active, edit_recent_completed, create_new_booking.\n"
@@ -558,6 +561,10 @@ def _build_intake_workflow_system_prompt() -> str:
         "- If customer messages conflict, prefer the latest customer-provided value unless the newer message is too vague to override the earlier one.\n"
         "- Do not ask for a field that is already reliably known unless the value is conflicting or unclear.\n"
         "- missing_fields must list only fields that are truly still needed before save.\n\n"
+        "Source identity policy:\n"
+        "- conversation.summary.incoming_user_id, latest_inbound_sender_id, username, and platform are backend-provided source metadata.\n"
+        "- Treat source identity values as factual when present. Do not invent them if missing.\n"
+        "- If workflow instructions ask to record the inbound user id, Telegram id, Instagram id, username, or similar source identity, use these conversation summary fields.\n\n"
         "Booking-state fast path:\n"
         "- If the latest customer message clearly cancels, reschedules, corrects, or otherwise updates an active "
         "booking or a recent completed booking, treat it as a booking-state operation. Reuse the saved booking "
@@ -602,11 +609,16 @@ def _build_intake_workflow_system_prompt() -> str:
         "- When ready_to_save=true, save_payload must contain the merged final field set that should be persisted now.\n"
         "- When ready_to_save=true, reply_text must describe the completed action. Never ask the customer to confirm "
         "a booking or change that you are saving now. If confirmation is still needed, set ready_to_save=false.\n"
+        "- When workflow instructions explicitly require writing fields before all required fields are collected, set "
+        "sink_action=upsert_partial and put only those interim fields in sink_payload. Use this for cases like "
+        "recording incoming_user_id or username on the first inbound message. Otherwise use sink_action=none and sink_payload={}. "
+        "Do not use upsert_partial for ignored conversations.\n"
         "- When needs_business_knowledge=true and workflow.knowledge_file_ids is non-empty, set ready_to_save=false, "
         'reply_action=none, reply_text="", and business_knowledge_query to the exact missing source-backed fact.\n'
         "- sink_arguments may contain sink-tool arguments or overrides discovered via tools or context "
         "(for example sheetName for Google Sheets). These are merged into the final sink write.\n"
         "- When ready_to_save=false, save_payload should usually be empty.\n"
+        "- When ready_to_save=true, leave sink_action=none; the service will perform the final save using save_payload.\n"
         "- When no sink overrides are needed, sink_arguments should usually be empty.\n"
         "- conversation_summary should be a short operational summary of what the customer currently wants.\n"
         "- reason should briefly explain the match decision and booking_action.\n\n"
@@ -743,6 +755,7 @@ def _compact_recent_messages(messages: Any) -> list[dict[str, str]]:
                 "id": _trim_text_chars(item.get("id", ""), limit=80),
                 "created_time": _trim_text_chars(item.get("created_time", ""), limit=64),
                 "sender_role": _trim_text_chars(item.get("sender_role", ""), limit=24),
+                "sender_id": _trim_text_chars(item.get("sender_id", ""), limit=80),
                 "sender_username": _trim_text_chars(item.get("sender_username", ""), limit=48),
                 "text": _trim_text_chars(item.get("text", ""), limit=300),
             }
@@ -790,8 +803,11 @@ def _compact_conversation_for_prompt(conversation: dict[str, Any]) -> dict[str, 
     summary = safe_conversation.get("summary")
     safe_summary = summary if isinstance(summary, dict) else {}
     compact_summary = {
+        "platform": _trim_text_chars(safe_summary.get("platform", ""), limit=64),
         "conversation_id": _trim_text_chars(safe_summary.get("conversation_id", ""), limit=120),
         "recipient_id": _trim_text_chars(safe_summary.get("recipient_id", ""), limit=120),
+        "incoming_user_id": _trim_text_chars(safe_summary.get("incoming_user_id", ""), limit=120),
+        "username": _trim_text_chars(safe_summary.get("username", ""), limit=64),
         "latest_inbound_message_id": _trim_text_chars(
             safe_summary.get("latest_inbound_message_id", ""),
             limit=120,
@@ -803,6 +819,10 @@ def _compact_conversation_for_prompt(conversation: dict[str, Any]) -> dict[str, 
         "latest_inbound_sender_username": _trim_text_chars(
             safe_summary.get("latest_inbound_sender_username", ""),
             limit=64,
+        ),
+        "latest_inbound_sender_id": _trim_text_chars(
+            safe_summary.get("latest_inbound_sender_id", ""),
+            limit=120,
         ),
         "latest_inbound_message_text_preview": _trim_text_chars(
             safe_summary.get("latest_inbound_message_text_preview", ""),
@@ -880,14 +900,20 @@ def _build_intake_workflow_agent_prompt(
         "Final answer contract:\n"
         "- Return strict JSON only with keys:\n"
         "  matches_workflow, confidence, conversation_summary, extracted_fields, missing_fields, "
-        "reply_action, reply_text, ready_to_save, booking_action, save_payload, sink_arguments, "
-        "needs_business_knowledge, business_knowledge_query, knowledge_source_refs, grounding_status, reason.\n"
+        "reply_action, reply_text, ready_to_save, booking_action, save_payload, sink_action, "
+        "sink_payload, sink_arguments, needs_business_knowledge, business_knowledge_query, "
+        "knowledge_source_refs, grounding_status, reason.\n"
         "- booking_action must be one of: ignore, update_active, edit_recent_completed, create_new_booking.\n"
         "- reply_action must be one of: none, send_reply, mark_cancelled.\n"
         "- If availability is blocked or conflicting, do not set ready_to_save=true.\n"
         "- If details are missing, ask one concise follow-up question in reply_text.\n"
         "- If ready_to_save=true, reply_text must be a final saved/updated/cancelled confirmation and must not ask "
         "for confirmation. If you still need confirmation from the customer, use ready_to_save=false.\n"
+        "- conversation.summary contains backend-provided source identity fields such as platform, incoming_user_id, "
+        "latest_inbound_sender_id, and username. Use them when workflow instructions ask you to record Telegram, "
+        "Instagram, user, or username metadata. Do not invent missing ids.\n"
+        "- If workflow instructions explicitly require writing fields before all required fields are collected, set "
+        "sink_action=upsert_partial and put only those interim fields in sink_payload. Otherwise use sink_action=none.\n"
         "- If needs_business_knowledge=true and workflow.knowledge_file_ids is non-empty, set ready_to_save=false, "
         'reply_action=none, reply_text="", and business_knowledge_query to the exact missing source-backed fact.\n'
         "- If the customer asks a business/service/pricing/booking question that is close to the workflow but outside its configured scope, return matches_workflow=false, booking_action=ignore, reply_action=send_reply with a concise redirect based on workflow instructions.\n"
@@ -4018,6 +4044,8 @@ class OpenTulpaLangGraphRuntime:
             "ready_to_save": bool(decision.ready_to_save),
             "booking_action": str(decision.booking_action).strip().lower() or "ignore",
             "save_payload": dict(decision.save_payload),
+            "sink_action": str(decision.sink_action).strip().lower() or "none",
+            "sink_payload": dict(decision.sink_payload),
             "sink_arguments": dict(decision.sink_arguments),
             "needs_business_knowledge": bool(decision.needs_business_knowledge),
             "business_knowledge_query": str(decision.business_knowledge_query).strip()[:500],

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -154,6 +154,15 @@ def _normalize_optional_id(value: Any) -> str:
     return text
 
 
+def _incoming_user_id(conversation_summary: dict[str, Any]) -> str:
+    return str(
+        conversation_summary.get("incoming_user_id")
+        or conversation_summary.get("latest_inbound_sender_id")
+        or conversation_summary.get("latest_inbound_sender_user_id")
+        or ""
+    ).strip()
+
+
 def _clean_mapping(value: Any) -> dict[str, str]:
     if not isinstance(value, dict):
         return {}
@@ -442,6 +451,7 @@ class IntakeWorkflowService:
             "latest_inbound_message_id": str(
                 conversation_summary.get("latest_inbound_message_id", "") or ""
             ).strip(),
+            "latest_inbound_sender_id": _incoming_user_id(conversation_summary),
             "latest_inbound_sender_username": str(
                 conversation_summary.get("latest_inbound_sender_username", "") or ""
             ).strip(),
@@ -478,6 +488,36 @@ class IntakeWorkflowService:
         log_event = getattr(runtime, "log_behavior_event", None)
         if callable(log_event):
             log_event(event=event, **fields)
+
+    @staticmethod
+    def _source_platform(workflow: dict[str, Any]) -> str:
+        channel = str(workflow.get("channel", "") or "").strip().lower()
+        provider = str(workflow.get("provider", "") or "").strip().lower()
+        if channel == "telegram_business_dm" and provider == "telegram_bot_api":
+            return "telegram_business"
+        if channel == "instagram_dm" and provider == "composio":
+            return "instagram"
+        return channel or provider or "unknown"
+
+    def _enrich_conversation_summary(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        summary = dict(_safe_dict(conversation_summary))
+        incoming_user_id = _incoming_user_id(summary)
+        username = str(
+            summary.get("username")
+            or summary.get("latest_inbound_sender_username")
+            or ""
+        ).strip()
+        if incoming_user_id:
+            summary["incoming_user_id"] = incoming_user_id
+        if username:
+            summary["username"] = username
+        summary.setdefault("platform", self._source_platform(workflow))
+        return summary
 
     def _conversation_lock(self, *, workflow_id: str, conversation_id: str) -> asyncio.Lock:
         key = f"{workflow_id}:{conversation_id}"
@@ -1689,6 +1729,8 @@ class IntakeWorkflowService:
             "workflow_id": str(workflow.get("workflow_id", "") or "sample_workflow_id"),
             "conversation_id": "sample_conversation_id",
             "customer_id": str(workflow.get("customer_id", "") or "sample_customer_id"),
+            "incoming_user_id": "sample_incoming_user_id",
+            "latest_inbound_sender_id": "sample_incoming_user_id",
         }
         static_arguments = _safe_dict(sink_config.get("static_arguments"))
         field_mapping = _clean_mapping(sink_config.get("field_mapping"))
@@ -2722,7 +2764,10 @@ class IntakeWorkflowService:
         errors: list[str] = []
         result_items: list[dict[str, Any]] = []
         for item in items:
-            conversation_summary = _safe_dict(item)
+            conversation_summary = self._enrich_conversation_summary(
+                workflow=workflow,
+                conversation_summary=_safe_dict(item),
+            )
             conversation_id = str(conversation_summary.get("conversation_id", "") or "").strip()
             if not conversation_id:
                 continue
@@ -2740,6 +2785,10 @@ class IntakeWorkflowService:
                         workflow=workflow,
                         conversation_id=conversation_id,
                         fallback=conversation_summary,
+                    )
+                    conversation_summary = self._enrich_conversation_summary(
+                        workflow=workflow,
+                        conversation_summary=conversation_summary,
                     )
                     if refresh_error:
                         errors.append(f"{conversation_id}: {refresh_error}")
@@ -2822,7 +2871,10 @@ class IntakeWorkflowService:
                     )
                     continue
 
-                cursor_summary = detailed_summary or conversation_summary
+                cursor_summary = self._enrich_conversation_summary(
+                    workflow=workflow,
+                    conversation_summary=detailed_summary or conversation_summary,
+                )
                 latest_inbound_id = str(cursor_summary.get("latest_inbound_message_id", "") or "").strip()
                 latest_inbound_time = str(
                     cursor_summary.get("latest_inbound_message_created_time", "") or ""
@@ -3307,6 +3359,8 @@ class IntakeWorkflowService:
             missing_fields=_unique_string_list(decision.get("missing_fields")),
             extracted_fields=_safe_dict(decision.get("extracted_fields")),
             save_payload=_safe_dict(decision.get("save_payload")),
+            sink_action=str(decision.get("sink_action", "") or "").strip().lower(),
+            sink_payload=_safe_dict(decision.get("sink_payload")),
             reason=str(decision.get("reason", "") or "").strip(),
         )
         return decision, None
@@ -3326,6 +3380,8 @@ class IntakeWorkflowService:
         ready_to_save = bool(decision.get("ready_to_save"))
         reply_action = str(decision.get("reply_action", "none") or "none").strip().lower()
         reply_text = str(decision.get("reply_text", "") or "").strip()
+        sink_action = str(decision.get("sink_action", "none") or "none").strip().lower()
+        sink_payload = _safe_dict(decision.get("sink_payload"))
         self._emit_observability(
             event="intake.apply.start",
             workflow=workflow,
@@ -3333,7 +3389,23 @@ class IntakeWorkflowService:
             booking_action=booking_action,
             reply_action=reply_action,
             ready_to_save=ready_to_save,
+            sink_action=sink_action,
         )
+        if sink_action not in {"none", "upsert_partial"}:
+            error = f"unsupported sink_action={sink_action}"
+            self._emit_observability(
+                event="intake.apply.error",
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                phase="decision_validation",
+                error=error,
+                sink_action=sink_action,
+            )
+            return {}, error, self._build_recovery_feedback(
+                phase="decision_validation",
+                error=error,
+                decision=decision,
+            )
         if booking_action not in {
             "ignore",
             "update_active",
@@ -3348,6 +3420,22 @@ class IntakeWorkflowService:
                 phase="decision_validation",
                 error=error,
                 booking_action=booking_action,
+            )
+            return {}, error, self._build_recovery_feedback(
+                phase="decision_validation",
+                error=error,
+                decision=decision,
+            )
+        if booking_action == "ignore" and sink_action != "none":
+            error = "sink_action requires an active booking action"
+            self._emit_observability(
+                event="intake.apply.error",
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                phase="decision_validation",
+                error=error,
+                booking_action=booking_action,
+                sink_action=sink_action,
             )
             return {}, error, self._build_recovery_feedback(
                 phase="decision_validation",
@@ -3472,6 +3560,8 @@ class IntakeWorkflowService:
 
         extracted_fields = dict(_safe_dict(target_booking.get("extracted_fields")))
         extracted_fields.update(_safe_dict(decision.get("extracted_fields")))
+        if not ready_to_save and sink_action == "upsert_partial":
+            extracted_fields.update(sink_payload)
         conversation_summary_text = str(decision.get("conversation_summary", "") or "").strip()
         if not conversation_summary_text:
             conversation_summary_text = str(
@@ -3578,6 +3668,7 @@ class IntakeWorkflowService:
                 sink_result, sink_error = self._write_to_sink(
                     workflow=workflow,
                     booking=target_booking,
+                    conversation_summary=conversation_summary,
                     payload=save_payload,
                     sink_arguments=sink_arguments,
                 )
@@ -3679,6 +3770,67 @@ class IntakeWorkflowService:
             target_booking["sink_write_status"] = sink_status
             target_booking["sink_record_ref"] = sink_ref
             target_booking["updated_at"] = _utc_now_iso()
+            if sink_action == "upsert_partial" and sink_payload:
+                sink_type = str(workflow.get("sink_type", "") or "").strip().lower()
+                if sink_type not in {"google_sheets_composio", "generic_composio_write"}:
+                    error = "sink_action=upsert_partial requires a Composio upsert sink"
+                    self._emit_observability(
+                        event="intake.apply.error",
+                        workflow=workflow,
+                        conversation_summary=conversation_summary,
+                        phase="decision_validation",
+                        error=error,
+                        booking_id=str(target_booking.get("booking_id", "") or "").strip(),
+                        sink_type=sink_type,
+                    )
+                    return {}, error, self._build_recovery_feedback(
+                        phase="decision_validation",
+                        error=error,
+                        decision=decision,
+                    )
+                self._emit_observability(
+                    event="intake.sink_write.partial_start",
+                    workflow=workflow,
+                    conversation_summary=conversation_summary,
+                    booking_id=str(target_booking.get("booking_id", "") or "").strip(),
+                    sink_type=str(workflow.get("sink_type", "") or "").strip(),
+                    payload=sink_payload,
+                )
+                sink_result, sink_error = self._write_to_sink(
+                    workflow=workflow,
+                    booking=target_booking,
+                    conversation_summary=conversation_summary,
+                    payload=sink_payload,
+                    sink_arguments=sink_arguments,
+                )
+                if sink_error is not None:
+                    target_booking["sink_write_status"] = "failed"
+                    self._upsert_booking(target_booking)
+                    self._emit_observability(
+                        event="intake.sink_write.partial_error",
+                        workflow=workflow,
+                        conversation_summary=conversation_summary,
+                        booking_id=str(target_booking.get("booking_id", "") or "").strip(),
+                        sink_type=str(workflow.get("sink_type", "") or "").strip(),
+                        error=sink_error,
+                    )
+                    return {}, sink_error, self._build_recovery_feedback(
+                        phase="sink_execution",
+                        error=sink_error,
+                        decision=decision,
+                    )
+                sink_status = "partial_succeeded"
+                sink_ref = _safe_dict(sink_result)
+                target_booking["sink_write_status"] = sink_status
+                target_booking["sink_record_ref"] = sink_ref
+                self._emit_observability(
+                    event="intake.sink_write.partial_ok",
+                    workflow=workflow,
+                    conversation_summary=conversation_summary,
+                    booking_id=str(target_booking.get("booking_id", "") or "").strip(),
+                    sink_type=str(workflow.get("sink_type", "") or "").strip(),
+                    sink_result=sink_ref,
+                )
             self._upsert_booking(target_booking)
 
         if reply_action == "send_reply":
@@ -3768,6 +3920,8 @@ class IntakeWorkflowService:
                 "missing_fields": _unique_string_list(decision.get("missing_fields")),
                 "extracted_fields": _safe_dict(decision.get("extracted_fields")),
                 "save_payload": _safe_dict(decision.get("save_payload")),
+                "sink_action": str(decision.get("sink_action", "") or "").strip().lower(),
+                "sink_payload": _safe_dict(decision.get("sink_payload")),
                 "sink_arguments": _safe_dict(decision.get("sink_arguments")),
             },
         }
@@ -3872,6 +4026,7 @@ class IntakeWorkflowService:
         *,
         workflow: dict[str, Any],
         booking: dict[str, Any],
+        conversation_summary: dict[str, Any],
         payload: dict[str, Any],
         sink_arguments: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], str | None]:
@@ -3880,12 +4035,14 @@ class IntakeWorkflowService:
             return self._write_to_local_csv(
                 workflow=workflow,
                 booking=booking,
+                conversation_summary=conversation_summary,
                 payload=payload,
             )
         if sink_type in {"google_sheets_composio", "generic_composio_write"}:
             return self._write_to_composio_sink(
                 workflow=workflow,
                 booking=booking,
+                conversation_summary=conversation_summary,
                 payload=payload,
                 sink_arguments=sink_arguments,
             )
@@ -3896,6 +4053,7 @@ class IntakeWorkflowService:
         *,
         workflow: dict[str, Any],
         booking: dict[str, Any],
+        conversation_summary: dict[str, Any],
         payload: dict[str, Any],
     ) -> tuple[dict[str, Any], str | None]:
         sink_config = _safe_dict(workflow.get("sink_config"))
@@ -3954,6 +4112,7 @@ class IntakeWorkflowService:
         *,
         workflow: dict[str, Any],
         booking: dict[str, Any],
+        conversation_summary: dict[str, Any],
         payload: dict[str, Any],
         sink_arguments: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], str | None]:
@@ -3998,6 +4157,8 @@ class IntakeWorkflowService:
             "workflow_id": str(workflow["workflow_id"]),
             "conversation_id": str(booking["conversation_id"]),
             "customer_id": str(workflow["customer_id"]),
+            "incoming_user_id": _incoming_user_id(conversation_summary),
+            "latest_inbound_sender_id": _incoming_user_id(conversation_summary),
         }
         toolkit = _normalize_toolkit_slug(sink_config.get("toolkit"))
         tool_slug = self._resolve_composio_sink_tool_slug(

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -163,6 +163,14 @@ def _incoming_user_id(conversation_summary: dict[str, Any]) -> str:
     ).strip()
 
 
+def _incoming_username(conversation_summary: dict[str, Any]) -> str:
+    return str(
+        conversation_summary.get("username")
+        or conversation_summary.get("latest_inbound_sender_username")
+        or ""
+    ).strip()
+
+
 def _clean_mapping(value: Any) -> dict[str, str]:
     if not isinstance(value, dict):
         return {}
@@ -507,11 +515,7 @@ class IntakeWorkflowService:
     ) -> dict[str, Any]:
         summary = dict(_safe_dict(conversation_summary))
         incoming_user_id = _incoming_user_id(summary)
-        username = str(
-            summary.get("username")
-            or summary.get("latest_inbound_sender_username")
-            or ""
-        ).strip()
+        username = _incoming_username(summary)
         if incoming_user_id:
             summary["incoming_user_id"] = incoming_user_id
         if username:
@@ -4159,6 +4163,8 @@ class IntakeWorkflowService:
             "customer_id": str(workflow["customer_id"]),
             "incoming_user_id": _incoming_user_id(conversation_summary),
             "latest_inbound_sender_id": _incoming_user_id(conversation_summary),
+            "username": _incoming_username(conversation_summary),
+            "latest_inbound_sender_username": _incoming_username(conversation_summary),
         }
         toolkit = _normalize_toolkit_slug(sink_config.get("toolkit"))
         tool_slug = self._resolve_composio_sink_tool_slug(

--- a/src/opentulpa/interfaces/telegram/business.py
+++ b/src/opentulpa/interfaces/telegram/business.py
@@ -440,6 +440,7 @@ class TelegramBusinessService:
                     "latest_inbound_message_id": str((latest_inbound or {}).get("message_id", "") or ""),
                     "latest_inbound_message_created_time": str((latest_inbound or {}).get("date_iso", "") or ""),
                     "latest_inbound_message_text_preview": str((latest_inbound or {}).get("text", "") or "")[:280],
+                    "latest_inbound_sender_id": str((latest_inbound or {}).get("from_user_id", "") or ""),
                     "latest_inbound_sender_username": str((latest_inbound or {}).get("from_username", "") or ""),
                     "latest_outbound_message_id": str((latest_outbound or {}).get("message_id", "") or ""),
                     "latest_outbound_message_created_time": str((latest_outbound or {}).get("date_iso", "") or ""),

--- a/tests/e2e/scenarios/test_google_sheets_sink_resolution.py
+++ b/tests/e2e/scenarios/test_google_sheets_sink_resolution.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from harness.runner import E2EHarness
 
+from opentulpa.intake import service as intake_service_module
 from tests.test_intake_workflow_service import (
     _FakeComposio,
     _FakeRuntime,
@@ -15,6 +17,75 @@ from tests.test_intake_workflow_service import (
 )
 
 pytestmark = [pytest.mark.e2e, pytest.mark.telegram]
+
+
+def _wait_until(predicate: Any, timeout_seconds: float = 45.0) -> bool:
+    import time
+
+    deadline = time.time() + max(0.1, float(timeout_seconds))
+    while time.time() < deadline:
+        if bool(predicate()):
+            return True
+        time.sleep(0.2)
+    return bool(predicate())
+
+
+def _business_message(
+    *,
+    business_connection_id: str,
+    lead_chat_id: int,
+    lead_user_id: int,
+    username: str,
+    message_id: int,
+    text: str,
+) -> dict[str, Any]:
+    return {
+        "update_id": int(datetime.now(UTC).timestamp() * 1000) + int(message_id),
+        "business_message": {
+            "business_connection_id": business_connection_id,
+            "message_id": message_id,
+            "date": int(datetime.now(UTC).timestamp()),
+            "chat": {"id": lead_chat_id, "type": "private", "username": username},
+            "from": {"id": lead_user_id, "is_bot": False, "username": username},
+            "text": text,
+        },
+    }
+
+
+def _telegram_message(*, chat_id: int, user_id: int, text: str, message_id: int) -> dict[str, Any]:
+    return {
+        "update_id": int(datetime.now(UTC).timestamp() * 1000) + int(message_id),
+        "message": {
+            "message_id": message_id,
+            "date": int(datetime.now(UTC).timestamp()),
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {"id": user_id, "is_bot": False, "username": f"user_{user_id}"},
+            "text": text,
+        },
+    }
+
+
+def _list_workflows(harness: E2EHarness, *, customer_id: str) -> list[dict[str, Any]]:
+    response = harness.client.post(
+        "/internal/intake/workflows/list",
+        json={"customer_id": customer_id, "include_disabled": True},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    workflows = payload.get("workflows") or []
+    return workflows if isinstance(workflows, list) else []
+
+
+def _first_sheet_row(write: dict[str, Any]) -> dict[str, Any]:
+    normalized = write.get("normalized_rows")
+    if isinstance(normalized, list) and normalized and isinstance(normalized[0], dict):
+        return dict(normalized[0])
+    args = write.get("arguments") if isinstance(write.get("arguments"), dict) else {}
+    headers = args.get("headers")
+    rows = args.get("rows")
+    if isinstance(headers, list) and isinstance(rows, list) and rows and isinstance(rows[0], list):
+        return dict(zip([str(item) for item in headers], rows[0], strict=False))
+    return {}
 
 
 @pytest.mark.asyncio
@@ -143,6 +214,162 @@ async def test_google_sheets_sink_resolves_single_tab_for_telegram_business_inta
     )
     assert written["тип услуги"] == "Мойка"
     assert written["время записи"] == "завтра 10:00"
+
+
+@pytest.mark.live_llm
+def test_live_llm_telegram_business_intake_upserts_partial_identity_then_final_row(
+    e2e_harness: E2EHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(intake_service_module, "_TELEGRAM_BUSINESS_WEBHOOK_SETTLE_SECONDS", 0.0)
+    monkeypatch.setattr(intake_service_module, "_PENDING_RUN_POLL_SECONDS", 0.02)
+
+    owner_user_id = 321
+    owner_chat_id = 654
+    customer_id = f"telegram_{owner_user_id}"
+    business_connection_id = "bc_e2e_partial_identity"
+    lead_chat_id = 7001
+    lead_user_id = 9001
+    lead_username = "partial_lead_9001"
+
+    e2e_harness.client.app.state.telegram_business.upsert_connection(
+        {
+            "id": business_connection_id,
+            "user_chat_id": owner_chat_id,
+            "is_enabled": True,
+            "user": {"id": owner_user_id, "is_bot": False, "first_name": "Kim"},
+            "rights": {"can_reply": True},
+        }
+    )
+    assert (
+        e2e_harness.post_telegram(
+            body=_telegram_message(chat_id=owner_chat_id, user_id=owner_user_id, text="/fresh", message_id=100)
+        )
+        == 200
+    )
+    assert _wait_until(
+        lambda: any(
+            int(item.get("chat_id", 0)) == owner_chat_id
+            and "fresh chat context" in str(item.get("text", "")).lower()
+            for item in e2e_harness.telegram_client.sent_messages
+        ),
+        timeout_seconds=45.0,
+    )
+
+    owner_message_count = len(e2e_harness.telegram_client.sent_messages)
+    assert (
+        e2e_harness.post_telegram(
+            body=_telegram_message(
+                chat_id=owner_chat_id,
+                user_id=owner_user_id,
+                message_id=101,
+                text=(
+                    "Create a Telegram Business DM intake workflow named 'Live Partial Identity Intake'. "
+                    "Use the already connected Telegram Business account. "
+                    "The workflow handles car wash booking leads. Required fields are exactly: service, name, phone, time. "
+                    "Critical behavior: on the first inbound message from a new intake user, before all required fields are collected, "
+                    "record the backend-provided incoming_user_id, username, and conversation_id in Google Sheets by using "
+                    "sink_action=upsert_partial with those exact fields in sink_payload. Then ask for missing booking details. "
+                    "When the lead later provides service, name, phone, and time, save the final booking normally. "
+                    "Do not invent ids; use conversation.summary source identity fields. "
+                    "Save to Google Sheets with sink_type google_sheets_composio, toolkit googlesheets, "
+                    "spreadsheetId=sheet_partial_identity, sheetName=Bookings, and field_mapping: "
+                    "incoming_user_id -> Telegram ID, username -> Username, conversation_id -> Conversation ID, "
+                    "service -> Service, name -> Name, phone -> Phone, time -> Time. "
+                    "Prepare the exact configuration and wait for my confirmation before saving."
+                ),
+            )
+        )
+        == 200
+    )
+    assert _wait_until(
+        lambda: len(e2e_harness.telegram_client.sent_messages) > owner_message_count,
+        timeout_seconds=90.0,
+    )
+    assert _list_workflows(e2e_harness, customer_id=customer_id) == []
+    assert (
+        e2e_harness.post_telegram(
+            body=_telegram_message(
+                chat_id=owner_chat_id,
+                user_id=owner_user_id,
+                message_id=102,
+                text="Looks correct. Save and activate this workflow now exactly as proposed.",
+            )
+        )
+        == 200
+    )
+    assert _wait_until(
+        lambda: len(_list_workflows(e2e_harness, customer_id=customer_id)) == 1,
+        timeout_seconds=90.0,
+    )
+    workflow = _list_workflows(e2e_harness, customer_id=customer_id)[0]
+    assert workflow["name"] == "Live Partial Identity Intake"
+    assert workflow["channel"] == "telegram_business_dm"
+    assert workflow["provider"] == "telegram_bot_api"
+    assert workflow["enabled"] is True
+    assert workflow["source_config"] == {"business_connection_id": business_connection_id}
+
+    assert (
+        e2e_harness.post_telegram(
+            body=_business_message(
+                business_connection_id=business_connection_id,
+                lead_chat_id=lead_chat_id,
+                lead_user_id=lead_user_id,
+                username=lead_username,
+                message_id=1,
+                text="Hi, I want to book a wash.",
+            )
+        )
+        == 200
+    )
+    assert _wait_until(
+        lambda: len(getattr(e2e_harness.composio_service, "sheet_writes", [])) >= 1,
+        timeout_seconds=90.0,
+    )
+    first_write = _first_sheet_row(e2e_harness.composio_service.sheet_writes[0])
+    assert first_write["Telegram ID"] == str(lead_user_id)
+    assert first_write["Username"] == lead_username
+    assert first_write["Conversation ID"] == str(lead_chat_id)
+    bookings = e2e_harness.list_bookings(
+        customer_id=customer_id,
+        workflow_id=workflow["workflow_id"],
+        conversation_id=str(lead_chat_id),
+    )
+    assert bookings and bookings[0]["status"] == "active"
+
+    assert (
+        e2e_harness.post_telegram(
+            body=_business_message(
+                business_connection_id=business_connection_id,
+                lead_chat_id=lead_chat_id,
+                lead_user_id=lead_user_id,
+                username=lead_username,
+                message_id=2,
+                text="Express wash, name Alice, phone +79990000001, tomorrow 10am.",
+            )
+        )
+        == 200
+    )
+    assert _wait_until(
+        lambda: any(
+            str(item.get("status", "")).strip() == "completed"
+            for item in e2e_harness.list_bookings(
+                customer_id=customer_id,
+                workflow_id=workflow["workflow_id"],
+                conversation_id=str(lead_chat_id),
+            )
+        )
+        and len(getattr(e2e_harness.composio_service, "sheet_writes", [])) >= 2,
+        timeout_seconds=90.0,
+    )
+    second_write = _first_sheet_row(e2e_harness.composio_service.sheet_writes[-1])
+    assert second_write["Booking ID"] == first_write["Booking ID"]
+    assert second_write["Telegram ID"] == str(lead_user_id)
+    assert second_write["Username"] == lead_username
+    assert second_write["Service"]
+    assert second_write["Name"]
+    assert second_write["Phone"]
+    assert second_write["Time"]
 
 
 def test_google_sheets_sink_setup_rejects_ambiguous_multi_tab_target(tmp_path: Path) -> None:

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -3780,7 +3780,6 @@ async def test_telegram_business_intake_can_upsert_partial_google_sheets_row(
                 "sink_action": "upsert_partial",
                 "sink_payload": {
                     "incoming_user_id": "999",
-                    "username": "alice",
                     "service": "wash",
                 },
                 "reason": "Workflow asks to record source identity on first contact.",

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -3757,6 +3757,199 @@ async def test_google_sheets_sink_auto_resolves_single_unknown_sheet_name_at_set
     assert written["Телефон"] == "+79990000001"
 
 
+@pytest.mark.asyncio
+async def test_telegram_business_intake_can_upsert_partial_google_sheets_row(
+    tmp_path: Path,
+) -> None:
+    customer_id = "telegram_123"
+    business_connection_id = "bc_partial"
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.96,
+                "conversation_summary": "Customer opened a booking.",
+                "extracted_fields": {"service": "wash"},
+                "missing_fields": ["name", "phone", "time"],
+                "reply_action": "send_reply",
+                "reply_text": "What name, phone, and time should I use?",
+                "ready_to_save": False,
+                "booking_action": "create_new_booking",
+                "save_payload": {},
+                "sink_action": "upsert_partial",
+                "sink_payload": {
+                    "incoming_user_id": "999",
+                    "username": "alice",
+                    "service": "wash",
+                },
+                "reason": "Workflow asks to record source identity on first contact.",
+            },
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.98,
+                "conversation_summary": "Customer provided all booking details.",
+                "extracted_fields": {
+                    "name": "Alice",
+                    "phone": "+79990000001",
+                    "time": "tomorrow 10am",
+                },
+                "missing_fields": [],
+                "reply_action": "send_reply",
+                "reply_text": "Booked for tomorrow at 10am.",
+                "ready_to_save": True,
+                "booking_action": "update_active",
+                "save_payload": {
+                    "name": "Alice",
+                    "phone": "+79990000001",
+                    "time": "tomorrow 10am",
+                },
+                "sink_action": "none",
+                "sink_payload": {},
+                "reason": "All required fields are present.",
+            },
+        ]
+    )
+    composio = _FakeComposio(
+        {
+            "conversation_id": "unused",
+            "recipient_id": "unused",
+            "latest_inbound_message_id": "unused",
+            "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        },
+        _instagram_conversation(
+            conversation_id="unused",
+            latest_message_id="unused",
+            latest_message_text="unused",
+            latest_message_time="2026-04-07T08:00:00+00:00",
+        ),
+    )
+    service, _, _, telegram_business, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=composio,
+    )
+    telegram_business.upsert_connection(
+        {
+            "id": business_connection_id,
+            "user_chat_id": 777,
+            "is_enabled": True,
+            "user": {"id": 123, "is_bot": False, "first_name": "Kim"},
+            "rights": {"can_reply": True},
+        }
+    )
+    workflow = service.upsert_workflow(
+        customer_id=customer_id,
+        name="Partial Row Intake",
+        channel="telegram_business_dm",
+        provider="telegram_bot_api",
+        source_config={"business_connection_id": business_connection_id},
+        intent_description="Collect booking details and record lead identity immediately.",
+        required_fields=["name", "phone", "time"],
+        assistant_instructions="Record incoming_user_id and username on first contact before all fields are collected.",
+        sink_type="google_sheets_composio",
+        sink_config={
+            "toolkit": "googlesheets",
+            "field_mapping": {
+                "incoming_user_id": "Telegram ID",
+                "username": "Username",
+                "service": "Service",
+                "name": "Name",
+                "phone": "Phone",
+                "time": "Time",
+            },
+            "static_arguments": {
+                "spreadsheetId": "sheet_123",
+                "sheetName": "Bookings",
+            },
+        },
+    )
+
+    telegram_business.upsert_message(
+        business_connection_id=business_connection_id,
+        customer_id=customer_id,
+        message=_telegram_business_inbound(
+            business_connection_id=business_connection_id,
+            chat_id=555,
+            user_id=999,
+            username="alice",
+            message_id=10,
+            text="Hi, I need a wash.",
+            date=int(datetime.now(UTC).timestamp()),
+        ),
+    )
+
+    first = await service.run_workflow(
+        customer_id=customer_id,
+        workflow_id=workflow["workflow_id"],
+        event_type="telegram_business_webhook",
+    )
+
+    assert first["ok"] is True
+    assert len(composio.execute_calls) == 1
+    first_write = dict(
+        zip(
+            composio.execute_calls[0]["arguments"]["headers"],
+            composio.execute_calls[0]["arguments"]["rows"][0],
+            strict=False,
+        )
+    )
+    assert first_write["Telegram ID"] == "999"
+    assert first_write["Username"] == "alice"
+    assert first_write["Service"] == "wash"
+    bookings = service.list_bookings(
+        customer_id=customer_id,
+        workflow_id=workflow["workflow_id"],
+        conversation_id="555",
+    )
+    assert bookings[0]["status"] == "active"
+    assert bookings[0]["sink_write_status"] == "partial_succeeded"
+    assert bookings[0]["extracted_fields"]["incoming_user_id"] == "999"
+
+    telegram_business.upsert_message(
+        business_connection_id=business_connection_id,
+        customer_id=customer_id,
+        message=_telegram_business_inbound(
+            business_connection_id=business_connection_id,
+            chat_id=555,
+            user_id=999,
+            username="alice",
+            message_id=11,
+            text="Alice, +79990000001, tomorrow 10am.",
+            date=int(datetime.now(UTC).timestamp()),
+        ),
+    )
+
+    second = await service.run_workflow(
+        customer_id=customer_id,
+        workflow_id=workflow["workflow_id"],
+        event_type="telegram_business_webhook",
+    )
+
+    assert second["ok"] is True
+    assert len(composio.execute_calls) == 2
+    second_write = dict(
+        zip(
+            composio.execute_calls[1]["arguments"]["headers"],
+            composio.execute_calls[1]["arguments"]["rows"][0],
+            strict=False,
+        )
+    )
+    assert second_write["Booking ID"] == first_write["Booking ID"]
+    assert second_write["Telegram ID"] == "999"
+    assert second_write["Name"] == "Alice"
+    assert second_write["Phone"] == "+79990000001"
+    assert second_write["Time"] == "tomorrow 10am"
+    bookings = service.list_bookings(
+        customer_id=customer_id,
+        workflow_id=workflow["workflow_id"],
+        conversation_id="555",
+    )
+    assert bookings[0]["status"] == "completed"
+    assert bookings[0]["sink_write_status"] == "succeeded"
+
+
 def test_google_sheets_sink_requires_explicit_sheet_name_when_target_has_multiple_tabs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_telegram_business_service.py
+++ b/tests/test_telegram_business_service.py
@@ -43,6 +43,7 @@ def test_telegram_business_service_persists_connection_and_message_state(tmp_pat
     )
     assert conversations["items"][0]["conversation_id"] == "555"
     assert conversations["items"][0]["latest_inbound_message_id"] == "10"
+    assert conversations["items"][0]["latest_inbound_sender_id"] == "999"
 
 
 def test_telegram_business_service_can_bind_connection_to_configured_owner(


### PR DESCRIPTION
## Summary
- add an agent-directed `sink_action=upsert_partial` path so intake workflows can write interim fields without completing the booking
- expose backend-derived source identity context (`incoming_user_id`, username, platform, latest inbound sender id) to intake decisions and sink payload enrichment
- preserve final-save behavior while letting Google Sheets/Composio sinks receive partial rows keyed by the active booking id
- add focused service coverage plus a live-LLM E2E that creates the workflow through owner chat, confirms it, then verifies first-message partial write and final completion write

Linear: OPE-55 https://linear.app/opentulpa/issue/OPE-55/allow-intake-agents-to-upsert-partial-sink-rows-with-source-identity

## E2E realism
The live E2E is as real as this repo harness currently allows without hitting external Telegram/Sheets by default: it uses the live LLM for owner workflow creation/confirmation and for intake decisions, sends webhook-shaped Telegram Business messages through the app, persists real intake state, and records sink writes through the harness fake/recording Sheets sink. Real Composio/Sheets can still be exercised with the existing real-Composio flag.

## Verification
- `uv run ruff check src/opentulpa/agent/runtime.py src/opentulpa/intake/service.py src/opentulpa/interfaces/telegram/business.py tests/test_intake_workflow_service.py tests/test_telegram_business_service.py tests/e2e/scenarios/test_google_sheets_sink_resolution.py`
- `uv run pytest tests/test_telegram_business_service.py tests/test_intake_workflow_service.py::test_telegram_business_intake_can_upsert_partial_google_sheets_row tests/test_runtime_structured_model.py -q`
- `uv run pytest tests/test_intake_workflow_service.py -q`
- `uv run pytest tests/e2e/scenarios/test_google_sheets_sink_resolution.py::test_live_llm_telegram_business_intake_upserts_partial_identity_then_final_row --run-e2e --run-live-llm -q`
- `git diff --check`