### PR TITLE
Add generic OpenTulpa web chat API

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1302,6 +1302,8 @@ class OpenTulpaLangGraphRuntime:
         self._interactive_update_senders_lock = asyncio.Lock()
         self._interactive_update_senders: dict[str, Any] = {}
         self._interactive_update_sent_keys: dict[str, set[str]] = {}
+        self._interactive_file_senders_lock = asyncio.Lock()
+        self._interactive_file_senders: dict[str, Any] = {}
         self._active_customer_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
             "opentulpa_active_customer_id",
             default="",
@@ -3988,6 +3990,77 @@ class OpenTulpaLangGraphRuntime:
             )
             return []
         return [str(item).strip() for item in drained if str(item).strip()]
+
+    async def register_interactive_file_sender(self, *, thread_id: str, sender: Any) -> None:
+        safe_thread_id = str(thread_id or "").strip()
+        if not safe_thread_id or sender is None:
+            return
+        if getattr(self, "_interactive_file_senders_lock", None) is None:
+            self._interactive_file_senders_lock = asyncio.Lock()
+        if getattr(self, "_interactive_file_senders", None) is None:
+            self._interactive_file_senders = {}
+        async with self._interactive_file_senders_lock:
+            self._interactive_file_senders[safe_thread_id] = sender
+
+    async def clear_interactive_file_sender(
+        self,
+        *,
+        thread_id: str,
+        sender: Any | None = None,
+    ) -> None:
+        safe_thread_id = str(thread_id or "").strip()
+        if not safe_thread_id:
+            return
+        lock = getattr(self, "_interactive_file_senders_lock", None)
+        senders = getattr(self, "_interactive_file_senders", None)
+        if lock is None or senders is None:
+            return
+        async with lock:
+            current = senders.get(safe_thread_id)
+            if sender is None or current is sender:
+                senders.pop(safe_thread_id, None)
+
+    async def emit_interactive_file(
+        self,
+        *,
+        thread_id: str,
+        file: dict[str, Any],
+    ) -> dict[str, Any]:
+        safe_thread_id = str(thread_id or "").strip()
+        if not safe_thread_id:
+            return {"ok": False, "sent": False, "reason": "missing_thread_id"}
+        if not isinstance(file, dict) or not file:
+            return {"ok": False, "sent": False, "reason": "missing_file"}
+        lock = getattr(self, "_interactive_file_senders_lock", None)
+        senders = getattr(self, "_interactive_file_senders", None)
+        if lock is None or senders is None:
+            return {"ok": False, "sent": False, "reason": "interactive_file_unavailable"}
+        async with lock:
+            sender = senders.get(safe_thread_id)
+        if sender is None:
+            return {"ok": False, "sent": False, "reason": "interactive_file_unavailable"}
+        try:
+            result = sender(file)
+            if inspect.isawaitable(result):
+                result = await result
+            sent = bool(result.get("sent", True)) if isinstance(result, dict) else bool(result)
+        except Exception as exc:
+            self.log_behavior_event(
+                event="interactive_file_delivery_failed",
+                thread_id=safe_thread_id,
+                customer_id=self.get_active_customer_id(),
+                error=type(exc).__name__,
+            )
+            return {"ok": False, "sent": False, "error": str(exc)}
+        if not sent:
+            return {"ok": False, "sent": False, "reason": "send_failed"}
+        self.log_behavior_event(
+            event="interactive_file_delivered",
+            thread_id=safe_thread_id,
+            customer_id=self.get_active_customer_id(),
+            file_id=str(file.get("id") or ""),
+        )
+        return {"ok": True, "sent": True}
 
     async def classify_workflow_setup_interruption(
         self,

--- a/src/opentulpa/agent/tools/file_tools.py
+++ b/src/opentulpa/agent/tools/file_tools.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from langchain.tools import tool
 
-from opentulpa.agent.tools.common import require_customer_id
+from opentulpa.agent.tools.common import require_customer_id, require_thread_id
 from opentulpa.agent.tools.core_tools import (
     _compact_uploaded_file_inspection,
     _tool_error_payload,
@@ -61,14 +61,16 @@ def register_file_tools(runtime: Any) -> dict[str, Any]:
         file_id: str,
         caption: str | None = None,
     ) -> Any:
-        """Send a previously uploaded file back to the user's Telegram chat."""
+        """Send a previously uploaded file back to the current chat."""
         customer_id = require_customer_id(runtime)
+        thread_id = require_thread_id(runtime)
         r = await runtime._request_with_backoff(
             "POST",
             "/internal/files/send",
             json_body={
                 "file_id": file_id,
                 "customer_id": customer_id,
+                "thread_id": thread_id,
                 "caption": caption,
             },
             timeout=25.0,
@@ -82,14 +84,16 @@ def register_file_tools(runtime: Any) -> dict[str, Any]:
         path: str,
         caption: str | None = None,
     ) -> Any:
-        """Send a local file from tulpa_stuff/ back to the user's Telegram chat."""
+        """Send a local file from tulpa_stuff/ back to the current chat."""
         customer_id = require_customer_id(runtime)
+        thread_id = require_thread_id(runtime)
         r = await runtime._request_with_backoff(
             "POST",
             "/internal/files/send_local",
             json_body={
                 "path": path,
                 "customer_id": customer_id,
+                "thread_id": thread_id,
                 "caption": caption,
             },
             timeout=25.0,
@@ -104,8 +108,9 @@ def register_file_tools(runtime: Any) -> dict[str, Any]:
         caption: str | None = None,
         max_bytes: int = 10_000_000,
     ) -> Any:
-        """Download an image from a web URL and send it to Telegram."""
+        """Download an image from a web URL and send it to the current chat."""
         customer_id = require_customer_id(runtime)
+        thread_id = require_thread_id(runtime)
         safe_max_bytes = max(250_000, min(int(max_bytes), 25_000_000))
         r = await runtime._request_with_backoff(
             "POST",
@@ -113,6 +118,7 @@ def register_file_tools(runtime: Any) -> dict[str, Any]:
             json_body={
                 "url": url,
                 "customer_id": customer_id,
+                "thread_id": thread_id,
                 "caption": caption,
                 "max_bytes": safe_max_bytes,
             },

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -17,6 +17,7 @@ from opentulpa.api.routes import (
     register_composio_routes,
     register_debug_log_routes,
     register_file_routes,
+    register_generic_chat_routes,
     register_health_routes,
     register_intake_workflow_routes,
     register_knowledge_routes,
@@ -524,6 +525,9 @@ def create_app(
         if (
             not trusted_server_client
             and not path.startswith("/webhook/")
+            and not path.startswith("/web/chat/")
+            and not path.startswith("/web/files/")
+            and not path.startswith("/web/local-files/")
             and path not in public_health_paths
         ):
             return JSONResponse(status_code=403, content={"detail": "forbidden public endpoint"})
@@ -548,6 +552,13 @@ def create_app(
     register_health_routes(app, get_agent_runtime=get_agent_runtime)
     register_debug_log_routes(app)
     register_chat_routes(app, get_turn_orchestrator=get_turn_orchestrator)
+    register_generic_chat_routes(
+        app,
+        generic_api_secret=settings.opentulpa_generic_api_secret,
+        get_agent_runtime=get_agent_runtime,
+        get_file_vault=get_file_vault,
+        get_workflow_setup_service=get_workflow_setup_service,
+    )
     register_memory_routes(app, get_memory=get_memory)
     register_file_routes(
         app,

--- a/src/opentulpa/api/routes/__init__.py
+++ b/src/opentulpa/api/routes/__init__.py
@@ -10,6 +10,7 @@ _ROUTE_IMPORTS = {
     "register_composio_routes": "opentulpa.api.routes.composio",
     "register_debug_log_routes": "opentulpa.api.routes.debug_logs",
     "register_file_routes": "opentulpa.api.routes.files",
+    "register_generic_chat_routes": "opentulpa.api.routes.generic_chat",
     "register_health_routes": "opentulpa.api.routes.health",
     "register_intake_workflow_routes": "opentulpa.api.routes.intake",
     "register_knowledge_routes": "opentulpa.api.routes.knowledge",

--- a/src/opentulpa/api/routes/files.py
+++ b/src/opentulpa/api/routes/files.py
@@ -33,6 +33,39 @@ def _telegram_delivery_payload(**fields: Any) -> dict[str, Any]:
     return payload
 
 
+async def _web_file_delivery_payload(
+    *,
+    get_agent_runtime: Callable[[], Any],
+    thread_id: str,
+    file: dict[str, Any],
+    caption: str | None,
+) -> dict[str, Any] | None:
+    safe_thread_id = str(thread_id or "").strip()
+    if not safe_thread_id:
+        return None
+    runtime = get_agent_runtime()
+    emitter = getattr(runtime, "emit_interactive_file", None)
+    if not callable(emitter):
+        return None
+    payload = dict(file)
+    if caption:
+        payload["caption"] = caption
+    result = await emitter(thread_id=safe_thread_id, file=payload)
+    if not isinstance(result, dict) or not result.get("sent"):
+        return None
+    return {
+        "ok": True,
+        "delivered_to_chat": True,
+        "delivery": "web",
+        "file": payload,
+        "model_instruction": (
+            "DELIVERED_TO_CHAT: The file has been sent to the current web chat. "
+            "Do not call the file-send tool again for this file. "
+            "Continue with a short final confirmation only."
+        ),
+    }
+
+
 def register_file_routes(
     app: FastAPI,
     *,
@@ -82,11 +115,10 @@ def register_file_routes(
         body = await request.json()
         customer_id = str(body.get("customer_id", "")).strip()
         file_id = str(body.get("file_id", "")).strip()
+        thread_id = str(body.get("thread_id", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
         caption = caption or None
-        if not telegram_enabled:
-            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         if not customer_id or not file_id:
             return JSONResponse(
                 status_code=400, content={"detail": "customer_id and file_id are required"}
@@ -94,6 +126,16 @@ def register_file_routes(
         record = vault.get_file(customer_id, file_id)
         if not record:
             return JSONResponse(status_code=404, content={"detail": "file not found"})
+        web_payload = await _web_file_delivery_payload(
+            get_agent_runtime=get_agent_runtime,
+            thread_id=thread_id,
+            file=sanitize_uploaded_file_record(record, include_excerpt=False),
+            caption=caption,
+        )
+        if web_payload is not None:
+            return web_payload
+        if not telegram_enabled:
+            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
 
         chat_id = record.get("chat_id")
         if chat_id is None:
@@ -125,11 +167,10 @@ def register_file_routes(
         body = await request.json()
         customer_id = str(body.get("customer_id", "")).strip()
         local_path = str(body.get("path", "")).strip()
+        thread_id = str(body.get("thread_id", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
         caption = caption or None
-        if not telegram_enabled:
-            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         if not customer_id or not local_path:
             return JSONResponse(
                 status_code=400, content={"detail": "customer_id and path are required"}
@@ -158,6 +199,23 @@ def register_file_routes(
                 },
             )
 
+        guessed_mime, _ = mimetypes.guess_type(str(target.name))
+        web_payload = await _web_file_delivery_payload(
+            get_agent_runtime=get_agent_runtime,
+            thread_id=thread_id,
+            file={
+                "kind": "local_file",
+                "original_filename": str(target.name),
+                "mime_type": guessed_mime or "application/octet-stream",
+                "size_bytes": file_size,
+                "local_path": local_path,
+            },
+            caption=caption,
+        )
+        if web_payload is not None:
+            return web_payload
+        if not telegram_enabled:
+            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         chat_id: Any = None
         slots = get_telegram_chat().find_session_slots(customer_id)
         if slots:
@@ -168,7 +226,6 @@ def register_file_routes(
             raw_bytes = target.read_bytes()
         except Exception:
             return JSONResponse(status_code=502, content={"detail": "failed to read local file"})
-        guessed_mime, _ = mimetypes.guess_type(str(target.name))
         sent = await get_telegram_client().send_file(
             chat_id=chat_id,
             filename=str(target.name),
@@ -187,25 +244,17 @@ def register_file_routes(
         body = await request.json()
         customer_id = str(body.get("customer_id", "")).strip()
         image_url = str(body.get("url", "")).strip()
+        thread_id = str(body.get("thread_id", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
         caption = caption or None
         max_bytes = int(body.get("max_bytes", 10_000_000))
 
-        if not telegram_enabled:
-            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         if not customer_id or not image_url:
             return JSONResponse(
                 status_code=400,
                 content={"detail": "customer_id and url are required"},
             )
-
-        chat_id: Any = None
-        slots = get_telegram_chat().find_session_slots(customer_id)
-        if slots:
-            chat_id = slots[0].get("chat_id")
-        if chat_id is None:
-            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
 
         try:
             downloaded = await download_image_from_web_url(image_url, max_bytes=max_bytes)
@@ -213,6 +262,29 @@ def register_file_routes(
             return JSONResponse(status_code=400, content={"detail": str(exc)})
         except Exception as exc:
             return JSONResponse(status_code=502, content={"detail": f"image fetch failed: {exc}"})
+
+        web_payload = await _web_file_delivery_payload(
+            get_agent_runtime=get_agent_runtime,
+            thread_id=thread_id,
+            file={
+                "kind": "web_image",
+                "original_filename": str(downloaded["filename"]),
+                "mime_type": str(downloaded["content_type"]),
+                "size_bytes": int(downloaded["size_bytes"]),
+                "url": str(downloaded["final_url"]),
+            },
+            caption=caption,
+        )
+        if web_payload is not None:
+            return web_payload
+        if not telegram_enabled:
+            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
+        chat_id: Any = None
+        slots = get_telegram_chat().find_session_slots(customer_id)
+        if slots:
+            chat_id = slots[0].get("chat_id")
+        if chat_id is None:
+            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
 
         sent = await get_telegram_client().send_file(
             chat_id=chat_id,

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -8,21 +8,47 @@ import mimetypes
 from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from hmac import compare_digest
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import quote
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, File, Form, Query, Request, UploadFile
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL
 from opentulpa.api.file_helpers import sanitize_uploaded_file_record
-from opentulpa.interfaces.telegram.attachments import (
-    _skip_auto_summary_for_upload,
+from opentulpa.context.uploaded_files import (
     build_uploaded_files_context,
+    should_skip_auto_summary_for_upload,
 )
 from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
 
 MAX_WEB_UPLOAD_BYTES = 45_000_000
+
+
+class WebChatTurnRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    customer_id: str = Field(min_length=1)
+    thread_id: str = Field(min_length=1)
+    text: str = Field(min_length=1)
+    file_ids: list[str] = Field(default_factory=list, max_length=20)
+    include_pending_context: bool = True
+
+    @field_validator("file_ids", mode="before")
+    @classmethod
+    def _clean_file_ids(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("file_ids must be a list")
+        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        return cleaned[:20]
+
+
+class WebFileResponse(BaseModel):
+    ok: bool
+    file: dict[str, Any]
 
 
 def _bearer_token(request: Request) -> str:
@@ -60,8 +86,12 @@ def register_generic_chat_routes(
 ) -> None:
     """Register authenticated generic chat endpoints."""
 
-    @app.post("/web/chat/turns")
-    async def web_chat_turn(request: Request) -> Any:
+    @app.post(
+        "/web/chat/turns",
+        response_class=StreamingResponse,
+        responses={200: {"content": {"text/event-stream": {}}}},
+    )
+    async def web_chat_turn(payload: WebChatTurnRequest, request: Request) -> Any:
         secret = str(generic_api_secret or "").strip()
         if not secret:
             return JSONResponse(
@@ -71,18 +101,6 @@ def register_generic_chat_routes(
         if not _authorized(request, secret):
             return JSONResponse(status_code=401, content={"detail": "unauthorized"})
 
-        body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
-        thread_id = str(body.get("thread_id", "")).strip()
-        text = str(body.get("text", "")).strip()
-        raw_file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
-        file_ids = [str(item).strip() for item in raw_file_ids if str(item).strip()][:20]
-        include_pending_context = bool(body.get("include_pending_context", True))
-        if not customer_id or not thread_id or not text:
-            return JSONResponse(
-                status_code=400,
-                content={"detail": "customer_id, thread_id, and text are required"},
-            )
         runtime = get_agent_runtime()
         if runtime is None or not (hasattr(runtime, "ainvoke_text") or hasattr(runtime, "astream_text")):
             return JSONResponse(status_code=503, content={"detail": "agent runtime unavailable"})
@@ -92,18 +110,25 @@ def register_generic_chat_routes(
                 runtime=runtime,
                 workflow_setup_service=get_workflow_setup_service(),
                 file_vault=get_file_vault(),
-                customer_id=customer_id,
-                thread_id=thread_id,
-                text=text,
-                file_ids=file_ids,
-                include_pending_context=include_pending_context,
+                customer_id=payload.customer_id,
+                thread_id=payload.thread_id,
+                text=payload.text,
+                file_ids=payload.file_ids,
+                include_pending_context=payload.include_pending_context,
             ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
-    @app.post("/web/files/upload")
-    async def web_file_upload(request: Request) -> Any:
+    @app.post("/web/files/upload", response_model=WebFileResponse)
+    async def web_file_upload(
+        request: Request,
+        customer_id: Annotated[str, Form(min_length=1)],
+        thread_id: Annotated[str, Form(min_length=1)],
+        upload: Annotated[UploadFile, File(alias="file")],
+        kind: Annotated[str, Form()] = "document",
+        caption: Annotated[str | None, Form()] = None,
+    ) -> Any:
         secret = str(generic_api_secret or "").strip()
         if not secret:
             return JSONResponse(
@@ -112,73 +137,76 @@ def register_generic_chat_routes(
             )
         if not _authorized(request, secret):
             return JSONResponse(status_code=401, content={"detail": "unauthorized"})
-        form = await request.form()
-        customer_id = str(form.get("customer_id") or "").strip()
-        thread_id = str(form.get("thread_id") or "").strip()
-        kind = str(form.get("kind") or "document").strip() or "document"
-        caption = str(form.get("caption") or "").strip() or None
-        upload = form.get("file")
-        if not customer_id or not thread_id:
+        safe_customer_id = str(customer_id or "").strip()
+        safe_thread_id = str(thread_id or "").strip()
+        safe_kind = str(kind or "document").strip() or "document"
+        safe_caption = str(caption or "").strip() or None
+        if not safe_customer_id or not safe_thread_id:
             return JSONResponse(
                 status_code=400,
                 content={"detail": "customer_id and thread_id are required"},
             )
-        if upload is None or not hasattr(upload, "read"):
-            return JSONResponse(status_code=400, content={"detail": "file is required"})
         raw_bytes = await upload.read()
         if not isinstance(raw_bytes, bytes) or not raw_bytes:
             return JSONResponse(status_code=400, content={"detail": "file is empty"})
         if len(raw_bytes) > MAX_WEB_UPLOAD_BYTES:
             return JSONResponse(status_code=413, content={"detail": "file is too large"})
-        filename = str(getattr(upload, "filename", "") or f"{kind}.bin").strip()
+        filename = str(getattr(upload, "filename", "") or f"{safe_kind}.bin").strip()
         content_type = str(getattr(upload, "content_type", "") or "").strip() or None
         vault = get_file_vault()
         record = vault.ingest_file(
-            customer_id=customer_id,
+            customer_id=safe_customer_id,
             chat_id=None,
-            kind=kind,
+            kind=safe_kind,
             telegram_file_id=None,
             original_filename=filename,
             mime_type=content_type,
-            caption=caption,
+            caption=safe_caption,
             raw_bytes=raw_bytes,
         )
         runtime = get_agent_runtime()
         record = await _postprocess_uploaded_file(
             runtime=runtime,
             vault=vault,
-            customer_id=customer_id,
+            customer_id=safe_customer_id,
             record=record,
             raw_bytes=raw_bytes,
-            caption=caption,
+            caption=safe_caption,
         )
         return {
             "ok": True,
             "file": _web_file_metadata(record),
         }
 
-    @app.get("/web/files/{file_id}/metadata")
-    async def web_file_metadata(file_id: str, request: Request) -> Any:
+    @app.get("/web/files/{file_id}/metadata", response_model=WebFileResponse)
+    async def web_file_metadata(
+        file_id: str,
+        request: Request,
+        customer_id: Annotated[str, Query(min_length=1)],
+    ) -> Any:
         auth = _authorized_web_request(request, generic_api_secret)
         if auth is not None:
             return auth
-        customer_id = str(request.query_params.get("customer_id") or "").strip()
-        record = get_file_vault().get_file(customer_id, file_id)
+        record = get_file_vault().get_file(customer_id.strip(), file_id)
         if not record:
             return JSONResponse(status_code=404, content={"detail": "file not found"})
         return {"ok": True, "file": _web_file_metadata(record)}
 
     @app.get("/web/files/{file_id}/content")
-    async def web_file_content(file_id: str, request: Request) -> Any:
+    async def web_file_content(
+        file_id: str,
+        request: Request,
+        customer_id: Annotated[str, Query(min_length=1)],
+    ) -> Any:
         auth = _authorized_web_request(request, generic_api_secret)
         if auth is not None:
             return auth
-        customer_id = str(request.query_params.get("customer_id") or "").strip()
+        safe_customer_id = customer_id.strip()
         vault = get_file_vault()
-        record = vault.get_file(customer_id, file_id)
+        record = vault.get_file(safe_customer_id, file_id)
         if not record:
             return JSONResponse(status_code=404, content={"detail": "file not found"})
-        raw_bytes = vault.read_file_bytes(customer_id, file_id)
+        raw_bytes = vault.read_file_bytes(safe_customer_id, file_id)
         if raw_bytes is None:
             return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
         filename = str(record.get("original_filename") or "file.bin")
@@ -190,15 +218,18 @@ def register_generic_chat_routes(
         )
 
     @app.get("/web/local-files/content")
-    async def web_local_file_content(request: Request) -> Any:
+    async def web_local_file_content(
+        request: Request,
+        local_path: Annotated[str, Query(alias="path", min_length=1)],
+    ) -> Any:
         auth = _authorized_web_request(request, generic_api_secret)
         if auth is not None:
             return auth
-        local_path = str(request.query_params.get("path") or "").strip()
-        if not local_path:
+        safe_local_path = local_path.strip()
+        if not safe_local_path:
             return JSONResponse(status_code=400, content={"detail": "path is required"})
         try:
-            target = (TULPA_STUFF_DIR.parent / local_path).resolve()
+            target = (TULPA_STUFF_DIR.parent / safe_local_path).resolve()
         except Exception:
             return JSONResponse(status_code=400, content={"detail": "invalid path"})
         if not is_within(target, TULPA_STUFF_DIR) or not target.exists() or target.is_dir():
@@ -377,7 +408,7 @@ async def _postprocess_uploaded_file(
     if (
         runtime is not None
         and hasattr(runtime, "summarize_uploaded_blob")
-        and not _skip_auto_summary_for_upload(kind=kind, filename=filename, mime_type=mime_type)
+        and not should_skip_auto_summary_for_upload(kind=kind, filename=filename, mime_type=mime_type)
     ):
         with suppress(Exception):
             summary = await runtime.summarize_uploaded_blob(

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -1,0 +1,433 @@
+"""Authenticated generic chat routes for non-Telegram clients."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import mimetypes
+from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
+from hmac import compare_digest
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL
+from opentulpa.api.file_helpers import sanitize_uploaded_file_record
+from opentulpa.interfaces.telegram.attachments import (
+    _skip_auto_summary_for_upload,
+    build_uploaded_files_context,
+)
+from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
+
+MAX_WEB_UPLOAD_BYTES = 45_000_000
+
+
+def _bearer_token(request: Request) -> str:
+    header = str(request.headers.get("authorization") or "").strip()
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def _authorized(request: Request, expected_secret: str) -> bool:
+    token = _bearer_token(request)
+    return bool(token and compare_digest(token, expected_secret))
+
+
+def _sse(event: str, payload: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _progress_message(chunk: str) -> str:
+    if chunk == STREAM_WAIT_SIGNAL:
+        return "Working..."
+    if chunk.startswith(STREAM_PROGRESS_PREFIX):
+        return chunk.removeprefix(STREAM_PROGRESS_PREFIX).strip() or "Working..."
+    return ""
+
+
+def register_generic_chat_routes(
+    app: FastAPI,
+    *,
+    generic_api_secret: str | None,
+    get_agent_runtime: Callable[[], Any],
+    get_file_vault: Callable[[], Any],
+    get_workflow_setup_service: Callable[[], Any],
+) -> None:
+    """Register authenticated generic chat endpoints."""
+
+    @app.post("/web/chat/turns")
+    async def web_chat_turn(request: Request) -> Any:
+        secret = str(generic_api_secret or "").strip()
+        if not secret:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "OPENTULPA_GENERIC_API_SECRET is not configured"},
+            )
+        if not _authorized(request, secret):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+
+        body = await request.json()
+        customer_id = str(body.get("customer_id", "")).strip()
+        thread_id = str(body.get("thread_id", "")).strip()
+        text = str(body.get("text", "")).strip()
+        raw_file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
+        file_ids = [str(item).strip() for item in raw_file_ids if str(item).strip()][:20]
+        include_pending_context = bool(body.get("include_pending_context", True))
+        if not customer_id or not thread_id or not text:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "customer_id, thread_id, and text are required"},
+            )
+        runtime = get_agent_runtime()
+        if runtime is None or not (hasattr(runtime, "ainvoke_text") or hasattr(runtime, "astream_text")):
+            return JSONResponse(status_code=503, content={"detail": "agent runtime unavailable"})
+
+        return StreamingResponse(
+            _stream_turn(
+                runtime=runtime,
+                workflow_setup_service=get_workflow_setup_service(),
+                file_vault=get_file_vault(),
+                customer_id=customer_id,
+                thread_id=thread_id,
+                text=text,
+                file_ids=file_ids,
+                include_pending_context=include_pending_context,
+            ),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    @app.post("/web/files/upload")
+    async def web_file_upload(request: Request) -> Any:
+        secret = str(generic_api_secret or "").strip()
+        if not secret:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "OPENTULPA_GENERIC_API_SECRET is not configured"},
+            )
+        if not _authorized(request, secret):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        form = await request.form()
+        customer_id = str(form.get("customer_id") or "").strip()
+        thread_id = str(form.get("thread_id") or "").strip()
+        kind = str(form.get("kind") or "document").strip() or "document"
+        caption = str(form.get("caption") or "").strip() or None
+        upload = form.get("file")
+        if not customer_id or not thread_id:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "customer_id and thread_id are required"},
+            )
+        if upload is None or not hasattr(upload, "read"):
+            return JSONResponse(status_code=400, content={"detail": "file is required"})
+        raw_bytes = await upload.read()
+        if not isinstance(raw_bytes, bytes) or not raw_bytes:
+            return JSONResponse(status_code=400, content={"detail": "file is empty"})
+        if len(raw_bytes) > MAX_WEB_UPLOAD_BYTES:
+            return JSONResponse(status_code=413, content={"detail": "file is too large"})
+        filename = str(getattr(upload, "filename", "") or f"{kind}.bin").strip()
+        content_type = str(getattr(upload, "content_type", "") or "").strip() or None
+        vault = get_file_vault()
+        record = vault.ingest_file(
+            customer_id=customer_id,
+            chat_id=None,
+            kind=kind,
+            telegram_file_id=None,
+            original_filename=filename,
+            mime_type=content_type,
+            caption=caption,
+            raw_bytes=raw_bytes,
+        )
+        runtime = get_agent_runtime()
+        record = await _postprocess_uploaded_file(
+            runtime=runtime,
+            vault=vault,
+            customer_id=customer_id,
+            record=record,
+            raw_bytes=raw_bytes,
+            caption=caption,
+        )
+        return {
+            "ok": True,
+            "file": _web_file_metadata(record),
+        }
+
+    @app.get("/web/files/{file_id}/metadata")
+    async def web_file_metadata(file_id: str, request: Request) -> Any:
+        auth = _authorized_web_request(request, generic_api_secret)
+        if auth is not None:
+            return auth
+        customer_id = str(request.query_params.get("customer_id") or "").strip()
+        record = get_file_vault().get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        return {"ok": True, "file": _web_file_metadata(record)}
+
+    @app.get("/web/files/{file_id}/content")
+    async def web_file_content(file_id: str, request: Request) -> Any:
+        auth = _authorized_web_request(request, generic_api_secret)
+        if auth is not None:
+            return auth
+        customer_id = str(request.query_params.get("customer_id") or "").strip()
+        vault = get_file_vault()
+        record = vault.get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        raw_bytes = vault.read_file_bytes(customer_id, file_id)
+        if raw_bytes is None:
+            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
+        filename = str(record.get("original_filename") or "file.bin")
+        mime_type = str(record.get("mime_type") or "").strip()
+        return Response(
+            content=raw_bytes,
+            media_type=mime_type or "application/octet-stream",
+            headers={"Content-Disposition": _content_disposition(filename)},
+        )
+
+    @app.get("/web/local-files/content")
+    async def web_local_file_content(request: Request) -> Any:
+        auth = _authorized_web_request(request, generic_api_secret)
+        if auth is not None:
+            return auth
+        local_path = str(request.query_params.get("path") or "").strip()
+        if not local_path:
+            return JSONResponse(status_code=400, content={"detail": "path is required"})
+        try:
+            target = (TULPA_STUFF_DIR.parent / local_path).resolve()
+        except Exception:
+            return JSONResponse(status_code=400, content={"detail": "invalid path"})
+        if not is_within(target, TULPA_STUFF_DIR) or not target.exists() or target.is_dir():
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        raw_bytes = target.read_bytes()
+        guessed_mime, _ = mimetypes.guess_type(str(target.name))
+        return Response(
+            content=raw_bytes,
+            media_type=guessed_mime or "application/octet-stream",
+            headers={"Content-Disposition": _content_disposition(target.name)},
+        )
+
+
+async def _stream_turn(
+    *,
+    runtime: Any,
+    workflow_setup_service: Any,
+    file_vault: Any,
+    customer_id: str,
+    thread_id: str,
+    text: str,
+    file_ids: list[str],
+    include_pending_context: bool,
+) -> AsyncIterator[str]:
+    assert customer_id.strip()
+    assert thread_id.strip()
+    assert text.strip()
+    queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue(maxsize=100)
+
+    async def _send_owner_update(message: str) -> dict[str, Any]:
+        safe = str(message or "").strip()
+        if not safe:
+            return {"ok": False, "sent": False, "reason": "empty_message"}
+        await queue.put(("owner_update", {"message": safe}))
+        return {"ok": True, "sent": True}
+
+    async def _send_file(file: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(file, dict) or not file:
+            return {"ok": False, "sent": False, "reason": "missing_file"}
+        await queue.put(("file", {"file": _normalize_file_event(file)}))
+        return {"ok": True, "sent": True}
+
+    async def _run_turn() -> None:
+        turn_mode = "interactive"
+        if workflow_setup_service is not None and hasattr(workflow_setup_service, "thread_status"):
+            status = workflow_setup_service.thread_status(
+                customer_id=customer_id,
+                thread_id=thread_id,
+            )
+            if str(status.get("status", "") or "").strip().lower() == "active":
+                turn_mode = "workflow_setup"
+
+        try:
+            if hasattr(runtime, "register_interactive_update_sender"):
+                await runtime.register_interactive_update_sender(
+                    thread_id=thread_id,
+                    sender=_send_owner_update,
+                )
+            if hasattr(runtime, "register_interactive_file_sender"):
+                await runtime.register_interactive_file_sender(
+                    thread_id=thread_id,
+                    sender=_send_file,
+                )
+            effective_text = _text_with_uploaded_file_context(
+                file_vault=file_vault,
+                customer_id=customer_id,
+                text=text,
+                file_ids=file_ids,
+            )
+            if turn_mode == "workflow_setup" or not hasattr(runtime, "astream_text"):
+                final_text = await runtime.ainvoke_text(
+                    thread_id=thread_id,
+                    customer_id=customer_id,
+                    text=effective_text,
+                    turn_mode=turn_mode,
+                    include_pending_context=include_pending_context,
+                )
+            else:
+                final_text = ""
+                async for chunk in runtime.astream_text(
+                    thread_id=thread_id,
+                    customer_id=customer_id,
+                    text=effective_text,
+                    turn_mode=turn_mode,
+                    include_pending_context=include_pending_context,
+                ):
+                    current = str(chunk or "").strip()
+                    if not current:
+                        continue
+                    progress = _progress_message(current)
+                    if progress:
+                        await queue.put(("status", {"message": progress}))
+                        continue
+                    final_text = current
+                    await queue.put(("delta", {"text": current}))
+            final_text = str(final_text or "").strip()
+            if (
+                turn_mode == "workflow_setup"
+                and workflow_setup_service is not None
+                and hasattr(workflow_setup_service, "after_reply")
+            ):
+                workflow_setup_service.after_reply(
+                    customer_id=customer_id,
+                    thread_id=thread_id,
+                    reply_text=final_text,
+                )
+            await queue.put(("final", {"text": final_text}))
+        except Exception as exc:
+            await queue.put(("error", {"message": str(exc), "type": type(exc).__name__}))
+        finally:
+            if hasattr(runtime, "clear_interactive_update_sender"):
+                with suppress(Exception):
+                    await runtime.clear_interactive_update_sender(
+                        thread_id=thread_id,
+                        sender=_send_owner_update,
+                    )
+            if hasattr(runtime, "clear_interactive_file_sender"):
+                with suppress(Exception):
+                    await runtime.clear_interactive_file_sender(
+                        thread_id=thread_id,
+                        sender=_send_file,
+                    )
+            await queue.put(("done", {}))
+
+    yield _sse("status", {"message": "Starting..."})
+    task = asyncio.create_task(_run_turn())
+    try:
+        while True:
+            event, payload = await queue.get()
+            if event == "done":
+                break
+            yield _sse(event, payload)
+    finally:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+
+def _authorized_web_request(request: Request, generic_api_secret: str | None) -> JSONResponse | None:
+    secret = str(generic_api_secret or "").strip()
+    if not secret:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "OPENTULPA_GENERIC_API_SECRET is not configured"},
+        )
+    if not _authorized(request, secret):
+        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+    return None
+
+
+async def _postprocess_uploaded_file(
+    *,
+    runtime: Any,
+    vault: Any,
+    customer_id: str,
+    record: dict[str, Any],
+    raw_bytes: bytes,
+    caption: str | None,
+) -> dict[str, Any]:
+    kind = str(record.get("kind") or "").strip()
+    filename = str(record.get("original_filename") or "").strip()
+    mime_type = str(record.get("mime_type") or "").strip() or None
+    if kind == "voice" and runtime is not None and hasattr(runtime, "transcribe_audio_blob"):
+        with suppress(Exception):
+            transcript = await runtime.transcribe_audio_blob(
+                filename=filename or "voice.ogg",
+                mime_type=mime_type,
+                kind=kind,
+                raw_bytes=raw_bytes,
+            )
+            if str(transcript or "").strip():
+                updated = vault.set_ai_summary(customer_id, str(record.get("id") or ""), str(transcript))
+                if isinstance(updated, dict):
+                    record = updated
+    if (
+        runtime is not None
+        and hasattr(runtime, "summarize_uploaded_blob")
+        and not _skip_auto_summary_for_upload(kind=kind, filename=filename, mime_type=mime_type)
+    ):
+        with suppress(Exception):
+            summary = await runtime.summarize_uploaded_blob(
+                filename=filename or None,
+                mime_type=mime_type,
+                kind=kind,
+                raw_bytes=raw_bytes,
+                caption=caption,
+            )
+            if str(summary or "").strip():
+                updated = vault.set_ai_summary(customer_id, str(record.get("id") or ""), str(summary))
+                if isinstance(updated, dict):
+                    record = updated
+    return record
+
+
+def _web_file_metadata(record: dict[str, Any]) -> dict[str, Any]:
+    clean = sanitize_uploaded_file_record(record, include_excerpt=False)
+    file_id = str(clean.get("id") or "").strip()
+    if file_id:
+        clean["content_path"] = f"/web/files/{quote(file_id)}/content"
+        clean["metadata_path"] = f"/web/files/{quote(file_id)}/metadata"
+    return clean
+
+
+def _normalize_file_event(file: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(file)
+    file_id = str(payload.get("id") or "").strip()
+    local_path = str(payload.get("local_path") or "").strip()
+    if file_id and not payload.get("content_path"):
+        payload["content_path"] = f"/web/files/{quote(file_id)}/content"
+    if local_path and not payload.get("content_path"):
+        payload["content_path"] = f"/web/local-files/content?path={quote(local_path)}"
+    return payload
+
+
+def _text_with_uploaded_file_context(
+    *,
+    file_vault: Any,
+    customer_id: str,
+    text: str,
+    file_ids: list[str],
+) -> str:
+    records = file_vault.get_many(customer_id, file_ids) if file_ids else []
+    context = build_uploaded_files_context(records) if records else ""
+    if not context:
+        return text
+    return f"{context}\n\nCurrent user message:\n{text}"
+
+
+def _content_disposition(filename: str) -> str:
+    safe = str(filename or "file.bin").replace('"', "")
+    return f'inline; filename="{safe}"'

--- a/src/opentulpa/context/uploaded_files.py
+++ b/src/opentulpa/context/uploaded_files.py
@@ -1,0 +1,92 @@
+"""Shared uploaded-file prompt and summarization policy."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+DOCUMENT_EXTENSIONS = {
+    ".csv",
+    ".doc",
+    ".docx",
+    ".md",
+    ".ods",
+    ".pdf",
+    ".rtf",
+    ".tsv",
+    ".txt",
+    ".xls",
+    ".xlsx",
+}
+
+
+def build_uploaded_files_context(
+    records: list[dict[str, Any]], *, include_unclear_intent_guidance: bool = True
+) -> str:
+    if not records:
+        return ""
+    lines = [
+        "Internal uploaded-file context. Do not quote this metadata verbatim to the user.",
+        "Use file_id values with uploaded_file_* tools when deeper inspection is needed.",
+        "If a spreadsheet, price list, FAQ, or policy is intended for workflow setup, start/open the setup session first, then prepare it with business_knowledge_index and query it with business_knowledge_query before activation.",
+    ]
+    if include_unclear_intent_guidance:
+        lines.insert(
+            2,
+            "If recent conversation clearly says these files should become reusable chat context, use user_context_add_files. If intent is unclear, ask what the user wants done with the files; do not infer intent from filenames or content.",
+        )
+        lines.append(
+            "User-facing reply guidance: briefly acknowledge the upload and ask one focused follow-up question when the intended action is unclear."
+        )
+    for rec in records:
+        mime_type = str(rec.get("mime_type", "")).strip()
+        summary = str(rec.get("summary", "")).strip()
+        if "ai_summary=" in summary:
+            summary = summary.split("ai_summary=", 1)[1].strip()
+        if (
+            (mime_type.lower() == XLSX_MIME_TYPE or str(rec.get("original_filename", "")).lower().endswith(".xlsx"))
+            and "no extractable text was available" in summary.lower()
+        ):
+            summary = (
+                "Spreadsheet file stored. Use uploaded_file_inspect_structure with this file_id "
+                "or business_knowledge_index to prepare workflow knowledge without loading the workbook into chat context. "
+                "Do not use uploaded_file_analyze to create broad workflow source packs."
+            )
+        summary = re.sub(r"\s+", " ", summary)[:1200]
+        lines.append(
+            "- file_id={id} name={name} kind={kind} mime_type={mime_type} created_at={created_at} summary={summary}".format(
+                id=str(rec.get("id", "")).strip(),
+                name=str(rec.get("original_filename", "")).strip(),
+                kind=str(rec.get("kind", "")).strip(),
+                mime_type=mime_type or "unknown",
+                created_at=str(rec.get("created_at", "")).strip(),
+                summary=summary or "stored; no summary available yet",
+            )
+        )
+    return "\n".join(lines)
+
+
+def should_skip_auto_summary_for_upload(
+    *, kind: str | None, filename: str | None, mime_type: str | None
+) -> bool:
+    """Avoid hauling knowledge-source documents into the LLM at upload time."""
+    safe_kind = str(kind or "").strip().lower()
+    if safe_kind in {"photo", "video", "video_note", "audio", "voice"}:
+        return False
+    safe_mime = str(mime_type or "").strip().lower()
+    safe_name = str(filename or "").strip().lower()
+    if safe_kind == "document":
+        return True
+    if safe_mime.startswith("text/") or safe_mime in {
+        "application/pdf",
+        "application/msword",
+        "application/rtf",
+        "application/vnd.ms-excel",
+        XLSX_MIME_TYPE,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "text/csv",
+        "text/tab-separated-values",
+    }:
+        return True
+    return any(safe_name.endswith(ext) for ext in DOCUMENT_EXTENSIONS)

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -135,6 +135,10 @@ class Settings(BaseSettings):
         default=None,
         description="Optional secret for webhook path",
     )
+    opentulpa_generic_api_secret: str | None = Field(
+        default=None,
+        description="Optional bearer secret for authenticated generic non-Telegram API routes.",
+    )
 
     # Memory (mem0)
     mem0_user_id: str = Field(default="default", description="Default user id for mem0")

--- a/src/opentulpa/interfaces/telegram/attachments.py
+++ b/src/opentulpa/interfaces/telegram/attachments.py
@@ -8,24 +8,13 @@ from pathlib import Path
 from typing import Any
 
 from opentulpa.context.file_vault import FileVaultService
+from opentulpa.context.uploaded_files import (
+    should_skip_auto_summary_for_upload,
+)
 from opentulpa.interfaces.telegram.client import TelegramClient
 from opentulpa.interfaces.telegram.models import TelegramAttachment
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
-XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-_DOCUMENT_EXTENSIONS = {
-    ".csv",
-    ".doc",
-    ".docx",
-    ".md",
-    ".ods",
-    ".pdf",
-    ".rtf",
-    ".tsv",
-    ".txt",
-    ".xls",
-    ".xlsx",
-}
 
 
 def _safe_segment(value: str, *, fallback: str) -> str:
@@ -115,75 +104,6 @@ def extract_attachments(message: dict[str, Any]) -> list[TelegramAttachment]:
     return attachments
 
 
-def build_uploaded_files_context(
-    records: list[dict[str, Any]], *, include_unclear_intent_guidance: bool = True
-) -> str:
-    if not records:
-        return ""
-    lines = [
-        "Internal uploaded-file context. Do not quote this metadata verbatim to the user.",
-        "Use file_id values with uploaded_file_* tools when deeper inspection is needed.",
-        "If a spreadsheet, price list, FAQ, or policy is intended for workflow setup, start/open the setup session first, then prepare it with business_knowledge_index and query it with business_knowledge_query before activation.",
-    ]
-    if include_unclear_intent_guidance:
-        lines.insert(
-            2,
-            "If recent conversation clearly says these files should become reusable chat context, use user_context_add_files. If intent is unclear, ask what the user wants done with the files; do not infer intent from filenames or content.",
-        )
-        lines.append(
-            "User-facing reply guidance: briefly acknowledge the upload and ask one focused follow-up question when the intended action is unclear."
-        )
-    for rec in records:
-        mime_type = str(rec.get("mime_type", "")).strip()
-        summary = str(rec.get("summary", "")).strip()
-        if "ai_summary=" in summary:
-            summary = summary.split("ai_summary=", 1)[1].strip()
-        if (
-            (mime_type.lower() == XLSX_MIME_TYPE or str(rec.get("original_filename", "")).lower().endswith(".xlsx"))
-            and "no extractable text was available" in summary.lower()
-        ):
-            summary = (
-                "Spreadsheet file stored. Use uploaded_file_inspect_structure with this file_id "
-                "or business_knowledge_index to prepare workflow knowledge without loading the workbook into chat context. "
-                "Do not use uploaded_file_analyze to create broad workflow source packs."
-            )
-        summary = re.sub(r"\s+", " ", summary)[:1200]
-        lines.append(
-            "- file_id={id} name={name} kind={kind} mime_type={mime_type} created_at={created_at} summary={summary}".format(
-                id=str(rec.get("id", "")).strip(),
-                name=str(rec.get("original_filename", "")).strip(),
-                kind=str(rec.get("kind", "")).strip(),
-                mime_type=mime_type or "unknown",
-                created_at=str(rec.get("created_at", "")).strip(),
-                summary=summary or "stored; no summary available yet",
-            )
-        )
-    return "\n".join(lines)
-
-
-def _skip_auto_summary_for_upload(*, kind: str | None, filename: str | None, mime_type: str | None) -> bool:
-    """Avoid hauling knowledge-source documents into the LLM at upload time."""
-    safe_kind = str(kind or "").strip().lower()
-    if safe_kind in {"photo", "video", "video_note", "audio", "voice"}:
-        return False
-    safe_mime = str(mime_type or "").strip().lower()
-    safe_name = str(filename or "").strip().lower()
-    if safe_kind == "document":
-        return True
-    if safe_mime.startswith("text/") or safe_mime in {
-        "application/pdf",
-        "application/msword",
-        "application/rtf",
-        "application/vnd.ms-excel",
-        XLSX_MIME_TYPE,
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "text/csv",
-        "text/tab-separated-values",
-    }:
-        return True
-    return any(safe_name.endswith(ext) for ext in _DOCUMENT_EXTENSIONS)
-
-
 async def ingest_attachments(
     *,
     attachments: list[TelegramAttachment],
@@ -243,7 +163,7 @@ async def ingest_attachments(
             if (
                 agent_runtime is not None
                 and hasattr(agent_runtime, "summarize_uploaded_blob")
-                and not _skip_auto_summary_for_upload(
+                and not should_skip_auto_summary_for_upload(
                     kind=attachment.kind,
                     filename=attachment.filename or file_path_name,
                     mime_type=attachment.mime_type or str(downloaded.get("mime_type", "")).strip() or None,

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from opentulpa.context.file_vault import FileVaultService
+from opentulpa.context.uploaded_files import build_uploaded_files_context
 from opentulpa.core.config import get_openai_compatible_api_key_from_env
 from opentulpa.core.debug_logs import (
     DEFAULT_DEBUG_LOG_LOOKBACK_DAYS,
@@ -17,7 +18,6 @@ from opentulpa.core.debug_logs import (
 )
 from opentulpa.core.ids import new_short_id
 from opentulpa.interfaces.telegram.attachments import (
-    build_uploaded_files_context,
     extract_attachments,
     ingest_attachments,
 )

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -67,6 +67,21 @@ def test_web_chat_rejects_missing_bearer(monkeypatch: Any, tmp_path: Any) -> Non
     assert response.status_code == 401
 
 
+def test_web_chat_has_typed_request_validation(monkeypatch: Any, tmp_path: Any) -> None:
+    client, _ = _client(monkeypatch, tmp_path)
+    response = client.post(
+        "/web/chat/turns",
+        headers={"authorization": "Bearer generic-secret"},
+        json={"customer_id": "telegram_1", "thread_id": "dashboard-owner-1", "text": ""},
+    )
+    assert response.status_code == 422
+
+    openapi = client.get("/openapi.json").json()
+    operation = openapi["paths"]["/web/chat/turns"]["post"]
+    schema_ref = operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    assert schema_ref.endswith("/WebChatTurnRequest")
+
+
 def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_path: Any) -> None:
     client, runtime = _client(monkeypatch, tmp_path)
     with client.stream(

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from opentulpa.api.app import create_app
+from opentulpa.context.file_vault import FileVaultService
+from opentulpa.core.config import get_settings
+
+
+class _StreamingRuntime:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.update_sender: Any | None = None
+        self.file_sender: Any | None = None
+
+    async def register_interactive_update_sender(self, *, thread_id: str, sender: Any) -> None:
+        assert thread_id
+        assert sender is not None
+        self.update_sender = sender
+
+    async def clear_interactive_update_sender(self, *, thread_id: str, sender: Any | None = None) -> None:
+        assert thread_id
+        if sender is None or sender is self.update_sender:
+            self.update_sender = None
+
+    async def register_interactive_file_sender(self, *, thread_id: str, sender: Any) -> None:
+        assert thread_id
+        assert sender is not None
+        self.file_sender = sender
+
+    async def clear_interactive_file_sender(self, *, thread_id: str, sender: Any | None = None) -> None:
+        assert thread_id
+        if sender is None or sender is self.file_sender:
+            self.file_sender = None
+
+    async def astream_text(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        assert self.update_sender is not None
+        result = self.update_sender("Checking context.")
+        if hasattr(result, "__await__"):
+            await result
+        assert self.file_sender is not None
+        file_result = self.file_sender({"id": "file_123", "original_filename": "demo.pdf"})
+        if hasattr(file_result, "__await__"):
+            await file_result
+        yield "Hello"
+        yield "Hello from web."
+
+
+def _client(monkeypatch: Any, tmp_path: Any) -> tuple[TestClient, _StreamingRuntime]:
+    monkeypatch.setenv("OPENTULPA_GENERIC_API_SECRET", "generic-secret")
+    get_settings.cache_clear()
+    runtime = _StreamingRuntime()
+    vault = FileVaultService(root_dir=tmp_path / "vault", db_path=tmp_path / "vault.db")
+    app = create_app(agent_runtime=runtime, file_vault_service=vault)
+    return TestClient(app), runtime
+
+
+def test_web_chat_rejects_missing_bearer(monkeypatch: Any, tmp_path: Any) -> None:
+    client, _ = _client(monkeypatch, tmp_path)
+    response = client.post(
+        "/web/chat/turns",
+        json={"customer_id": "telegram_1", "thread_id": "dashboard-owner-1", "text": "hi"},
+    )
+    assert response.status_code == 401
+
+
+def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_path: Any) -> None:
+    client, runtime = _client(monkeypatch, tmp_path)
+    with client.stream(
+        "POST",
+        "/web/chat/turns",
+        headers={"authorization": "Bearer generic-secret"},
+        json={
+            "customer_id": "telegram_1",
+            "thread_id": "dashboard-owner-1",
+            "text": "hi",
+        },
+    ) as response:
+        text = response.read().decode("utf-8")
+
+    assert response.status_code == 200
+    assert "event: status" in text
+    assert "event: owner_update" in text
+    assert "Checking context." in text
+    assert "event: file" in text
+    assert "/web/files/file_123/content" in text
+    assert "event: delta" in text
+    assert "Hello from web." in text
+    assert "event: final" in text
+    assert runtime.calls[0]["customer_id"] == "telegram_1"
+    assert runtime.calls[0]["thread_id"] == "dashboard-owner-1"
+
+
+def test_web_file_upload_and_content_are_bearer_protected(monkeypatch: Any, tmp_path: Any) -> None:
+    client, _ = _client(monkeypatch, tmp_path)
+
+    upload = client.post(
+        "/web/files/upload",
+        headers={"authorization": "Bearer generic-secret"},
+        data={"customer_id": "telegram_1", "thread_id": "dashboard-owner-1", "kind": "document"},
+        files={"file": ("hello.txt", b"hello world", "text/plain")},
+    )
+    assert upload.status_code == 200
+    file_id = upload.json()["file"]["id"]
+
+    unauth = client.get(
+        f"/web/files/{file_id}/content",
+        params={"customer_id": "telegram_1"},
+    )
+    assert unauth.status_code == 401
+
+    content = client.get(
+        f"/web/files/{file_id}/content",
+        headers={"authorization": "Bearer generic-secret"},
+        params={"customer_id": "telegram_1"},
+    )
+    assert content.status_code == 200
+    assert content.content == b"hello world"
+    assert content.headers["content-type"].startswith("text/plain")

--- a/tests/test_intake_tools.py
+++ b/tests/test_intake_tools.py
@@ -281,6 +281,7 @@ async def test_tulpa_file_send_marks_delivered_file_for_agent() -> None:
     assert runtime.calls[0][2]["json_body"] == {
         "path": "tulpa_stuff/sample_delivery_report.txt",
         "customer_id": "telegram_123",
+        "thread_id": "thread_123",
         "caption": "Sample delivery report",
     }
 

--- a/tests/test_telegram_attachments.py
+++ b/tests/test_telegram_attachments.py
@@ -4,9 +4,8 @@ import pytest
 
 import opentulpa.interfaces.telegram.attachments as attachments_module
 from opentulpa.context.file_vault import FileVaultService
+from opentulpa.context.uploaded_files import XLSX_MIME_TYPE, build_uploaded_files_context
 from opentulpa.interfaces.telegram.attachments import (
-    XLSX_MIME_TYPE,
-    build_uploaded_files_context,
     extract_attachments,
     ingest_attachments,
 )


### PR DESCRIPTION
## Summary

Adds the OpenTulpa runtime side of generic authenticated web chat so dashboard-owned clients can talk to a deployed OpenTulpa without exposing OpenTulpa directly to end users.

## What Changed

- adds optional `OPENTULPA_GENERIC_API_SECRET` bearer auth
- adds `/web/chat/turns` SSE route for non-Telegram chat turns
- adds `/web/files/upload`, file metadata, file content, and local-file preview routes
- reuses existing OpenTulpa file vault, upload summarization, and voice transcription paths
- injects uploaded file context into generic chat turns
- allows runtime file-send tools to deliver files back to the active web chat stream
- keeps Telegram delivery as fallback when no web sender is registered
- adds tests for bearer protection, streaming events, file events, upload, and file reads

## Validation

- `uv run ruff check src/opentulpa/api/routes/generic_chat.py src/opentulpa/api/routes/files.py src/opentulpa/api/app.py src/opentulpa/agent/runtime.py src/opentulpa/agent/tools/file_tools.py tests/test_generic_chat_routes.py tests/test_intake_tools.py`
- `uv run pytest tests/test_generic_chat_routes.py tests/test_core_tools.py tests/test_intake_tools.py tests/test_interactive_owner_update_runtime.py -q` (`29 passed`)
