### PR TITLE
Fix Instagram intake scan failures

### DIFF
--- a/src/opentulpa/agent/prompt_policy.py
+++ b/src/opentulpa/agent/prompt_policy.py
@@ -44,8 +44,9 @@ PROMPT_POLICY_BLOCKS: list[tuple[str, str, list[tuple[str, str]]]] = [
             ("B06", "Never present concrete fetched data unless it exists in this turn's tool outputs."),
             ("B07", "To stop/cancel schedules: call routine_list, then routine_delete by routine_id, and claim success only after verified removal."),
             ("B08", "If user provides timezone/UTC offset, call time_profile_set."),
-            ("B09", "Keep scheduled routines distinct from intake workflows. Routines are clock-driven jobs; intake workflows are message-driven lead handling. Do not infer that an intake workflow is broken just because routine_id or schedule is empty."),
+            ("B09", "Keep scheduled routines distinct from intake workflows. Do not infer that an intake workflow is broken just because routine_id or schedule is empty; check the workflow channel/provider first."),
             ("B10", "Telegram Business intake workflows use Telegram webhook events, not polling routines. For channel=telegram_business_dm, an empty routine_id/schedule is expected; debug webhook/business connection/intake state instead of creating routine_create."),
+            ("B11", "Instagram DM intake workflows use scheduled Composio polling. Do not promise webhook-like handling or 'every new Instagram DM automatically' unless you clearly state it depends on the configured polling schedule and accessible Composio conversations."),
         ],
     ),
     (

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -956,7 +956,7 @@ class IntakeWorkflowService:
         conversation_id: str,
         fallback: dict[str, Any],
     ) -> tuple[dict[str, Any], str | None]:
-        items, source_error = self._load_source_items(workflow=workflow)
+        items, source_error, _source_warnings = self._load_source_items(workflow=workflow)
         if source_error is not None:
             return fallback, source_error
         for item in items:
@@ -1607,6 +1607,14 @@ class IntakeWorkflowService:
             }
 
         warnings: list[str] = []
+        safe_channel = str(normalized.get("channel", "") or "").strip().lower()
+        safe_provider = str(normalized.get("provider", "") or "").strip().lower()
+        if safe_channel == "instagram_dm" and safe_provider == "composio":
+            warnings.append(
+                "Instagram DM intake uses scheduled Composio polling, not webhook delivery; "
+                "new messages are handled on the configured schedule and only for conversations "
+                "Composio can read."
+            )
         dry_run = self._build_sink_dry_run_preview(normalized, warnings=warnings)
         return {
             "ok": True,
@@ -2607,13 +2615,13 @@ class IntakeWorkflowService:
         self,
         *,
         workflow: dict[str, Any],
-    ) -> tuple[list[dict[str, Any]], str | None]:
+    ) -> tuple[list[dict[str, Any]], str | None, list[dict[str, str]]]:
         channel = str(workflow.get("channel", "") or "").strip().lower()
         provider = str(workflow.get("provider", "") or "").strip().lower()
         if channel == "instagram_dm" and provider == "composio":
             composio = self._composio
             if composio is None or not bool(getattr(composio, "enabled", False)):
-                return [], f"Workflow {workflow['name']} failed: Composio is not available."
+                return [], f"Workflow {workflow['name']} failed: Composio is not available.", []
             source_config = _safe_dict(workflow.get("source_config"))
             connected_account_id = str(source_config.get("connected_account_id", "") or "").strip() or None
             scan_limit = max(1, min(int(source_config.get("scan_limit", 10) or 10), 25))
@@ -2626,15 +2634,20 @@ class IntakeWorkflowService:
                     else []
                 )
             )
+            warnings: list[dict[str, str]] = []
             try:
                 if configured_conversation_ids:
                     items = []
                     for conversation_id in configured_conversation_ids:
-                        detailed = composio.get_instagram_conversation(
-                            customer_id=str(workflow["customer_id"]),
-                            conversation_id=conversation_id,
-                            connected_account_id=connected_account_id,
-                        )
+                        try:
+                            detailed = composio.get_instagram_conversation(
+                                customer_id=str(workflow["customer_id"]),
+                                conversation_id=conversation_id,
+                                connected_account_id=connected_account_id,
+                            )
+                        except Exception as exc:
+                            warnings.append({"conversation_id": conversation_id, "error": str(exc)})
+                            continue
                         items.append(_safe_dict(detailed.get("summary")))
                 else:
                     conversations_payload = composio.list_instagram_conversations(
@@ -2643,17 +2656,25 @@ class IntakeWorkflowService:
                         limit=scan_limit,
                     )
                     items = _safe_list(conversations_payload.get("items"))
