### PR TITLE
Harden tool and stream reliability

### DIFF
--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -12,7 +12,7 @@ from langchain.chat_models import init_chat_model
 from langchain_openrouter import ChatOpenRouter
 from pydantic import BaseModel
 
-from opentulpa.agent.lc_messages import SystemMessage
+from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
 from opentulpa.agent.utils import content_to_text as _content_to_text
 
 logger = logging.getLogger(__name__)
@@ -650,7 +650,54 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
         )
         raw = _content_to_text(getattr(response, "content", response)).strip()
         if raw:
-            return schema.model_validate_json(clean_json_text_block(raw)), None
+            try:
+                return schema.model_validate_json(clean_json_text_block(raw)), None
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                repair_messages = list(messages) + [
+                    SystemMessage(
+                        content=(
+                            "Your previous structured output could not be parsed against the required schema. "
+                            "Return only one valid JSON object for that schema. Do not include markdown, prose, "
+                            "tool calls, or explanatory text."
+                        )
+                    ),
+                    HumanMessage(
+                        content=(
+                            f"Schema name: {schema.__name__}\n"
+                            f"Parse error: {last_error}\n"
+                            f"Previous output:\n{raw[:4000]}"
+                        )
+                    ),
+                ]
+                runtime.log_behavior_event(
+                    event="llm.invoke.structured_repair_retry",
+                    model_name=resolved_model_name,
+                    call_site=str((call_context or {}).get("call_site") or "structured_model_fallback"),
+                    trace_id=str((call_context or {}).get("trace_id") or ""),
+                    thread_id=str((call_context or {}).get("thread_id") or ""),
+                    customer_id=str((call_context or {}).get("customer_id") or ""),
+                    error=last_error,
+                )
+                repair_response = await runtime.ainvoke_model(
+                    model,
+                    repair_messages,
+                    model_name=resolved_model_name,
+                    stable_prefix_count=stable_prefix_count,
+                    call_context={
+                        **dict(call_context or {}),
+                        "call_site": str(
+                            (call_context or {}).get("call_site")
+                            or "structured_model_fallback"
+                        )
+                        + "_repair",
+                    },
+                )
+                repair_raw = _content_to_text(
+                    getattr(repair_response, "content", repair_response)
+                ).strip()
+                if repair_raw:
+                    return schema.model_validate_json(clean_json_text_block(repair_raw)), None
     except Exception as exc:
         last_error = f"{type(exc).__name__}: {exc}"
     return None, last_error

--- a/src/opentulpa/agent/tools/composio_tools.py
+++ b/src/opentulpa/agent/tools/composio_tools.py
@@ -9,6 +9,39 @@ from langchain.tools import tool
 from opentulpa.agent.tools.common import require_customer_id
 
 
+def _toolkit_from_slug(tool_slug: str) -> str:
+    prefix = str(tool_slug or "").strip().split("_", 1)[0].lower()
+    if prefix == "googlesheets":
+        return "googlesheets"
+    if prefix == "googledrive":
+        return "googledrive"
+    if prefix == "instagram":
+        return "instagram"
+    return prefix
+
+
+def _composio_failure_payload(
+    *,
+    operation: str,
+    status_code: int,
+    response_text: str,
+    retryable: bool,
+    suggested_next_action: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ok": False,
+        "error": f"{operation} failed",
+        "status_code": status_code,
+        "retryable": retryable,
+        "response": response_text,
+        "suggested_next_action": suggested_next_action,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
 def register_composio_tools(runtime: Any) -> dict[str, Any]:
     @tool
     async def composio_status() -> Any:
@@ -209,12 +242,44 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
     ) -> Any:
         """Execute a Composio tool for the active user using explicit JSON arguments from the tool schema. For Instagram sends, verify the exact thread first with composio_instagram_reply_precheck."""
         customer_id = require_customer_id(runtime)
