### PR TITLE
[codex] Add OpenTulpa web event feed

### DIFF
--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -31,6 +31,7 @@ from opentulpa.api.routes import (
     register_tulpa_routes,
     register_user_context_routes,
     register_wake_and_search_routes,
+    register_web_event_routes,
 )
 from opentulpa.api.tulpa_loader import TulpaRouterLoader
 from opentulpa.application import (
@@ -61,6 +62,7 @@ from opentulpa.tasks.sandbox import PROJECT_ROOT
 from opentulpa.tasks.sandbox import delete_file as sandbox_delete_file
 from opentulpa.tasks.service import TaskService
 from opentulpa.tasks.wake_queue import WakeQueueService
+from opentulpa.web.events import WebEventStore, set_default_web_event_store
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +215,10 @@ def create_app(
     context_events_service = context_events or EventContextService(
         db_path=PROJECT_ROOT / ".opentulpa" / "context_events.db"
     )
+    web_event_store = WebEventStore(
+        db_path=PROJECT_ROOT / ".opentulpa" / "web_events.db"
+    )
+    set_default_web_event_store(web_event_store)
     profile_service = customer_profile_service or CustomerProfileService(
         db_path=PROJECT_ROOT / ".opentulpa" / "customer_profiles.db"
     )
@@ -285,6 +291,9 @@ def create_app(
 
     def get_context_events() -> EventContextService:
         return _require(context_events_service, "EventContextService")
+
+    def get_web_events() -> WebEventStore:
+        return web_event_store
 
     def get_profiles() -> CustomerProfileService:
         return _require(profile_service, "CustomerProfileService")
@@ -524,6 +533,7 @@ def create_app(
         if (
             not trusted_server_client
             and not path.startswith("/webhook/")
+            and path != "/web/events"
             and path not in public_health_paths
         ):
             return JSONResponse(status_code=403, content={"detail": "forbidden public endpoint"})
@@ -595,6 +605,11 @@ def create_app(
         app,
         get_wake_queue=get_wake_queue,
         llm_model=settings.llm_model,
+    )
+    register_web_event_routes(
+        app,
+        settings=settings,
+        get_web_events=get_web_events,
     )
     register_tulpa_routes(
         app,

--- a/src/opentulpa/api/routes/__init__.py
+++ b/src/opentulpa/api/routes/__init__.py
@@ -24,6 +24,7 @@ _ROUTE_IMPORTS = {
     "register_tulpa_routes": "opentulpa.api.routes.tulpa",
     "register_user_context_routes": "opentulpa.api.routes.user_context",
     "register_wake_and_search_routes": "opentulpa.api.routes.wake_search",
+    "register_web_event_routes": "opentulpa.api.routes.web_events",
 }
 
 __all__ = list(_ROUTE_IMPORTS)

--- a/src/opentulpa/api/routes/chat.py
+++ b/src/opentulpa/api/routes/chat.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from opentulpa.domain.conversation import ConversationTurnRequest
+from opentulpa.web.events import append_web_event
 
 
 def register_chat_routes(
@@ -52,6 +53,14 @@ def register_chat_routes(
                 recursion_limit_override=recursion_limit_override,
             )
         )
+        if result.status == "ok":
+            append_web_event(
+                customer_id=result.customer_id,
+                thread_id=result.thread_id,
+                source="chat",
+                kind="assistant_message",
+                text=result.text,
+            )
         status_code = 200 if result.status == "ok" else 503 if result.status == "unavailable" else 400
         return JSONResponse(
             status_code=status_code,

--- a/src/opentulpa/api/routes/web_events.py
+++ b/src/opentulpa/api/routes/web_events.py
@@ -1,0 +1,79 @@
+"""Authenticated web event feed for dashboard polling."""
+
+from __future__ import annotations
+
+import hmac
+import json
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+
+def register_web_event_routes(
+    app: FastAPI,
+    *,
+    settings: Any,
+    get_web_events: Callable[[], Any],
+) -> None:
+    """Register dashboard-facing event feed routes."""
+
+    @app.get("/web/events")
+    async def list_web_events(request: Request) -> JSONResponse:
+        expected_token = str(getattr(settings, "opentulpa_web_token", "") or "").strip()
+        if not expected_token:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "opentulpa web token is not configured"},
+            )
+        incoming = str(request.headers.get("authorization", "") or "").strip()
+        prefix = "Bearer "
+        token = incoming[len(prefix) :].strip() if incoming.startswith(prefix) else ""
+        if not hmac.compare_digest(token, expected_token):
+            return JSONResponse(status_code=403, content={"detail": "invalid opentulpa web token"})
+
+        after_id = _int_query(request, "after_id", default=0)
+        limit = _int_query(request, "limit", default=100)
+        customer_id = str(request.query_params.get("customer_id", "") or "").strip() or None
+        events = get_web_events().list_events(
+            after_id=after_id,
+            limit=limit,
+            customer_id=customer_id,
+        )
+        return JSONResponse(
+            content={
+                "events": [_serialize_event(event) for event in events],
+                "next_cursor": events[-1]["id"] if events else after_id,
+            }
+        )
+
+
+def _int_query(request: Request, name: str, *, default: int) -> int:
+    raw = str(request.query_params.get(name, "") or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _serialize_event(event: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    try:
+        loaded = json.loads(str(event.get("metadata_json") or "{}"))
+        if isinstance(loaded, dict):
+            metadata = loaded
+    except json.JSONDecodeError:
+        metadata = {}
+    return {
+        "id": int(event["id"]),
+        "created_at": str(event["created_at"]),
+        "customer_id": str(event["customer_id"]),
+        "thread_id": str(event["thread_id"]),
+        "source": str(event["source"]),
+        "kind": str(event["kind"]),
+        "text": str(event["text"]),
+        "metadata": metadata,
+    }

--- a/src/opentulpa/application/wake_orchestrator.py
+++ b/src/opentulpa/application/wake_orchestrator.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from opentulpa.core.ids import new_short_id
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
+from opentulpa.web.events import append_web_event
 
 
 class WakeOrchestrator:
@@ -67,6 +68,23 @@ class WakeOrchestrator:
                 source="routine",
                 event_type=event_type,
                 payload={key: value for key, value in event_payload.items() if value not in ("", None)},
+            )
+        summary = str(payload.get("execution_summary", "") or "").strip()
+        if summary and summary != NO_NOTIFY_TOKEN and bool(payload.get("notify_user", False)):
+            append_web_event(
+                customer_id=customer_id,
+                thread_id=str(payload.get("routine_id", "") or "").strip(),
+                source="routine",
+                kind="proactive_message",
+                text=summary,
+                metadata_json=json.dumps(
+                    {
+                        "event_type": event_type,
+                        "routine_id": str(payload.get("routine_id", "") or "").strip(),
+                        "routine_name": str(payload.get("routine_name", "") or "").strip(),
+                    },
+                    ensure_ascii=False,
+                ),
             )
 
     @staticmethod
@@ -155,11 +173,20 @@ class WakeOrchestrator:
             )
             return
         for item in replies:
-            await self._get_telegram_client().send_message(
+            sent = await self._get_telegram_client().send_message(
                 chat_id=item["chat_id"],
                 text=item["text"],
                 parse_mode="HTML",
             )
+            if sent:
+                append_web_event(
+                    customer_id=customer_id,
+                    thread_id=str(body.get("task_id", "") or "").strip(),
+                    source="task",
+                    kind="proactive_message",
+                    text=str(item.get("text", "") or ""),
+                    metadata_json=json.dumps({"event_type": event_type}, ensure_ascii=False),
+                )
 
     async def _handle_routine_event(self, body: dict[str, Any]) -> None:
         payload = body.get("payload") if isinstance(body.get("payload"), dict) else {}

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -135,6 +135,10 @@ class Settings(BaseSettings):
         default=None,
         description="Optional secret for webhook path",
     )
+    opentulpa_web_token: str | None = Field(
+        default=None,
+        description="Bearer token required for dashboard web operations against this deployment.",
+    )
 
     # Memory (mem0)
     mem0_user_id: str = Field(default="default", description="Default user id for mem0")

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -23,6 +23,7 @@ from opentulpa.core.ids import new_short_id
 from opentulpa.interfaces.telegram.client import TelegramClient
 from opentulpa.interfaces.telegram.constants import DEBUG_LOG_PATH, LOW_SIGNAL_REPLIES
 from opentulpa.interfaces.telegram.status_generation import generate_llm_status_message
+from opentulpa.web.events import append_web_event
 
 logger = logging.getLogger(__name__)
 NO_NOTIFY_TOKEN = "__NO_NOTIFY__"
@@ -497,6 +498,14 @@ async def stream_langgraph_reply_to_telegram(
         if sent:
             delivered_any = True
             interim_status_sent = True
+            append_web_event(
+                customer_id=customer_id,
+                thread_id=thread_id,
+                source="chat",
+                kind="status",
+                text=status_text,
+                metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
+            )
             logger.info(
                 "telegram.stream status_generation_sent chat_id=%s thread_id=%s customer_id=%s stage=%s chars=%s",
                 chat_id,
@@ -804,6 +813,14 @@ async def stream_langgraph_reply_to_telegram(
         )
         if sent:
             delivered_any = True
+            append_web_event(
+                customer_id=customer_id,
+                thread_id=thread_id,
+                source="chat",
+                kind="assistant_message",
+                text=final_reply,
+                metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
+            )
         else:
             final_reply = None
     logger.info(

--- a/src/opentulpa/web/__init__.py
+++ b/src/opentulpa/web/__init__.py
@@ -1,0 +1,2 @@
+"""Web dashboard event support."""
+

--- a/src/opentulpa/web/events.py
+++ b/src/opentulpa/web/events.py
@@ -1,0 +1,159 @@
+"""Durable web-visible event outbox."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class WebEventStore:
+    """SQLite-backed event outbox for dashboard consumers."""
+
+    def __init__(self, db_path: Path) -> None:
+        assert db_path is not None
+        self._db_path = db_path
+        self._lock = threading.Lock()
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS web_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    created_at TEXT NOT NULL,
+                    customer_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    text TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_web_events_id ON web_events(id)")
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_web_events_customer_thread
+                ON web_events(customer_id, thread_id, id)
+                """
+            )
+
+    def append(
+        self,
+        *,
+        customer_id: str,
+        thread_id: str,
+        source: str,
+        kind: str,
+        text: str,
+        metadata_json: str = "{}",
+    ) -> int:
+        assert source.strip()
+        assert kind.strip()
+        body = str(text or "").strip()
+        if not body:
+            return 0
+        created_at = datetime.now(UTC).isoformat()
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO web_events (
+                    created_at, customer_id, thread_id, source, kind, text, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    created_at,
+                    str(customer_id or "").strip(),
+                    str(thread_id or "").strip(),
+                    source.strip(),
+                    kind.strip(),
+                    body,
+                    metadata_json.strip() or "{}",
+                ),
+            )
+            event_id = int(cursor.lastrowid or 0)
+        assert event_id > 0
+        return event_id
+
+    def list_events(
+        self,
+        *,
+        after_id: int = 0,
+        limit: int = 100,
+        customer_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        safe_limit = max(1, min(int(limit), 500))
+        conditions = ["id > ?"]
+        params: list[Any] = [max(0, int(after_id))]
+        if customer_id:
+            conditions.append("customer_id = ?")
+            params.append(customer_id.strip())
+        query = (
+            "SELECT id, created_at, customer_id, thread_id, source, kind, text, metadata_json "
+            f"FROM web_events WHERE {' AND '.join(conditions)} ORDER BY id ASC LIMIT ?"
+        )
+        params.append(safe_limit)
+        with self._lock, self._connect() as conn:
+            rows: Iterable[sqlite3.Row] = conn.execute(query, params).fetchall()
+        return [
+            {
+                "id": int(row["id"]),
+                "created_at": str(row["created_at"]),
+                "customer_id": str(row["customer_id"]),
+                "thread_id": str(row["thread_id"]),
+                "source": str(row["source"]),
+                "kind": str(row["kind"]),
+                "text": str(row["text"]),
+                "metadata_json": str(row["metadata_json"] or "{}"),
+            }
+            for row in rows
+        ]
+
+
+_DEFAULT_STORE: WebEventStore | None = None
+
+
+def set_default_web_event_store(store: WebEventStore | None) -> None:
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+def append_web_event(
+    *,
+    customer_id: str,
+    thread_id: str,
+    source: str,
+    kind: str,
+    text: str,
+    metadata_json: str = "{}",
+) -> int:
+    store = _DEFAULT_STORE
+    if store is None:
+        return 0
+    try:
+        return store.append(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            source=source,
+            kind=kind,
+            text=text,
+            metadata_json=metadata_json,
+        )
+    except Exception:
+        logger.exception("failed to append web event source=%s kind=%s", source, kind)
+        return 0

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -62,3 +62,22 @@ def test_webhook_route_public_with_telegram_auth(
         )
         assert response.status_code == 200
     get_settings.cache_clear()
+
+
+def test_web_events_route_public_with_bearer_auth(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    get_settings.cache_clear()
+    with _mk_client(tmp_path, client_host="8.8.8.8") as client:
+        rejected = client.get("/web/events")
+        accepted = client.get(
+            "/web/events?after_id=999999",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert rejected.status_code == 403
+    assert accepted.status_code == 200
+    assert accepted.json() == {"events": [], "next_cursor": 999999}
+    get_settings.cache_clear()

--- a/tests/test_web_events.py
+++ b/tests/test_web_events.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opentulpa.api.routes.web_events import register_web_event_routes
+from opentulpa.web.events import WebEventStore, append_web_event, set_default_web_event_store
+
+
+def test_web_event_store_lists_events_after_cursor(tmp_path: Path) -> None:
+    store = WebEventStore(tmp_path / "web_events.db")
+    first_id = store.append(
+        customer_id="telegram_1",
+        thread_id="chat-1",
+        source="chat",
+        kind="assistant_message",
+        text="First",
+    )
+    second_id = store.append(
+        customer_id="telegram_1",
+        thread_id="chat-1",
+        source="routine",
+        kind="proactive_message",
+        text="Second",
+    )
+
+    events = store.list_events(after_id=first_id)
+
+    assert second_id > first_id
+    assert [event["id"] for event in events] == [second_id]
+    assert events[0]["text"] == "Second"
+
+
+def test_web_events_route_requires_bearer_token(tmp_path: Path) -> None:
+    store = WebEventStore(tmp_path / "web_events.db")
+    store.append(
+        customer_id="telegram_1",
+        thread_id="chat-1",
+        source="chat",
+        kind="assistant_message",
+        text="Hello dashboard",
+    )
+    app = FastAPI()
+    register_web_event_routes(
+        app,
+        settings=type("Settings", (), {"opentulpa_web_token": "secret"})(),
+        get_web_events=lambda: store,
+    )
+
+    with TestClient(app) as client:
+        rejected = client.get("/web/events")
+        accepted = client.get("/web/events", headers={"authorization": "Bearer secret"})
+
+    assert rejected.status_code == 403
+    assert accepted.status_code == 200
+    assert accepted.json()["events"][0]["text"] == "Hello dashboard"
+
+
+def test_append_web_event_never_raises_when_store_fails() -> None:
+    class BrokenStore:
+        def append(self, **_: object) -> int:
+            raise RuntimeError("sqlite unavailable")
+
+    set_default_web_event_store(BrokenStore())  # type: ignore[arg-type]
+    try:
+        event_id = append_web_event(
+            customer_id="telegram_1",
+            thread_id="chat-1",
+            source="chat",
+            kind="assistant_message",
+            text="Hello",
+        )
+    finally:
+        set_default_web_event_store(None)
+
+    assert event_id == 0


### PR DESCRIPTION
## Summary
- Add OpenTulpa `/web/events` as a durable, token-authenticated event feed.
- Record web-visible chat, task, and routine outputs without changing Telegram delivery.
- Guard web event writes so outbox failures cannot break Telegram or wake flows.

## Validation
- `uv run ruff check src/opentulpa/web/events.py tests/test_web_events.py`
- `python3 -m compileall src/opentulpa/web/events.py`
- `uv run pytest -q tests/test_web_events.py tests/test_internal_api_auth.py tests/test_wake_orchestrator.py`