+                    warnings = [
+                        {
+                            "conversation_id": str(_safe_dict(item).get("conversation_id", "") or ""),
+                            "error": str(_safe_dict(item).get("error", "") or ""),
+                        }
+                        for item in _safe_list(conversations_payload.get("warnings"))
+                        if str(_safe_dict(item).get("error", "") or "").strip()
+                    ]
             except Exception as exc:
-                return [], f"Workflow {workflow['name']} failed while reading Instagram DMs: {exc}"
-            return items, None
+                return [], f"Workflow {workflow['name']} failed while reading Instagram DMs: {exc}", warnings
+            return items, None, warnings
         if channel == "telegram_business_dm" and provider == "telegram_bot_api":
             telegram_business = self._telegram_business
             if telegram_business is None:
-                return [], f"Workflow {workflow['name']} failed: Telegram Business is not available."
+                return [], f"Workflow {workflow['name']} failed: Telegram Business is not available.", []
             source_config = _safe_dict(workflow.get("source_config"))
             business_connection_id = str(source_config.get("business_connection_id", "") or "").strip()
             if not business_connection_id:
-                return [], f"Workflow {workflow['name']} failed: source_config.business_connection_id is required."
+                return [], f"Workflow {workflow['name']} failed: source_config.business_connection_id is required.", []
             scan_limit = max(1, min(int(source_config.get("scan_limit", 10) or 10), 50))
             configured_conversation_ids = _unique_string_list(
                 source_config.get("conversation_ids")
@@ -2670,11 +2691,11 @@ class IntakeWorkflowService:
                 limit=scan_limit,
                 chat_ids=configured_conversation_ids or None,
             )
-            return _safe_list(payload.get("items")), None
+            return _safe_list(payload.get("items")), None, []
         return [], (
             f"Workflow {workflow['name']} failed: unsupported source "
             f"{workflow.get('channel')}/{workflow.get('provider')}."
-        )
+        ), []
 
     def _load_source_conversation(
         self,
@@ -2754,7 +2775,7 @@ class IntakeWorkflowService:
                 "summary": NO_NOTIFY_TOKEN,
                 "reason": "workflow_disabled",
             }
-        items, source_error = self._load_source_items(workflow=workflow)
+        items, source_error, source_warnings = self._load_source_items(workflow=workflow)
         if source_error is not None:
             return {
                 "ok": False,
@@ -3171,6 +3192,7 @@ class IntakeWorkflowService:
             "matched_conversations": matched,
             "results": result_items,
             "errors": errors,
+            "source_warnings": source_warnings,
             "summary": summary,
         }
 

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -2639,15 +2639,11 @@ class IntakeWorkflowService:
                 if configured_conversation_ids:
                     items = []
                     for conversation_id in configured_conversation_ids:
-                        try:
-                            detailed = composio.get_instagram_conversation(
-                                customer_id=str(workflow["customer_id"]),
-                                conversation_id=conversation_id,
-                                connected_account_id=connected_account_id,
-                            )
-                        except Exception as exc:
-                            warnings.append({"conversation_id": conversation_id, "error": str(exc)})
-                            continue
+                        detailed = composio.get_instagram_conversation(
+                            customer_id=str(workflow["customer_id"]),
+                            conversation_id=conversation_id,
+                            connected_account_id=connected_account_id,
+                        )
                         items.append(_safe_dict(detailed.get("summary")))
                 else:
                     conversations_payload = composio.list_instagram_conversations(

--- a/src/opentulpa/integrations/composio.py
+++ b/src/opentulpa/integrations/composio.py
@@ -657,15 +657,20 @@ class ComposioService:
             raise RuntimeError(str(response.get("error") or "failed to list Instagram conversations"))
         items = _safe_list(_safe_dict(response.get("data")).get("data"))
         summaries: list[dict[str, Any]] = []
+        warnings: list[dict[str, str]] = []
         for item in items:
             conversation_id = str(_safe_dict(item).get("id", "") or "").strip()
             if not conversation_id:
                 continue
-            conversation = self._fetch_instagram_conversation(
-                customer_id=safe_customer,
-                conversation_id=conversation_id,
-                connected_account_id=safe_account,
-            )
+            try:
+                conversation = self._fetch_instagram_conversation(
+                    customer_id=safe_customer,
+                    conversation_id=conversation_id,
+                    connected_account_id=safe_account,
+                )
+            except Exception as exc:
+                warnings.append({"conversation_id": conversation_id, "error": str(exc)})
+                continue
             summary = self._summarize_instagram_conversation(
                 conversation=conversation,
                 requested_recipient_id=None,
@@ -679,6 +684,7 @@ class ComposioService:
             "customer_id": safe_customer,
             "connected_account_id": safe_account,
             "items": summaries,
+            "warnings": warnings,
         }
 
     def get_instagram_conversation(

--- a/tests/test_composio_service.py
+++ b/tests/test_composio_service.py
@@ -95,6 +95,56 @@ class _FakeGoogleSheetsComposioService(ComposioService):
         }
 
 
+class _PartialInstagramComposioService(ComposioService):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.calls: list[dict[str, object]] = []
+
+    def _sdk_execute_tool(self, *, slug, arguments, connected_account_id, user_id, text=None):  # type: ignore[override]
+        self.calls.append(
+            {
+                "slug": slug,
+                "arguments": dict(arguments),
+                "connected_account_id": connected_account_id,
+                "user_id": user_id,
+                "text": text,
+            }
+        )
+        if slug == "INSTAGRAM_LIST_ALL_CONVERSATIONS":
+            return {
+                "successful": True,
+                "error": None,
+                "data": {"data": [{"id": "conv_ok"}, {"id": "conv_bad"}]},
+            }
+        if arguments.get("conversation_id") == "conv_bad":
+            return {"successful": False, "error": "Unsupported get request", "data": {}}
+        return {
+            "successful": True,
+            "error": None,
+            "data": {
+                "id": "conv_ok",
+                "participants": {
+                    "data": [
+                        {"id": "business_1", "username": "biz"},
+                        {"id": "lead_1", "username": "lead"},
+                    ]
+                },
+                "messages": {
+                    "data": [
+                        {
+                            "id": "msg_1",
+                            "created_time": "2026-05-13T08:00:00+0000",
+                            "from": {"id": "lead_1", "username": "lead"},
+                            "to": {"data": [{"id": "business_1", "username": "biz"}]},
+                            "message": "Hello",
+                        }
+                    ]
+                },
+                "updated_time": "2026-05-13T08:00:00+0000",
+            },
+        }
+
+
 def test_instagram_send_retries_without_reply_to_message_id_on_invalid_mid() -> None:
     service = _FakeComposioService(api_key="test-key")
 
@@ -114,6 +164,21 @@ def test_instagram_send_retries_without_reply_to_message_id_on_invalid_mid() -> 
     assert service.calls[0]["arguments"]["reply_to_message_id"] == "mid_1"
     assert "reply_to_message_id" not in service.calls[1]["arguments"]
     assert result["data"]["retried_without_reply_to_message_id"] is True
+
+
+def test_list_instagram_conversations_skips_unreadable_threads() -> None:
+    service = _PartialInstagramComposioService(api_key="test-key")
+
+    result = service.list_instagram_conversations(
+        customer_id="telegram_1",
+        connected_account_id="acct_1",
+    )
+
+    assert result["ok"] is True
+    assert [item["conversation_id"] for item in result["items"]] == ["conv_ok"]
+    assert result["warnings"] == [
+        {"conversation_id": "conv_bad", "error": "Unsupported get request"}
+    ]
 
 
 def test_list_google_sheets_tab_names_uses_composio_sheet_discovery_tool() -> None:

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -2782,6 +2782,53 @@ async def test_intake_workflow_run_keeps_source_scan_warnings_nonfatal(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_intake_workflow_run_fails_configured_instagram_conversation_fetch(
+    tmp_path: Path,
+) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "conversation_updated_time": "2026-04-07T08:00:00+00:00",
+        "latest_message_id": "msg_1",
+        "latest_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_message_sender_id": "lead_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Hello",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+        latest_message_sender_id="lead_1",
+        latest_message_sender_username="lead",
+    )
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=_FakeComposio(summary, conversation),
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        source_config={"conversation_id": "conv_missing"},
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day", "time", "car_type", "wash_type"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+
+    assert result["ok"] is False
+    assert result["workflow_id"] == workflow["workflow_id"]
+    assert "failed while reading Instagram DMs" in result["summary"]
+
+
+@pytest.mark.asyncio
 async def test_intake_workflow_run_skips_outbound_only_update_without_model_call(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -153,9 +153,11 @@ class _FakeComposio:
         conversation: dict[str, Any],
         *,
         sheet_names_by_spreadsheet: dict[str, list[str]] | None = None,
+        list_warnings: list[dict[str, str]] | None = None,
     ) -> None:
         self.summary = summary
         self.conversation = conversation
+        self.list_warnings = list(list_warnings or [])
         self.sheet_names_by_spreadsheet = {
             str(key): list(value)
             for key, value in (sheet_names_by_spreadsheet or {}).items()
@@ -174,7 +176,7 @@ class _FakeComposio:
     ) -> dict[str, Any]:
         del customer_id, connected_account_id, limit
         self.list_calls += 1
-        return {"ok": True, "items": [self.summary]}
+        return {"ok": True, "items": [self.summary], "warnings": self.list_warnings}
 
     def get_instagram_conversation(
         self,
@@ -2733,6 +2735,50 @@ async def test_intake_workflow_run_skips_quiet_inbox_without_model_call(tmp_path
     assert runtime.calls == []
     assert composio.list_calls == 1
     assert composio.get_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_intake_workflow_run_keeps_source_scan_warnings_nonfatal(tmp_path: Path) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "conversation_updated_time": "2026-04-07T08:00:00+00:00",
+        "latest_message_id": "msg_out_1",
+        "latest_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_message_sender_id": "business_1",
+        "latest_outbound_message_id": "msg_out_1",
+        "latest_outbound_message_created_time": "2026-04-07T08:00:00+00:00",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_out_1",
+        latest_message_text="Thanks, your booking is confirmed.",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+        latest_message_sender_id="business_1",
+        latest_message_sender_username="detailer",
+    )
+    warning = {"conversation_id": "conv_bad", "error": "Unsupported get request"}
+    runtime = _FakeRuntime([])
+    composio = _FakeComposio(summary, conversation, list_warnings=[warning])
+    service, _, _, _, _ = _mk_service(tmp_path, runtime=runtime, composio=composio)
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day", "time", "car_type", "wash_type"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["source_warnings"] == [warning]
+    assert result["summary"] == NO_NOTIFY_TOKEN
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_policy_hardening.py
+++ b/tests/test_prompt_policy_hardening.py
@@ -98,6 +98,8 @@ def test_system_prompt_uses_structured_sections_and_rule_ids() -> None:
     assert "Keep scheduled routines distinct from intake workflows" in text
     assert "Telegram Business intake workflows use Telegram webhook events" in text
     assert "empty routine_id/schedule is expected" in text
+    assert "Instagram DM intake workflows use scheduled Composio polling" in text
+    assert "Do not promise webhook-like handling" in text
 
 
 def test_build_relevant_skill_discovery_context_is_discovery_only() -> None:

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -449,6 +449,7 @@ def test_workflow_setup_preflight_normalizes_single_google_sheet_tab_and_dry_run
     preflight = session["preflight"]
     assert preflight["ok"] is True
     assert preflight["status"] == "ready"
+    assert "scheduled Composio polling" in " ".join(preflight["warnings"])
     assert preflight["sink_preflight"]["dry_run"]["will_execute"] is False
     assert preflight["sink_preflight"]["dry_run"]["tool_slug"] == "GOOGLESHEETS_UPSERT_ROWS"
     static_arguments = session["draft_upsert"]["sink_config"]["static_arguments"]


### PR DESCRIPTION
## Summary
- skip unreadable Instagram conversations during Composio inbox scans and return per-thread warnings
- keep Instagram intake scan warnings nonfatal in workflow runs
- clarify that Instagram DM intake uses scheduled Composio polling, not webhook-like instant handling

## Root Cause
`INSTAGRAM_LIST_ALL_CONVERSATIONS` can return a conversation ID that `INSTAGRAM_GET_CONVERSATION` cannot read. The old scan path treated that one unreadable thread as fatal, so the whole Instagram intake workflow failed before processing accessible conversations.

## Validation
- `uv run pytest -q tests/test_composio_service.py tests/test_intake_workflow_service.py tests/test_workflow_setup_service.py tests/test_prompt_policy_hardening.py`
- `uv run ruff check src/opentulpa/integrations/composio.py src/opentulpa/intake/service.py src/opentulpa/agent/prompt_policy.py tests/test_composio_service.py tests/test_intake_workflow_service.py tests/test_prompt_policy_hardening.py tests/test_workflow_setup_service.py`