+        safe_tool_slug = str(tool_slug or "").strip()
+        schema_response = await runtime._request_with_backoff(
+            "GET",
+            f"/internal/composio/tools/{safe_tool_slug}/schema",
+            timeout=20.0,
+        )
+        if schema_response.status_code != 200:
+            toolkit = _toolkit_from_slug(safe_tool_slug)
+            candidates: Any = []
+            if toolkit:
+                search_response = await runtime._request_with_backoff(
+                    "GET",
+                    "/internal/composio/tools/search",
+                    params={"query": safe_tool_slug, "toolkits": toolkit, "limit": 8},
+                    timeout=20.0,
+                )
+                if search_response.status_code == 200:
+                    candidates = search_response.json().get("items", [])
+            return _composio_failure_payload(
+                operation="composio_tool_execute preflight",
+                status_code=schema_response.status_code,
+                response_text=schema_response.text,
+                retryable=False,
+                suggested_next_action=(
+                    "The requested Composio tool slug is not available. Choose one of the "
+                    "candidate tools from composio_tool_search, then retry with that exact slug."
+                ),
+                extra={
+                    "tool_slug": safe_tool_slug,
+                    "candidate_tools": candidates,
+                },
+            )
         r = await runtime._request_with_backoff(
             "POST",
             "/internal/composio/tools/execute",
             json_body={
                 "customer_id": customer_id,
-                "tool_slug": tool_slug,
+                "tool_slug": safe_tool_slug,
                 "arguments": arguments if isinstance(arguments, dict) else {},
                 "connected_account_id": connected_account_id,
                 "text": text,
@@ -222,7 +287,19 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             timeout=120.0,
         )
         if r.status_code != 200:
-            return {"error": f"composio_tool_execute failed: {r.text}"}
+            retryable = r.status_code in {408, 429, 500, 502, 503, 504}
+            return _composio_failure_payload(
+                operation="composio_tool_execute",
+                status_code=r.status_code,
+                response_text=r.text,
+                retryable=retryable,
+                suggested_next_action=(
+                    "Retry the same call later."
+                    if retryable
+                    else "Inspect the error. If it says the account is not connected, ask the user to authorize the toolkit. If arguments are invalid, repair them from composio_tool_schema."
+                ),
+                extra={"tool_slug": safe_tool_slug},
+            )
         return r.json()
 
     return {

--- a/src/opentulpa/agent/tools/composio_tools.py
+++ b/src/opentulpa/agent/tools/composio_tools.py
@@ -42,6 +42,10 @@ def _composio_failure_payload(
     return payload
 
 
+def _is_retryable_internal_status(status_code: int) -> bool:
+    return int(status_code or 0) in {408, 429, 500, 502, 503, 504}
+
+
 def register_composio_tools(runtime: Any) -> dict[str, Any]:
     @tool
     async def composio_status() -> Any:
@@ -249,9 +253,10 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             timeout=20.0,
         )
         if schema_response.status_code != 200:
+            retryable = _is_retryable_internal_status(schema_response.status_code)
             toolkit = _toolkit_from_slug(safe_tool_slug)
             candidates: Any = []
-            if toolkit:
+            if toolkit and not retryable:
                 search_response = await runtime._request_with_backoff(
                     "GET",
                     "/internal/composio/tools/search",
@@ -264,9 +269,11 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
                 operation="composio_tool_execute preflight",
                 status_code=schema_response.status_code,
                 response_text=schema_response.text,
-                retryable=False,
+                retryable=retryable,
                 suggested_next_action=(
-                    "The requested Composio tool slug is not available. Choose one of the "
+                    "Retry the same call later."
+                    if retryable
+                    else "The requested Composio tool slug is not available. Choose one of the "
                     "candidate tools from composio_tool_search, then retry with that exact slug."
                 ),
                 extra={
@@ -285,6 +292,7 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
                 "text": text,
             },
             timeout=120.0,
+            retries=0,
         )
         if r.status_code != 200:
             retryable = r.status_code in {408, 429, 500, 502, 503, 504}

--- a/src/opentulpa/api/routes/composio.py
+++ b/src/opentulpa/api/routes/composio.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -13,9 +12,6 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from opentulpa.core.public_urls import build_public_composio_callback_path
 
 logger = logging.getLogger(__name__)
-RETRYABLE_COMPOSIO_STATUS_CODES = {408, 429, 500, 502, 503, 504}
-
-
 def _parse_csv(value: str) -> list[str]:
     return [item.strip() for item in str(value or "").split(",") if item.strip()]
 
@@ -26,62 +22,6 @@ def _error_response(exc: Exception, *, operation: str) -> JSONResponse:
     detail = body if isinstance(body, dict) else {"detail": str(exc)}
     logger.warning("Composio route %s failed: %s", operation, detail)
     return JSONResponse(status_code=status_code, content=detail)
-
-
-def _is_retryable_composio_error(exc: Exception) -> bool:
-    status_code = int(getattr(exc, "status_code", 0) or 0)
-    if status_code in RETRYABLE_COMPOSIO_STATUS_CODES:
-        return True
-    body = getattr(exc, "body", None)
-    if isinstance(body, dict):
-        error = body.get("error") if isinstance(body.get("error"), dict) else body
-        try:
-            nested_status = int(error.get("status", 0) or 0)
-        except Exception:
-            nested_status = 0
-        if nested_status in RETRYABLE_COMPOSIO_STATUS_CODES:
-            return True
-        code = str(error.get("code", "") or "").lower()
-        slug = str(error.get("slug", "") or "").lower()
-        message = str(error.get("message", "") or "").lower()
-        if any(marker in f"{code} {slug} {message}" for marker in ("timeout", "bad gateway")):
-            return True
-    return False
-
-
-async def _execute_composio_tool_with_retry(
-    service: Any,
-    *,
-    customer_id: str,
-    tool_slug: str,
-    arguments: dict[str, Any],
-    connected_account_id: str | None,
-    text: str | None,
-) -> Any:
-    attempts = 3
-    for attempt in range(attempts):
-        try:
-            return service.execute_tool(
-                customer_id=customer_id,
-                tool_slug=tool_slug,
-                arguments=arguments,
-                connected_account_id=connected_account_id,
-                text=text,
-            )
-        except Exception as exc:
-            if attempt + 1 >= attempts or not _is_retryable_composio_error(exc):
-                raise
-            delay = 0.4 * (2**attempt)
-            logger.warning(
-                "Composio tool execute transient failure; retrying tool_slug=%s attempt=%s/%s delay=%.2fs error=%s",
-                tool_slug,
-                attempt + 1,
-                attempts,
-                delay,
-                f"{type(exc).__name__}: {exc}",
-            )
-            await asyncio.sleep(delay)
-    raise RuntimeError("Composio tool execute retry loop exhausted")
 
 
 def register_composio_routes(
@@ -255,8 +195,7 @@ def register_composio_routes(
     async def internal_composio_tool_execute(request: Request) -> Any:
         body = await request.json()
         try:
-            return await _execute_composio_tool_with_retry(
-                get_composio(),
+            return get_composio().execute_tool(
                 customer_id=str(body.get("customer_id", "")).strip(),
                 tool_slug=str(body.get("tool_slug", "")).strip(),
                 arguments=body.get("arguments") if isinstance(body.get("arguments"), dict) else {},

--- a/src/opentulpa/api/routes/composio.py
+++ b/src/opentulpa/api/routes/composio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -12,6 +13,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from opentulpa.core.public_urls import build_public_composio_callback_path
 
 logger = logging.getLogger(__name__)
+RETRYABLE_COMPOSIO_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
 
 def _parse_csv(value: str) -> list[str]:
@@ -24,6 +26,62 @@ def _error_response(exc: Exception, *, operation: str) -> JSONResponse:
     detail = body if isinstance(body, dict) else {"detail": str(exc)}
     logger.warning("Composio route %s failed: %s", operation, detail)
     return JSONResponse(status_code=status_code, content=detail)
+
+
+def _is_retryable_composio_error(exc: Exception) -> bool:
+    status_code = int(getattr(exc, "status_code", 0) or 0)
+    if status_code in RETRYABLE_COMPOSIO_STATUS_CODES:
+        return True
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        error = body.get("error") if isinstance(body.get("error"), dict) else body
+        try:
+            nested_status = int(error.get("status", 0) or 0)
+        except Exception:
+            nested_status = 0
+        if nested_status in RETRYABLE_COMPOSIO_STATUS_CODES:
+            return True
+        code = str(error.get("code", "") or "").lower()
+        slug = str(error.get("slug", "") or "").lower()
+        message = str(error.get("message", "") or "").lower()
+        if any(marker in f"{code} {slug} {message}" for marker in ("timeout", "bad gateway")):
+            return True
+    return False
+
+
+async def _execute_composio_tool_with_retry(
+    service: Any,
+    *,
+    customer_id: str,
+    tool_slug: str,
+    arguments: dict[str, Any],
+    connected_account_id: str | None,
+    text: str | None,
+) -> Any:
+    attempts = 3
+    for attempt in range(attempts):
+        try:
+            return service.execute_tool(
+                customer_id=customer_id,
+                tool_slug=tool_slug,
+                arguments=arguments,
+                connected_account_id=connected_account_id,
+                text=text,
+            )
+        except Exception as exc:
+            if attempt + 1 >= attempts or not _is_retryable_composio_error(exc):
+                raise
+            delay = 0.4 * (2**attempt)
+            logger.warning(
+                "Composio tool execute transient failure; retrying tool_slug=%s attempt=%s/%s delay=%.2fs error=%s",
+                tool_slug,
+                attempt + 1,
+                attempts,
+                delay,
+                f"{type(exc).__name__}: {exc}",
+            )
+            await asyncio.sleep(delay)
+    raise RuntimeError("Composio tool execute retry loop exhausted")
 
 
 def register_composio_routes(
@@ -197,7 +255,8 @@ def register_composio_routes(
     async def internal_composio_tool_execute(request: Request) -> Any:
         body = await request.json()
         try:
-            return get_composio().execute_tool(
+            return await _execute_composio_tool_with_retry(
+                get_composio(),
                 customer_id=str(body.get("customer_id", "")).strip(),
                 tool_slug=str(body.get("tool_slug", "")).strip(),
                 arguments=body.get("arguments") if isinstance(body.get("arguments"), dict) else {},

--- a/src/opentulpa/integrations/web_search.py
+++ b/src/opentulpa/integrations/web_search.py
@@ -5,6 +5,7 @@ The agent's general chat model remains separate. This integration is only used
 when the web_search tool is explicitly invoked.
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE = "https://openrouter.ai/api/v1"
 DEFAULT_WEB_SEARCH_MODEL = "perplexity/sonar-pro-search"
+RETRYABLE_WEB_SEARCH_STATUSES = {408, 429, 500, 502, 503, 504}
 
 
 def _default_search_model() -> str:
@@ -150,24 +152,56 @@ async def web_search(query: str) -> dict[str, object] | str:
         "reasoning": {"effort": "medium"},
     }
 
+    max_attempts = 3
     async with httpx.AsyncClient(timeout=60.0) as client:
-        try:
-            r = await client.post(
-                url,
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-            r.raise_for_status()
-            data = r.json()
-        except httpx.HTTPStatusError as e:
-            logger.exception("OpenRouter web search HTTP error: %s", e)
-            return f"Web search request failed: {e.response.status_code}."
-        except Exception as e:
-            logger.exception("OpenRouter web search error: %s", e)
-            return f"Web search failed: {e!s}."
+        for attempt in range(max_attempts):
+            try:
+                r = await client.post(
+                    url,
+                    json=payload,
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                )
+                r.raise_for_status()
+                data = r.json()
+                break
+            except httpx.HTTPStatusError as e:
+                status_code = e.response.status_code
+                retryable = status_code in RETRYABLE_WEB_SEARCH_STATUSES
+                if retryable and attempt < max_attempts - 1:
+                    delay = 0.75 * (2**attempt)
+                    logger.warning(
+                        "OpenRouter web search HTTP error; retrying status=%s attempt=%s/%s delay=%.2fs",
+                        status_code,
+                        attempt + 1,
+                        max_attempts,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                logger.exception("OpenRouter web search HTTP error: %s", e)
+                return f"Web search request failed: {status_code}."
+            except (httpx.TimeoutException, httpx.NetworkError) as e:
+                if attempt < max_attempts - 1:
+                    delay = 0.75 * (2**attempt)
+                    logger.warning(
+                        "OpenRouter web search transport error; retrying error=%s attempt=%s/%s delay=%.2fs",
+                        type(e).__name__,
+                        attempt + 1,
+                        max_attempts,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                logger.exception("OpenRouter web search error: %s", e)
+                return f"Web search failed: {e!s}."
+            except Exception as e:
+                logger.exception("OpenRouter web search error: %s", e)
+                return f"Web search failed: {e!s}."
+        else:  # pragma: no cover - loop always returns or breaks.
+            return "Web search failed after retries."
 
     choices = data.get("choices") or []
     if not choices:

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -469,6 +469,14 @@ async def stream_langgraph_reply_to_telegram(
                 "stage": stage,
                 "turn_mode": normalize_turn_mode(turn_mode),
                 "latest_user_message": str(text or "").strip()[:1000],
+                "latest_user_message_usage": (
+                    "Background context only. Use it to understand why the turn may be slow, "
+                    "but do not quote, paraphrase, summarize, or mention it in the status text."
+                ),
+                "status_goal": (
+                    "Send a generic progress update that says the assistant is still checking "
+                    "or preparing the answer."
+                ),
             },
             language="Russian",
         )
@@ -755,7 +763,7 @@ async def stream_langgraph_reply_to_telegram(
         await typing_task
     if not suppressed and not final_reply and timeout_failed_without_reply:
         logger.error(
-            "telegram.stream silent_timeout_suppressed chat_id=%s thread_id=%s customer_id=%s stage=%s "
+            "telegram.stream timeout_without_final_reply chat_id=%s thread_id=%s customer_id=%s stage=%s "
             "interim_status_sent=%s delivered_any=%s",
             chat_id,
             thread_id,
@@ -764,7 +772,10 @@ async def stream_langgraph_reply_to_telegram(
             interim_status_sent,
             delivered_any,
         )
-        suppressed = True
+        final_reply = (
+            "I couldn't finish that step before the reply timeout. "
+            "Please ask me to continue, and I'll resume from the saved context."
+        )
     if not suppressed and not final_reply:
         logger.error(
             "telegram.stream no_final_reply chat_id=%s thread_id=%s customer_id=%s",

--- a/src/opentulpa/interfaces/telegram/status_generation.py
+++ b/src/opentulpa/interfaces/telegram/status_generation.py
@@ -88,6 +88,10 @@ async def generate_llm_status_message(
                             f"Write text in {language}. One sentence, under 90 characters.\n"
                             "Do not answer the user's business question. Do not invent prices, availability, "
                             "booking facts, or completion. Only say that the answer is being checked or prepared.\n"
+                            "The context may include the user's latest message so you understand why the turn "
+                            "is taking time, but it is background-only.\n"
+                            "Do not mention the user's specific task, object names, message text, or table contents. "
+                            "Do not repeat, translate, summarize, or paraphrase the user's wording.\n"
                             "If a useful status update is not appropriate, set ok=false and text=\"\"."
                         )
                     ),

--- a/tests/test_composio_routes.py
+++ b/tests/test_composio_routes.py
@@ -506,7 +506,7 @@ def test_composio_execute_route_passes_customer_and_arguments(tmp_path: Path) ->
     )
 
 
-def test_composio_execute_route_retries_transient_errors(tmp_path: Path) -> None:
+def test_composio_execute_route_does_not_retry_transient_errors(tmp_path: Path) -> None:
     composio = _RetryOnceComposioService()
     client = _mk_client_with_composio(tmp_path, composio)
 
@@ -520,6 +520,6 @@ def test_composio_execute_route_retries_transient_errors(tmp_path: Path) -> None
             },
         )
 
-    assert response.status_code == 200
-    assert response.json()["successful"] is True
-    assert [call[0] for call in composio.calls] == ["execute_tool", "execute_tool"]
+    assert response.status_code == 500
+    assert response.json()["error"]["message"] == "Bad Gateway"
+    assert [call[0] for call in composio.calls] == ["execute_tool"]

--- a/tests/test_composio_routes.py
+++ b/tests/test_composio_routes.py
@@ -265,6 +265,38 @@ class _FakeComposioService:
         return {"ok": True, "tool_slug": tool_slug, "successful": True, "data": {"items": []}}
 
 
+class _FakeComposioTransientError(Exception):
+    status_code = 500
+    body = {"error": {"status": 500, "message": "Bad Gateway"}}
+
+
+class _RetryOnceComposioService(_FakeComposioService):
+    def execute_tool(
+        self,
+        *,
+        customer_id: str,
+        tool_slug: str,
+        arguments: dict[str, Any] | None = None,
+        connected_account_id: str | None = None,
+        text: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            (
+                "execute_tool",
+                {
+                    "customer_id": customer_id,
+                    "tool_slug": tool_slug,
+                    "arguments": arguments,
+                    "connected_account_id": connected_account_id,
+                    "text": text,
+                },
+            )
+        )
+        if len(self.calls) == 1:
+            raise _FakeComposioTransientError("temporary")
+        return {"ok": True, "tool_slug": tool_slug, "successful": True, "data": {"items": []}}
+
+
 def _mk_client(tmp_path: Path) -> tuple[TestClient, _FakeComposioService]:
     skills = SkillStoreService(
         db_path=tmp_path / "skills.db",
@@ -276,6 +308,18 @@ def _mk_client(tmp_path: Path) -> tuple[TestClient, _FakeComposioService]:
         composio_service=composio,
     )
     return TestClient(app), composio
+
+
+def _mk_client_with_composio(tmp_path: Path, composio: Any) -> TestClient:
+    skills = SkillStoreService(
+        db_path=tmp_path / "skills.db",
+        root_dir=tmp_path / "skills",
+    )
+    app = create_app(
+        skill_store_service=skills,
+        composio_service=composio,
+    )
+    return TestClient(app)
 
 
 def test_composio_status_route_exposes_callback_configuration(tmp_path: Path) -> None:
@@ -460,3 +504,22 @@ def test_composio_execute_route_passes_customer_and_arguments(tmp_path: Path) ->
             "text": "list the messages",
         },
     )
+
+
+def test_composio_execute_route_retries_transient_errors(tmp_path: Path) -> None:
+    composio = _RetryOnceComposioService()
+    client = _mk_client_with_composio(tmp_path, composio)
+
+    with client:
+        response = client.post(
+            "/internal/composio/tools/execute",
+            json={
+                "customer_id": "cust_123",
+                "tool_slug": "INSTAGRAM_LIST_ALL_MESSAGES",
+                "arguments": {"conversation_id": "conv_1"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["successful"] is True
+    assert [call[0] for call in composio.calls] == ["execute_tool", "execute_tool"]

--- a/tests/test_composio_tools.py
+++ b/tests/test_composio_tools.py
@@ -31,3 +31,46 @@ async def test_composio_authorize_toolkit_passes_customer_scope() -> None:
     assert path == "/internal/composio/authorize"
     assert kwargs["json_body"]["customer_id"] == "telegram_123"
     assert kwargs["json_body"]["toolkit"] == "gmail"
+
+
+@pytest.mark.asyncio
+async def test_composio_execute_preflights_tool_slug_and_returns_candidates() -> None:
+    runtime = DummyRuntime(
+        [
+            Response(404, {"error": {"message": "Tool GOOGLESHEETS_GET_ROWS not found"}}),
+            Response(200, {"items": [{"slug": "GOOGLESHEETS_VALUES_GET"}]}),
+        ]
+    )
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["composio_tool_execute"].ainvoke(
+        {"tool_slug": "GOOGLESHEETS_GET_ROWS", "arguments": {}}
+    )
+
+    assert result["ok"] is False
+    assert result["retryable"] is False
+    assert result["candidate_tools"] == [{"slug": "GOOGLESHEETS_VALUES_GET"}]
+    assert [call[1] for call in runtime.calls] == [
+        "/internal/composio/tools/GOOGLESHEETS_GET_ROWS/schema",
+        "/internal/composio/tools/search",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_composio_execute_returns_structured_nonretryable_account_error() -> None:
+    runtime = DummyRuntime(
+        [
+            Response(200, {"tool": {"slug": "GOOGLESHEETS_VALUES_GET"}}),
+            Response(400, {"error": {"slug": "ActionExecute_ConnectedAccountNotFound"}}),
+        ]
+    )
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["composio_tool_execute"].ainvoke(
+        {"tool_slug": "GOOGLESHEETS_VALUES_GET", "arguments": {"range": "A1:B2"}}
+    )
+
+    assert result["ok"] is False
+    assert result["retryable"] is False
+    assert "authorize" in result["suggested_next_action"]
+    assert runtime.calls[-1][1] == "/internal/composio/tools/execute"

--- a/tests/test_composio_tools.py
+++ b/tests/test_composio_tools.py
@@ -57,6 +57,24 @@ async def test_composio_execute_preflights_tool_slug_and_returns_candidates() ->
 
 
 @pytest.mark.asyncio
+async def test_composio_execute_preflight_transient_error_is_retryable() -> None:
+    runtime = DummyRuntime([Response(503, {"error": {"message": "Bad Gateway"}})])
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["composio_tool_execute"].ainvoke(
+        {"tool_slug": "GOOGLESHEETS_GET_ROWS", "arguments": {}}
+    )
+
+    assert result["ok"] is False
+    assert result["retryable"] is True
+    assert result["candidate_tools"] == []
+    assert result["suggested_next_action"] == "Retry the same call later."
+    assert [call[1] for call in runtime.calls] == [
+        "/internal/composio/tools/GOOGLESHEETS_GET_ROWS/schema"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_composio_execute_returns_structured_nonretryable_account_error() -> None:
     runtime = DummyRuntime(
         [
@@ -74,3 +92,4 @@ async def test_composio_execute_returns_structured_nonretryable_account_error() 
     assert result["retryable"] is False
     assert "authorize" in result["suggested_next_action"]
     assert runtime.calls[-1][1] == "/internal/composio/tools/execute"
+    assert runtime.calls[-1][2]["retries"] == 0

--- a/tests/test_runtime_structured_model.py
+++ b/tests/test_runtime_structured_model.py
@@ -60,6 +60,21 @@ class _FallbackModel:
         return _FallbackResponse(self._content)
 
 
+class _SequenceFallbackModel:
+    def __init__(self, contents: list[str]) -> None:
+        self._contents = list(contents)
+        self.calls: list[object] = []
+
+    def with_structured_output(self, _schema: type[BaseModel]) -> _StructuredRunner:
+        raise RuntimeError("structured_unavailable")
+
+    async def ainvoke(self, messages: object) -> _FallbackResponse:
+        self.calls.append(messages)
+        if not self._contents:
+            return _FallbackResponse("")
+        return _FallbackResponse(self._contents.pop(0))
+
+
 class _BrokenStructuredThenFallbackModel(_FallbackModel):
     def with_structured_output(self, _schema: type[BaseModel]) -> _StructuredRunner:
         raise RuntimeError("structured_unavailable")
@@ -162,6 +177,29 @@ async def test_invoke_structured_model_rejects_wrapped_non_json_text() -> None:
     assert parsed is None
     assert isinstance(error, str)
     assert "ValidationError" in error
+
+
+@pytest.mark.asyncio
+async def test_invoke_structured_model_repairs_invalid_json_fallback_once() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    model = _SequenceFallbackModel(
+        [
+            '{"ok": true, "reason": ',
+            '{"ok": true, "reason": "repaired"}',
+        ]
+    )
+
+    parsed, error = await runtime._invoke_structured_model(
+        model=model,
+        messages=[],
+        schema=_Schema,
+    )
+
+    assert isinstance(parsed, _Schema)
+    assert parsed.ok is True
+    assert parsed.reason == "repaired"
+    assert error is None
+    assert len(model.calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_stream_timeout.py
+++ b/tests/test_telegram_stream_timeout.py
@@ -12,6 +12,7 @@ class _NeverYieldsRuntime:
     def __init__(self, status: str | None = None) -> None:
         self.status = status
         self.status_calls = 0
+        self.status_contexts: list[dict] = []
 
     async def astream_text(self, **kwargs):
         while True:
@@ -20,6 +21,9 @@ class _NeverYieldsRuntime:
 
     async def generate_status_message(self, **kwargs):
         self.status_calls += 1
+        context = kwargs.get("context")
+        if isinstance(context, dict):
+            self.status_contexts.append(context)
         if not self.status:
             return None
         return {"ok": True, "text": self.status}
@@ -110,17 +114,23 @@ async def test_stream_timeout_returns_user_visible_timeout(monkeypatch: pytest.M
     finally:
         monkeypatch.setattr(relay_module.asyncio, "wait_for", original_wait_for)
 
-    assert suppressed is True
-    assert final is None
+    assert suppressed is False
+    assert isinstance(final, str)
+    assert "reply timeout" in final
     assert runtime.status_calls == 1
+    assert runtime.status_contexts
+    assert runtime.status_contexts[0]["latest_user_message"] == "hello"
+    assert "do not quote" in runtime.status_contexts[0]["latest_user_message_usage"]
     # One automatic retry is attempted before surfacing timeout.
     assert calls["count"] >= 2
-    assert ("Уточняю детали и скоро отвечу." in [text for _, text, _ in fake_client.message_calls])
+    sent_texts = [text for _, text, _ in fake_client.message_calls]
+    assert "Уточняю детали и скоро отвечу." in sent_texts
+    assert final in sent_texts
     assert fake_client.chat_actions
 
 
 @pytest.mark.asyncio
-async def test_stream_timeout_logs_silent_suppression_when_status_generation_fails(
+async def test_stream_timeout_sends_final_timeout_when_status_generation_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -154,15 +164,16 @@ async def test_stream_timeout_logs_silent_suppression_when_status_generation_fai
     finally:
         monkeypatch.setattr(relay_module.asyncio, "wait_for", original_wait_for)
 
-    assert suppressed is True
-    assert final is None
+    assert suppressed is False
+    assert isinstance(final, str)
+    assert "reply timeout" in final
     assert runtime.status_calls == 1
-    assert fake_client.message_calls == []
+    assert [text for _, text, _ in fake_client.message_calls] == [final]
     assert calls["count"] >= 2
     messages = [record.getMessage() for record in caplog.records]
     assert any("telegram.stream status_generation_skipped" in message for message in messages)
     assert any(
-        "telegram.stream silent_timeout_suppressed" in message
+        "telegram.stream timeout_without_final_reply" in message
         and "interim_status_sent=False" in message
         and "delivered_any=False" in message
         for message in messages

--- a/tests/test_web_search_output_processing.py
+++ b/tests/test_web_search_output_processing.py
@@ -78,3 +78,43 @@ async def test_web_search_requests_medium_reasoning_effort(monkeypatch: pytest.M
 
     assert isinstance(result, dict)
     assert captured["json"]["reasoning"] == {"effort": "medium"}
+
+
+@pytest.mark.asyncio
+async def test_web_search_retries_transient_openrouter_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    async def _fake_sleep(delay: float) -> None:
+        captured_delays.append(delay)
+
+    async def _fake_post(
+        self: httpx.AsyncClient,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        _ = self, json, headers
+        calls["count"] += 1
+        request = httpx.Request("POST", url)
+        if calls["count"] == 1:
+            return httpx.Response(status_code=502, request=request, json={"error": "bad gateway"})
+        return httpx.Response(
+            status_code=200,
+            request=request,
+            json={"choices": [{"message": {"content": "Recovered answer"}}]},
+        )
+
+    captured_delays: list[float] = []
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+    monkeypatch.setattr(web_search_module.asyncio, "sleep", _fake_sleep)
+
+    result = await web_search_module.web_search("current news")
+
+    assert calls["count"] == 2
+    assert captured_delays == [0.75]
+    assert isinstance(result, dict)
+    assert result["answer"] == "Recovered answer"


### PR DESCRIPTION
## Summary

Closes OPE-56.

This PR hardens the failure modes found in the May 8 debug-log investigation:

- prevents Telegram interactive turns from going silent after only an interim status is sent
- keeps status-generation context while explicitly preventing visible status messages from parroting user task text
- retries transient OpenRouter-backed web_search failures with backoff
- preflights Composio tool slugs before execution and returns candidate tools for unavailable slugs
- returns structured Composio failure metadata: retryable flag, status code, response text, and suggested next action
- retries transient internal Composio execute failures
- adds one structured-output repair retry when JSON/schema parsing fails

## Verification

```bash
uv run pytest -q tests/test_composio_tools.py tests/test_composio_routes.py tests/test_runtime_structured_model.py tests/test_telegram_stream_timeout.py tests/test_web_search_output_processing.py
uv run ruff check src/opentulpa/agent/tools/composio_tools.py src/opentulpa/api/routes/composio.py src/opentulpa/agent/model_pool.py src/opentulpa/interfaces/telegram/relay.py src/opentulpa/interfaces/telegram/status_generation.py src/opentulpa/integrations/web_search.py tests/test_composio_tools.py tests/test_composio_routes.py tests/test_runtime_structured_model.py tests/test_telegram_stream_timeout.py tests/test_web_search_output_processing.py
```
