### PR TITLE
Add generic user id Telegram aliases

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,49 @@ This keeps these concerns separate:
 
 If a Business account is not visible after setup, inspect webhook delivery and stored connection state instead of adding the Business account to env vars. The useful checks are Telegram `getWebhookInfo`, `/debug_logs` webhook diagnostics, `.opentulpa/telegram_business.db`, and the workflow `source_config.business_connection_id`.
 
+### Profile identity aliases
+
+OpenTulpa identity is not required to be Telegram identity. The durable account id can be a generic `user_id` such as `usr_default`, and a Telegram user id can be bound later to add Telegram chat capability. Generic identity alone does not enable Telegram: Telegram chat and Telegram Business require a real Telegram user id plus a configured bot token/client.
+
+Profile binding is alias resolution, not data copying. Before storage reads or writes, API and Telegram entrypoints resolve the inbound id to one storage scope:
+
+```text
+request customer_id: usr_default  -> storage_user_id: usr_default
+request customer_id: telegram_123 -> storage_user_id: usr_default
+```
+
+Use the generic id when creating a non-Telegram OpenTulpa account. All normal OpenTulpa state can be created under that id: profiles, workflows, files, skills, memory, web chat events, scheduler rows, wake/search state, artifacts, and sandbox files. Example workflow payload:
+
+```json
+{
+  "customer_id": "usr_default",
+  "name": "Car Wash Intake"
+}
+```
+
+Bind Telegram only after the real Telegram user id is known:
+
+```http
+POST /profiles/bind-telegram
+Content-Type: application/json
+
+{"user_id":"usr_default","telegram_user_id":"123"}
+```
+
+After that bind, requests using either `usr_default` or `telegram_123` operate on the same canonical storage scope. The id `telegram_123` is the Telegram alias format; callers pass the raw Telegram id only to the bind route.
+
+First-created storage wins. If `usr_default` exists first, binding maps `telegram_123` to `usr_default`. If `telegram_123` already existed first, binding maps `usr_default` to the existing Telegram storage so legacy Telegram users keep their data. If both ids already have separate data, OpenTulpa rejects automatic binding because a silent merge can corrupt conversation history, artifacts, workflow state, or sandbox references.
+
+The current product model supports one generic OpenTulpa user and at most one main Telegram user binding for it. Existing Telegram-canonical users keep working because unbound Telegram chats still fall back to `telegram_<telegram_user_id>`.
+
+Manage ids with:
+
+- `GET /profiles`: list known profile ids and bindings.
+- `POST /profiles/bind-telegram`: bind a generic `user_id` to a Telegram user id.
+- Any customer-scoped route: pass either the generic id or its Telegram alias; the route resolves to canonical storage before reading or writing.
+
+Do not copy history, artifacts, or workflow rows between ids. If a user needs Telegram capability, create or keep the generic account, bind the Telegram user id, and let alias resolution share the same storage scope.
+
 ### Support act-as flow
 
 Support operators are trusted operators configured by `TELEGRAM_SUPPORT_USER_IDS` or `TELEGRAM_SUPPORT_USERNAMES`.

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -276,6 +276,9 @@ def create_app(
             bot_token=settings.telegram_bot_token,
             file_vault=vault_service,
             memory=memory_service,
+            resolve_customer_id=profile_service.resolve_customer_id,
+            resolve_telegram_customer_id=profile_service.resolve_telegram_customer_id,
+            alias_user_ids=profile_service.alias_user_ids,
         )
         if settings.telegram_bot_token
         else None
@@ -328,11 +331,14 @@ def create_app(
 
     telegram_business = TelegramBusinessService(
         db_path=PROJECT_ROOT / ".opentulpa" / "telegram_business.db",
-        owner_customer_id=_telegram_business_owner_customer_id(
-            allowed_usernames=settings.telegram_allowed_usernames,
-            allowed_user_ids=settings.telegram_allowed_user_ids,
-            state_path=PROJECT_ROOT / ".opentulpa" / "telegram_state.json",
+        owner_customer_id=profile_service.resolve_customer_id(
+            _telegram_business_owner_customer_id(
+                allowed_usernames=settings.telegram_allowed_usernames,
+                allowed_user_ids=settings.telegram_allowed_user_ids,
+                state_path=PROJECT_ROOT / ".opentulpa" / "telegram_state.json",
+            )
         ),
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     telegram_business.client = telegram_client
 
@@ -468,6 +474,7 @@ def create_app(
         get_telegram_client=get_telegram_client,
         get_agent_runtime=get_agent_runtime,
         get_intake_workflows=get_intake_workflows,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
 
     async def process_wake_event(body: dict[str, Any]) -> None:
@@ -561,15 +568,24 @@ def create_app(
 
     register_health_routes(app, get_agent_runtime=get_agent_runtime)
     register_debug_log_routes(app)
-    register_chat_routes(app, get_turn_orchestrator=get_turn_orchestrator)
+    register_chat_routes(
+        app,
+        get_turn_orchestrator=get_turn_orchestrator,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
     register_generic_chat_routes(
         app,
         web_token=settings.opentulpa_web_token,
         get_agent_runtime=get_agent_runtime,
         get_file_vault=get_file_vault,
         get_workflow_setup_service=get_workflow_setup_service,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
-    register_memory_routes(app, get_memory=get_memory)
+    register_memory_routes(
+        app,
+        get_memory=get_memory,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
     register_file_routes(
         app,
         get_file_vault=get_file_vault,
@@ -577,13 +593,19 @@ def create_app(
         get_telegram_client=get_telegram_client,
         get_agent_runtime=get_agent_runtime,
         telegram_enabled=bool(settings.telegram_bot_token),
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
-    register_knowledge_routes(app, get_knowledge_service=get_knowledge_service)
+    register_knowledge_routes(
+        app,
+        get_knowledge_service=get_knowledge_service,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
     register_user_context_routes(
         app,
         get_user_context_service=get_user_context_service,
         get_file_vault=get_file_vault,
         get_agent_runtime=get_agent_runtime,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_profile_routes(
         app,
@@ -594,40 +616,54 @@ def create_app(
         app,
         get_skill_store=get_skill_store,
         get_memory=lambda: memory_service,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_intake_workflow_routes(
         app,
         get_intake_workflows=get_intake_workflows,
         get_workflow_setup_service=get_workflow_setup_service,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_telegram_business_routes(
         app,
         get_telegram_business=get_telegram_business,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_system_routes(app)
-    register_composio_routes(app, get_composio=get_composio)
+    register_composio_routes(
+        app,
+        get_composio=get_composio,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
 
     register_scheduler_routes(
         app,
         get_scheduler=get_scheduler,
         delete_file=sandbox_delete_file,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_wake_and_search_routes(
         app,
         get_wake_queue=get_wake_queue,
         llm_model=settings.llm_model,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_web_event_routes(
         app,
         settings=settings,
         get_web_events=get_web_events,
+        resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_tulpa_routes(
         app,
         get_tulpa_loader=get_tulpa_loader,
         refresh_tulpa_mounts=refresh_tulpa_mounts,
     )
-    register_task_routes(app, get_tasks=get_tasks)
+    register_task_routes(
+        app,
+        get_tasks=get_tasks,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
 
     register_telegram_webhook_routes(
         app,

--- a/src/opentulpa/api/customer_ids.py
+++ b/src/opentulpa/api/customer_ids.py
@@ -1,0 +1,25 @@
+"""Customer id alias helpers for API route boundaries."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def resolve_customer_id(
+    customer_id: Any,
+    resolver: Callable[[str], str] | None,
+) -> str:
+    cid = str(customer_id or "").strip()
+    if not cid or resolver is None:
+        return cid
+    resolved = str(resolver(cid) or "").strip()
+    return resolved or cid
+
+
+def resolve_body_customer_id(
+    body: dict[str, Any],
+    resolver: Callable[[str], str] | None,
+) -> str:
+    return resolve_customer_id(body.get("customer_id", ""), resolver)
+

--- a/src/opentulpa/api/routes/chat.py
+++ b/src/opentulpa/api/routes/chat.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
 from opentulpa.domain.conversation import ConversationTurnRequest
 from opentulpa.web.events import append_web_event
 
@@ -16,13 +17,14 @@ def register_chat_routes(
     app: FastAPI,
     *,
     get_turn_orchestrator: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register API chat endpoints for direct (non-Telegram) turn simulation."""
 
     @app.post("/internal/chat")
     async def internal_chat(request: Request) -> Any:
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         text = str(body.get("text", "")).strip()
         thread_id = str(body.get("thread_id", "")).strip()
         if not thread_id and customer_id:
@@ -43,6 +45,13 @@ def register_chat_routes(
                 status_code=400,
                 content={"detail": "customer_id and text are required"},
             )
+        append_web_event(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            source="chat",
+            kind="user_message",
+            text=text,
+        )
         orchestrator = get_turn_orchestrator()
         result = await orchestrator.run_turn(
             ConversationTurnRequest(

--- a/src/opentulpa/api/routes/composio.py
+++ b/src/opentulpa/api/routes/composio.py
@@ -9,6 +9,8 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.core.public_urls import build_public_composio_callback_path
 
 logger = logging.getLogger(__name__)
@@ -28,6 +30,7 @@ def register_composio_routes(
     app: FastAPI,
     *,
     get_composio: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal Composio helper endpoints."""
 
@@ -67,7 +70,8 @@ def register_composio_routes(
     async def internal_composio_status() -> dict[str, Any]:
         service = get_composio()
         if hasattr(service, "status"):
-            return service.status()
+            result = service.status()
+            return dict(result) if isinstance(result, dict) else {"ok": True, "status": result}
         return {"ok": True, "enabled": bool(getattr(service, "enabled", False))}
 
     @app.post("/internal/composio/authorize")
@@ -75,7 +79,7 @@ def register_composio_routes(
         body = await request.json()
         try:
             return get_composio().authorize_toolkit(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 toolkit=str(body.get("toolkit", "")).strip(),
                 callback_url=str(body.get("callback_url", "")).strip() or None,
             )
@@ -109,7 +113,7 @@ def register_composio_routes(
             if str(is_connected or "").strip():
                 connected_flag = str(is_connected).strip().lower() in {"1", "true", "yes", "on"}
             return get_composio().list_toolkits(
-                customer_id=customer_id,
+                customer_id=resolve_customer_id_value(customer_id, resolve_customer_id),
                 toolkits=_parse_csv(toolkits),
                 is_connected=connected_flag,
                 limit=limit,
@@ -127,7 +131,7 @@ def register_composio_routes(
     ) -> Any:
         try:
             return get_composio().list_connected_accounts(
-                customer_id=customer_id,
+                customer_id=resolve_customer_id_value(customer_id, resolve_customer_id),
                 toolkits=_parse_csv(toolkits),
                 statuses=_parse_csv(statuses),
                 limit=limit,
@@ -182,7 +186,7 @@ def register_composio_routes(
         body = await request.json()
         try:
             return get_composio().inspect_instagram_reply_target(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 recipient_id=str(body.get("recipient_id", "")).strip() or None,
                 conversation_id=str(body.get("conversation_id", "")).strip() or None,
                 connected_account_id=str(body.get("connected_account_id", "")).strip() or None,
@@ -196,7 +200,7 @@ def register_composio_routes(
         body = await request.json()
         try:
             return get_composio().execute_tool(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 tool_slug=str(body.get("tool_slug", "")).strip(),
                 arguments=body.get("arguments") if isinstance(body.get("arguments"), dict) else {},
                 connected_account_id=str(body.get("connected_account_id", "")).strip() or None,

--- a/src/opentulpa/api/routes/files.py
+++ b/src/opentulpa/api/routes/files.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from opentulpa.agent.knowledge_prep import inspect_uploaded_file_structure
+from opentulpa.api.customer_ids import resolve_body_customer_id
 from opentulpa.api.file_helpers import (
     download_image_from_web_url,
     sanitize_uploaded_file_record,
@@ -41,6 +42,7 @@ def register_file_routes(
     get_telegram_client: Callable[[], Any],
     get_agent_runtime: Callable[[], Any],
     telegram_enabled: bool,
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register uploaded-file search/get/send/analyze endpoints."""
 
@@ -48,7 +50,7 @@ def register_file_routes(
     async def internal_files_search(request: Request) -> Any:
         vault = get_file_vault()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         query = str(body.get("query", "")).strip()
         limit = int(body.get("limit", 5))
         results = [
@@ -61,7 +63,7 @@ def register_file_routes(
     async def internal_files_get(request: Request) -> Any:
         vault = get_file_vault()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         file_id = str(body.get("file_id", "")).strip()
         max_excerpt_chars = max(500, min(int(body.get("max_excerpt_chars", 16000)), 60000))
         record = vault.get_file(customer_id, file_id)
@@ -80,7 +82,7 @@ def register_file_routes(
     async def internal_files_send(request: Request) -> Any:
         vault = get_file_vault()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         file_id = str(body.get("file_id", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
@@ -123,7 +125,7 @@ def register_file_routes(
     @app.post("/internal/files/send_local")
     async def internal_files_send_local(request: Request) -> Any:
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         local_path = str(body.get("path", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
@@ -185,7 +187,7 @@ def register_file_routes(
     @app.post("/internal/files/send_web_image")
     async def internal_files_send_web_image(request: Request) -> Any:
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         image_url = str(body.get("url", "")).strip()
         caption_raw = body.get("caption")
         caption = str(caption_raw).strip() if caption_raw is not None else None
@@ -240,7 +242,7 @@ def register_file_routes(
     async def internal_files_analyze(request: Request) -> Any:
         vault = get_file_vault()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         file_id = str(body.get("file_id", "")).strip()
         question_raw = body.get("question")
         question = str(question_raw).strip() if question_raw is not None else None
@@ -286,7 +288,7 @@ def register_file_routes(
     async def internal_files_inspect_structure(request: Request) -> Any:
         vault = get_file_vault()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         file_id = str(body.get("file_id", "")).strip()
         if not customer_id or not file_id:
             return JSONResponse(

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -16,12 +16,14 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.api.file_helpers import sanitize_uploaded_file_record
 from opentulpa.context.uploaded_files import (
     build_uploaded_files_context,
     should_skip_auto_summary_for_upload,
 )
 from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
+from opentulpa.web.events import append_web_event
 
 MAX_WEB_UPLOAD_BYTES = 45_000_000
 
@@ -83,8 +85,12 @@ def register_generic_chat_routes(
     get_agent_runtime: Callable[[], Any],
     get_file_vault: Callable[[], Any],
     get_workflow_setup_service: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register authenticated generic chat endpoints."""
+
+    def _resolve_customer_id(customer_id: str) -> str:
+        return resolve_customer_id_value(customer_id, resolve_customer_id)
 
     @app.post(
         "/web/chat/turns",
@@ -110,7 +116,7 @@ def register_generic_chat_routes(
                 runtime=runtime,
                 workflow_setup_service=get_workflow_setup_service(),
                 file_vault=get_file_vault(),
-                customer_id=payload.customer_id,
+                customer_id=_resolve_customer_id(payload.customer_id),
                 thread_id=payload.thread_id,
                 text=payload.text,
                 file_ids=payload.file_ids,
@@ -137,7 +143,7 @@ def register_generic_chat_routes(
             )
         if not _authorized(request, secret):
             return JSONResponse(status_code=401, content={"detail": "unauthorized"})
-        safe_customer_id = str(customer_id or "").strip()
+        safe_customer_id = _resolve_customer_id(customer_id)
         safe_thread_id = str(thread_id or "").strip()
         safe_kind = str(kind or "document").strip() or "document"
         safe_caption = str(caption or "").strip() or None
@@ -187,7 +193,7 @@ def register_generic_chat_routes(
         auth = _authorized_web_request(request, web_token)
         if auth is not None:
             return auth
-        record = get_file_vault().get_file(customer_id.strip(), file_id)
+        record = get_file_vault().get_file(_resolve_customer_id(customer_id), file_id)
         if not record:
             return JSONResponse(status_code=404, content={"detail": "file not found"})
         return {"ok": True, "file": _web_file_metadata(record)}
@@ -201,7 +207,7 @@ def register_generic_chat_routes(
         auth = _authorized_web_request(request, web_token)
         if auth is not None:
             return auth
-        safe_customer_id = customer_id.strip()
+        safe_customer_id = _resolve_customer_id(customer_id)
         vault = get_file_vault()
         record = vault.get_file(safe_customer_id, file_id)
         if not record:
@@ -263,6 +269,13 @@ async def _stream_turn(
         safe = str(message or "").strip()
         if not safe:
             return {"ok": False, "sent": False, "reason": "empty_message"}
+        append_web_event(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            source="web",
+            kind="owner_update",
+            text=safe,
+        )
         await queue.put(("owner_update", {"message": safe}))
         return {"ok": True, "sent": True}
 
@@ -273,6 +286,13 @@ async def _stream_turn(
         return {"ok": True, "sent": True}
 
     async def _run_turn() -> None:
+        append_web_event(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            source="web",
+            kind="user_message",
+            text=text,
+        )
         turn_mode = "interactive"
         if workflow_setup_service is not None and hasattr(workflow_setup_service, "thread_status"):
             status = workflow_setup_service.thread_status(
@@ -337,6 +357,14 @@ async def _stream_turn(
                     reply_text=final_text,
                 )
             await queue.put(("final", {"text": final_text}))
+            if final_text:
+                append_web_event(
+                    customer_id=customer_id,
+                    thread_id=thread_id,
+                    source="web",
+                    kind="assistant_message",
+                    text=final_text,
+                )
         except Exception as exc:
             await queue.put(("error", {"message": str(exc), "type": type(exc).__name__}))
         finally:

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -8,12 +8,15 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
 
 def register_intake_workflow_routes(
     app: FastAPI,
     *,
     get_intake_workflows: Callable[[], Any],
     get_workflow_setup_service: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal intake workflow endpoints."""
 
@@ -21,9 +24,10 @@ def register_intake_workflow_routes(
     async def internal_intake_workflows_upsert(request: Request) -> Any:
         service = get_intake_workflows()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             workflow = service.upsert_workflow(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 workflow_id=str(body.get("workflow_id", "")).strip() or None,
                 name=str(body.get("name", "")).strip(),
                 channel=str(body.get("channel", "instagram_dm")).strip() or "instagram_dm",
@@ -50,7 +54,7 @@ def register_intake_workflow_routes(
         service = get_intake_workflows()
         body = await request.json()
         workflows = service.list_workflows(
-            customer_id=str(body.get("customer_id", "")).strip(),
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
             include_disabled=bool(body.get("include_disabled", False)),
         )
         return {"ok": True, "workflows": workflows}
@@ -60,7 +64,7 @@ def register_intake_workflow_routes(
         service = get_intake_workflows()
         body = await request.json()
         workflow = service.get_workflow(
-            customer_id=str(body.get("customer_id", "")).strip(),
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
             workflow_id=str(body.get("workflow_id", "")).strip(),
         )
         if workflow is None:
@@ -72,7 +76,7 @@ def register_intake_workflow_routes(
         service = get_intake_workflows()
         body = await request.json()
         result = service.delete_workflow(
-            customer_id=str(body.get("customer_id", "")).strip(),
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
             workflow_id=str(body.get("workflow_id", "")).strip(),
         )
         if not bool(result.get("deleted", False)):
@@ -84,7 +88,7 @@ def register_intake_workflow_routes(
         service = get_intake_workflows()
         body = await request.json()
         workflow_id = str(body.get("workflow_id", "")).strip()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         if not workflow_id or not customer_id:
             return JSONResponse(
                 status_code=400,
@@ -103,9 +107,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_begin(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.begin_session(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
                 mode=str(body.get("mode", "")).strip(),
                 workflow_id=str(body.get("workflow_id", "")).strip() or None,
@@ -119,7 +124,7 @@ def register_intake_workflow_routes(
         service = get_workflow_setup_service()
         body = await request.json()
         session = service.get_thread_session(
-            customer_id=str(body.get("customer_id", "")).strip(),
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
             thread_id=str(body.get("thread_id", "")).strip(),
             include_paused=bool(body.get("include_paused", True)),
         )
@@ -131,9 +136,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_update(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.update_session(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
                 draft_patch=body.get("draft_patch") if isinstance(body.get("draft_patch"), dict) else None,
                 scratchpad_patch=body.get("scratchpad_patch") if isinstance(body.get("scratchpad_patch"), dict) else None,
@@ -146,9 +152,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_mark_proposed(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.mark_proposed(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:
@@ -159,9 +166,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_preflight(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.preflight_current(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:
@@ -172,9 +180,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_confirm_current(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.confirm_current(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:
@@ -185,9 +194,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_commit(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.commit(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:
@@ -198,9 +208,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_finalize_confirmation(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.finalize_confirmation(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
                 draft_patch=body.get("draft_patch") if isinstance(body.get("draft_patch"), dict) else None,
                 scratchpad_patch=body.get("scratchpad_patch") if isinstance(body.get("scratchpad_patch"), dict) else None,
@@ -213,9 +224,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_pause(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.pause(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:
@@ -226,9 +238,10 @@ def register_intake_workflow_routes(
     async def internal_intake_setup_cancel(request: Request) -> Any:
         service = get_workflow_setup_service()
         body = await request.json()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             session = service.cancel(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 thread_id=str(body.get("thread_id", "")).strip(),
             )
         except Exception as exc:

--- a/src/opentulpa/api/routes/knowledge.py
+++ b/src/opentulpa/api/routes/knowledge.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
 from opentulpa.business_knowledge.service import query_result_payload
 
 
@@ -15,6 +16,7 @@ def register_knowledge_routes(
     app: FastAPI,
     *,
     get_knowledge_service: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal business knowledge endpoints."""
 
@@ -24,7 +26,7 @@ def register_knowledge_routes(
         body = await request.json()
         try:
             return service.index_sources(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 scope_type=str(body.get("scope_type", "")).strip(),
                 scope_id=str(body.get("scope_id", "")).strip(),
                 file_ids=body.get("file_ids") if isinstance(body.get("file_ids"), list) else [],
@@ -38,7 +40,7 @@ def register_knowledge_routes(
         body = await request.json()
         try:
             result = service.query(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 scope_type=str(body.get("scope_type", "")).strip(),
                 scope_id=str(body.get("scope_id", "")).strip(),
                 query=str(body.get("query", "")).strip(),
@@ -57,7 +59,7 @@ def register_knowledge_routes(
         body = await request.json()
         try:
             return service.preflight_scope(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 scope_type=str(body.get("scope_type", "")).strip(),
                 scope_id=str(body.get("scope_id", "")).strip(),
                 workflow_goal=str(body.get("workflow_goal", "")).strip(),
@@ -71,7 +73,7 @@ def register_knowledge_routes(
         body = await request.json()
         try:
             return service.promote_scope(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
                 source_scope_type=str(body.get("source_scope_type", "")).strip(),
                 source_scope_id=str(body.get("source_scope_id", "")).strip(),
                 target_scope_type=str(body.get("target_scope_type", "")).strip(),

--- a/src/opentulpa/api/routes/memory.py
+++ b/src/opentulpa/api/routes/memory.py
@@ -7,11 +7,14 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
+
 
 def register_memory_routes(
     app: FastAPI,
     *,
     get_memory: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal memory add/search endpoints."""
 
@@ -20,7 +23,7 @@ def register_memory_routes(
         mem = get_memory()
         body = await request.json()
         messages = body.get("messages", [])
-        user_id = body.get("user_id") or mem.user_id
+        user_id = resolve_customer_id_value(body.get("user_id") or mem.user_id, resolve_customer_id)
         metadata = body.get("metadata") or {}
         infer = bool(body.get("infer", True))
         retries = int(body.get("retries", 1) or 1)
@@ -38,7 +41,7 @@ def register_memory_routes(
         mem = get_memory()
         body = await request.json()
         query = str(body.get("query", "") or "")
-        user_id = body.get("user_id") or mem.user_id
+        user_id = resolve_customer_id_value(body.get("user_id") or mem.user_id, resolve_customer_id)
         try:
             limit = int(body.get("limit", 5))
         except (TypeError, ValueError):

--- a/src/opentulpa/api/routes/profiles.py
+++ b/src/opentulpa/api/routes/profiles.py
@@ -15,6 +15,8 @@ from opentulpa.context.customer_profile_models import (
     CustomerScopedRequest,
     DirectiveGetResponse,
     DirectiveSetRequest,
+    ProfilesListResponse,
+    TelegramBindingRequest,
     TimeProfileGetResponse,
     TimeProfileSetRequest,
     TimeProfileSetResponse,
@@ -53,65 +55,87 @@ def register_profile_routes(
 ) -> None:
     """Register directive + timezone profile endpoints."""
 
+    @app.get("/profiles", response_model=ProfilesListResponse)
+    async def profiles_list() -> ProfilesListResponse:
+        profiles = get_profiles()
+        return ProfilesListResponse(
+            profiles=profiles.list_profiles(),
+            bindings=profiles.list_identity_bindings(),
+        )
+
+    @app.post("/profiles/bind-telegram", response_model=CustomerScopedOkResponse)
+    async def profiles_bind_telegram(body: TelegramBindingRequest) -> CustomerScopedOkResponse:
+        profiles = get_profiles()
+        binding = profiles.bind_telegram_user_id(
+            user_id=body.user_id,
+            telegram_user_id=body.telegram_user_id,
+        )
+        return CustomerScopedOkResponse(customer_id=binding.user_id)
+
     @app.post("/internal/directive/get", response_model=DirectiveGetResponse)
     async def internal_directive_get(body: CustomerScopedRequest) -> DirectiveGetResponse:
         profiles = get_profiles()
+        customer_id = profiles.resolve_customer_id(body.customer_id)
         return DirectiveGetResponse(
-            customer_id=body.customer_id,
-            directive=profiles.get_directive(body.customer_id),
+            customer_id=customer_id,
+            directive=profiles.get_directive(customer_id),
         )
 
     @app.post("/internal/directive/set", response_model=CustomerScopedOkResponse)
     async def internal_directive_set(body: DirectiveSetRequest) -> CustomerScopedOkResponse:
         profiles = get_profiles()
-        profiles.set_directive(body.customer_id, body.directive, source=body.source)
+        customer_id = profiles.resolve_customer_id(body.customer_id)
+        profiles.set_directive(customer_id, body.directive, source=body.source)
 
         # Best-effort memory signal for recall; directive DB remains source of truth.
         memory = get_memory()
         _schedule_best_effort_memory_add(
             memory,
             text=f"Directive updated for this user: {body.directive}",
-            user_id=body.customer_id,
+            user_id=customer_id,
             metadata={"kind": "directive_fact", "source": body.source},
         )
 
-        return CustomerScopedOkResponse(customer_id=body.customer_id)
+        return CustomerScopedOkResponse(customer_id=customer_id)
 
     @app.post("/internal/directive/clear", response_model=CustomerScopedClearResponse)
     async def internal_directive_clear(body: CustomerScopedRequest) -> CustomerScopedClearResponse:
         profiles = get_profiles()
-        cleared = profiles.clear_directive(body.customer_id, source="agent")
+        customer_id = profiles.resolve_customer_id(body.customer_id)
+        cleared = profiles.clear_directive(customer_id, source="agent")
 
         # Best-effort memory signal for recall; directive DB remains source of truth.
         memory = get_memory()
         _schedule_best_effort_memory_add(
             memory,
             text="Directive profile cleared for this user. Previous directive no longer applies.",
-            user_id=body.customer_id,
+            user_id=customer_id,
             metadata={"kind": "directive_fact", "source": "agent"},
         )
 
-        return CustomerScopedClearResponse(customer_id=body.customer_id, cleared=cleared)
+        return CustomerScopedClearResponse(customer_id=customer_id, cleared=cleared)
 
     @app.post("/internal/time_profile/get", response_model=TimeProfileGetResponse)
     async def internal_time_profile_get(body: CustomerScopedRequest) -> TimeProfileGetResponse:
         profiles = get_profiles()
+        customer_id = profiles.resolve_customer_id(body.customer_id)
         return TimeProfileGetResponse(
-            customer_id=body.customer_id,
-            utc_offset=profiles.get_utc_offset(body.customer_id),
+            customer_id=customer_id,
+            utc_offset=profiles.get_utc_offset(customer_id),
         )
 
     @app.post("/internal/time_profile/set", response_model=TimeProfileSetResponse)
     async def internal_time_profile_set(body: TimeProfileSetRequest) -> TimeProfileSetResponse:
         profiles = get_profiles()
-        updated = profiles.set_utc_offset(body.customer_id, body.utc_offset, source=body.source)
+        customer_id = profiles.resolve_customer_id(body.customer_id)
+        updated = profiles.set_utc_offset(customer_id, body.utc_offset, source=body.source)
         normalized = updated.utc_offset or body.utc_offset
         memory = get_memory()
         if normalized:
             _schedule_best_effort_memory_add(
                 memory,
                 text=f"User timezone is {normalized}.",
-                user_id=body.customer_id,
+                user_id=customer_id,
                 metadata={"kind": "life_fact", "source": body.source},
             )
-        return TimeProfileSetResponse(customer_id=body.customer_id, utc_offset=normalized)
+        return TimeProfileSetResponse(customer_id=customer_id, utc_offset=normalized)

--- a/src/opentulpa/api/routes/scheduler.py
+++ b/src/opentulpa/api/routes/scheduler.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.api.file_helpers import collect_routine_cleanup_paths, normalize_cleanup_paths
 from opentulpa.core.ids import new_short_id
 from opentulpa.scheduler.models import Routine
@@ -18,6 +19,7 @@ def register_scheduler_routes(
     *,
     get_scheduler: Callable[[], Any],
     delete_file: Callable[..., dict[str, Any]],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register scheduler routine management endpoints."""
 
@@ -26,6 +28,12 @@ def register_scheduler_routes(
         sched = get_scheduler()
         body = await request.json()
         payload = body.get("payload") if isinstance(body.get("payload"), dict) else {}
+        if str(payload.get("customer_id", "")).strip():
+            payload = dict(payload)
+            payload["customer_id"] = resolve_customer_id_value(
+                payload.get("customer_id", ""),
+                resolve_customer_id,
+            )
         instruction = str(payload.get("instruction", "")).strip()
         if not instruction:
             return JSONResponse(
@@ -49,12 +57,16 @@ def register_scheduler_routes(
     async def internal_scheduler_list_routines(customer_id: str | None = None) -> Any:
         sched = get_scheduler()
         routines = sched.list_routines()
-        cid = str(customer_id or "").strip()
+        cid = resolve_customer_id_value(customer_id, resolve_customer_id)
         if cid:
             routines = [
                 r
                 for r in routines
-                if str((r.payload or {}).get("customer_id", "")).strip() == cid
+                if resolve_customer_id_value(
+                    (r.payload or {}).get("customer_id", ""),
+                    resolve_customer_id,
+                )
+                == cid
             ]
         return {
             "routines": [
@@ -75,12 +87,15 @@ def register_scheduler_routes(
         customer_id: str | None = None,
     ) -> Any:
         sched = get_scheduler()
-        cid = str(customer_id or "").strip()
+        cid = resolve_customer_id_value(customer_id, resolve_customer_id)
         if cid:
             routine = sched.get_routine(routine_id)
             if routine is None:
                 return {"ok": False}
-            owner = str((routine.payload or {}).get("customer_id", "")).strip()
+            owner = resolve_customer_id_value(
+                (routine.payload or {}).get("customer_id", ""),
+                resolve_customer_id,
+            )
             if owner != cid:
                 return JSONResponse(
                     status_code=403,
@@ -93,7 +108,7 @@ def register_scheduler_routes(
     async def internal_scheduler_remove_routine_with_assets(request: Request) -> Any:
         sched = get_scheduler()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_customer_id_value(body.get("customer_id", ""), resolve_customer_id)
         if not customer_id:
             return JSONResponse(status_code=400, content={"detail": "customer_id is required"})
 
@@ -106,7 +121,11 @@ def register_scheduler_routes(
         routines = [
             r
             for r in sched.list_routines()
-            if str((r.payload or {}).get("customer_id", "")).strip() == customer_id
+            if resolve_customer_id_value(
+                (r.payload or {}).get("customer_id", ""),
+                resolve_customer_id,
+            )
+            == customer_id
         ]
         if routine_id:
             matched = [r for r in routines if r.id == routine_id]

--- a/src/opentulpa/api/routes/skills.py
+++ b/src/opentulpa/api/routes/skills.py
@@ -9,12 +9,15 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
 
 def register_skill_routes(
     app: FastAPI,
     *,
     get_skill_store: Callable[[], Any],
     get_memory: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal skill list/get/upsert/delete endpoints."""
 
@@ -22,7 +25,7 @@ def register_skill_routes(
     async def internal_skills_list(request: Request) -> Any:
         store = get_skill_store()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         include_global = bool(body.get("include_global", True))
         include_disabled = bool(body.get("include_disabled", False))
         limit = int(body.get("limit", 200))
@@ -38,7 +41,7 @@ def register_skill_routes(
     async def internal_skills_get(request: Request) -> Any:
         store = get_skill_store()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         name = str(body.get("name", "")).strip()
         include_files = bool(body.get("include_files", True))
         include_global = bool(body.get("include_global", True))
@@ -58,7 +61,7 @@ def register_skill_routes(
     async def internal_skills_upsert(request: Request) -> Any:
         store = get_skill_store()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         scope = str(body.get("scope", "user")).strip().lower()
         name = str(body.get("name", "")).strip()
         description = str(body.get("description", "")).strip()
@@ -118,7 +121,7 @@ def register_skill_routes(
     async def internal_skills_delete(request: Request) -> Any:
         store = get_skill_store()
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         scope = str(body.get("scope", "user")).strip().lower()
         name = str(body.get("name", "")).strip()
         if not name:

--- a/src/opentulpa/api/routes/tasks.py
+++ b/src/opentulpa/api/routes/tasks.py
@@ -8,18 +8,21 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
 
 def register_task_routes(
     app: FastAPI,
     *,
     get_tasks: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register task create/status/event/artifact/control endpoints."""
 
     @app.post("/internal/tasks/create")
     async def internal_task_create(request: Request) -> Any:
         body = await request.json()
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
         goal = str(body.get("goal", "")).strip()
         payload = body.get("payload") or {}
         risk_level = str(body.get("risk_level", "low")).strip() or "low"

--- a/src/opentulpa/api/routes/telegram_business.py
+++ b/src/opentulpa/api/routes/telegram_business.py
@@ -7,11 +7,14 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
 
 def register_telegram_business_routes(
     app: FastAPI,
     *,
     get_telegram_business: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register Telegram Business status routes."""
 
@@ -19,4 +22,4 @@ def register_telegram_business_routes(
     async def internal_telegram_business_status(request: Request) -> Any:
         service = get_telegram_business()
         body = await request.json()
-        return service.status(customer_id=str(body.get("customer_id", "")).strip())
+        return service.status(customer_id=resolve_body_customer_id(body, resolve_customer_id))

--- a/src/opentulpa/api/routes/user_context.py
+++ b/src/opentulpa/api/routes/user_context.py
@@ -21,6 +21,8 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
 
 def register_user_context_routes(
     app: FastAPI,
@@ -28,6 +30,7 @@ def register_user_context_routes(
     get_user_context_service: Callable[[], Any],
     get_file_vault: Callable[[], Any],
     get_agent_runtime: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal user-context endpoints."""
 
@@ -147,18 +150,19 @@ def register_user_context_routes(
         body = await request.json()
         try:
             started = time.monotonic()
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
             prep = await _prepare_user_context_files(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_ids=file_ids,
             )
             result = service.add_files(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_ids=file_ids,
             )
             _record_user_context_event(
                 "user_context.add_files",
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_count=len(file_ids),
                 source_count=_source_count(result),
                 warning_count=_warning_count(result),
@@ -175,8 +179,9 @@ def register_user_context_routes(
         service = get_user_context_service()
         body = await request.json()
         try:
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             return service.list_sources(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 include_archived=bool(body.get("include_archived", False)),
             )
         except Exception as exc:
@@ -187,8 +192,9 @@ def register_user_context_routes(
         service = get_user_context_service()
         body = await request.json()
         try:
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             return service.find_sources(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 query=str(body.get("query", "")).strip(),
                 limit=int(body.get("limit", 10) or 10),
             )
@@ -201,14 +207,15 @@ def register_user_context_routes(
         body = await request.json()
         try:
             started = time.monotonic()
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             result = service.query(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 query=str(body.get("query", "")).strip(),
                 max_extract_chars=int(body.get("max_extract_chars", 3000) or 3000),
             )
             _record_user_context_event(
                 "user_context.query",
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 ok=bool(result.get("ok")) if isinstance(result, dict) else False,
                 source_count=int(result.get("source_count") or 0) if isinstance(result, dict) else 0,
                 section_count=int(result.get("section_count") or 0) if isinstance(result, dict) else 0,
@@ -225,20 +232,21 @@ def register_user_context_routes(
         body = await request.json()
         try:
             started = time.monotonic()
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else None
             prep = {"prepared_count": 0, "failed_count": 0}
             if file_ids:
                 prep = await _prepare_user_context_files(
-                    customer_id=str(body.get("customer_id", "")).strip(),
+                    customer_id=customer_id,
                     file_ids=file_ids,
                 )
             result = service.reindex(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_ids=file_ids,
             )
             _record_user_context_event(
                 "user_context.reindex",
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_count=len(file_ids or []),
                 source_count=_source_count(result),
                 warning_count=_warning_count(result),
@@ -256,14 +264,15 @@ def register_user_context_routes(
         body = await request.json()
         try:
             started = time.monotonic()
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
             result = service.archive_sources(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_ids=file_ids,
             )
             _record_user_context_event(
                 "user_context.archive_sources",
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 file_count=len(file_ids),
                 elapsed_ms=int((time.monotonic() - started) * 1000),
             )
@@ -277,15 +286,16 @@ def register_user_context_routes(
         body = await request.json()
         try:
             started = time.monotonic()
+            customer_id = resolve_body_customer_id(body, resolve_customer_id)
             file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
             result = service.promote_to_intake(
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 workflow_id=str(body.get("workflow_id", "")).strip(),
                 file_ids=file_ids,
             )
             _record_user_context_event(
                 "user_context.promote_to_intake",
-                customer_id=str(body.get("customer_id", "")).strip(),
+                customer_id=customer_id,
                 workflow_id=str(body.get("workflow_id", "")).strip(),
                 file_count=len(file_ids),
                 source_count=_source_count(result),

--- a/src/opentulpa/api/routes/wake_search.py
+++ b/src/opentulpa/api/routes/wake_search.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.integrations.web_search import web_search as run_web_search
 
 
@@ -16,6 +17,7 @@ def register_wake_and_search_routes(
     *,
     get_wake_queue: Callable[[], Any],
     llm_model: str | None,
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register wake queue APIs and OpenRouter-backed web search endpoint."""
     _ = llm_model
@@ -28,6 +30,12 @@ def register_wake_and_search_routes(
             return JSONResponse(
                 status_code=400,
                 content={"detail": "wake payload must be JSON object"},
+            )
+        if str(body.get("customer_id", "")).strip():
+            body = dict(body)
+            body["customer_id"] = resolve_customer_id_value(
+                body.get("customer_id", ""),
+                resolve_customer_id,
             )
         queue_id = await get_wake_queue().enqueue(body)
         return {"ok": True, "queued": True, "queue_id": queue_id}

--- a/src/opentulpa/api/routes/web_events.py
+++ b/src/opentulpa/api/routes/web_events.py
@@ -10,12 +10,15 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
+
 
 def register_web_event_routes(
     app: FastAPI,
     *,
     settings: Any,
     get_web_events: Callable[[], Any],
+    resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register dashboard-facing event feed routes."""
 
@@ -35,7 +38,10 @@ def register_web_event_routes(
 
         after_id = _int_query(request, "after_id", default=0)
         limit = _int_query(request, "limit", default=100)
-        customer_id = str(request.query_params.get("customer_id", "") or "").strip() or None
+        customer_id = (
+            resolve_customer_id_value(request.query_params.get("customer_id", ""), resolve_customer_id)
+            or None
+        )
         events = get_web_events().list_events(
             after_id=after_id,
             limit=limit,

--- a/src/opentulpa/application/wake_orchestrator.py
+++ b/src/opentulpa/application/wake_orchestrator.py
@@ -24,6 +24,7 @@ class WakeOrchestrator:
         get_telegram_client: Callable[[], Any],
         get_agent_runtime: Callable[[], Any],
         get_intake_workflows: Callable[[], Any] | None = None,
+        resolve_customer_id: Callable[[str], str] | None = None,
     ) -> None:
         self._settings = settings
         self._get_context_events = get_context_events
@@ -31,6 +32,18 @@ class WakeOrchestrator:
         self._get_telegram_client = get_telegram_client
         self._get_agent_runtime = get_agent_runtime
         self._get_intake_workflows = get_intake_workflows
+        self._resolve_customer_id = resolve_customer_id
+
+    def _customer_id(self, value: Any) -> str:
+        cid = str(value or "").strip()
+        if not cid or self._resolve_customer_id is None:
+            return cid
+        resolved = str(self._resolve_customer_id(cid) or "").strip()
+        return resolved or cid
+
+    @staticmethod
+    def _payload(value: Any) -> dict[str, Any]:
+        return dict(value) if isinstance(value, dict) else {}
 
     def _backlog(self, *, customer_id: str, source: str, event_type: str, payload: dict[str, Any]) -> None:
         self._get_context_events().add_event(
@@ -112,9 +125,9 @@ class WakeOrchestrator:
         await self._handle_routine_event(body)
 
     async def _handle_task_event(self, body: dict[str, Any]) -> None:
-        customer_id = str(body.get("customer_id", "")).strip()
+        customer_id = self._customer_id(body.get("customer_id", ""))
         event_type = str(body.get("event_type", "")).strip()
-        payload = body.get("payload") if isinstance(body.get("payload"), dict) else {}
+        payload = self._payload(body.get("payload"))
         if not customer_id or event_type not in {"done", "failed", "needs_input", "worker_stopped"}:
             return
 
@@ -189,8 +202,8 @@ class WakeOrchestrator:
                 )
 
     async def _handle_routine_event(self, body: dict[str, Any]) -> None:
-        payload = body.get("payload") if isinstance(body.get("payload"), dict) else {}
-        customer_id = str(body.get("customer_id") or payload.get("customer_id") or "").strip()
+        payload = self._payload(body.get("payload"))
+        customer_id = self._customer_id(body.get("customer_id") or payload.get("customer_id") or "")
         if not customer_id:
             return
         event_type = str(body.get("event_type") or payload.get("event_type") or "scheduled").strip()
@@ -270,12 +283,12 @@ class WakeOrchestrator:
                     ),
                 )
                 return
-            slots: list[dict[str, Any]] = []
+            delivery_slots: list[dict[str, Any]] = []
             with suppress(Exception):
-                slots = self._get_telegram_chat().find_session_slots(customer_id)
-            owner_slots = [slot for slot in slots if str(slot.get("role", "")).strip() != "support"]
-            slots = owner_slots or slots[:1]
-            if not slots:
+                delivery_slots = self._get_telegram_chat().find_session_slots(customer_id)
+            owner_slots = [slot for slot in delivery_slots if str(slot.get("role", "")).strip() != "support"]
+            delivery_slots = owner_slots or delivery_slots[:1]
+            if not delivery_slots:
                 self._record_routine_execution(
                     customer_id=customer_id,
                     event_type=event_type,
@@ -284,8 +297,8 @@ class WakeOrchestrator:
                     notification_error="no_telegram_session_slots",
                 )
                 return
-            notified_chat_ids: list[int] = []
-            for slot in slots:
+            notified_owner_chat_ids: list[int] = []
+            for slot in delivery_slots:
                 chat_id = int(slot["chat_id"])
                 await self._get_telegram_client().send_message(
                     chat_id=chat_id,
@@ -294,13 +307,13 @@ class WakeOrchestrator:
                 )
                 with suppress(Exception):
                     self._get_telegram_chat().touch_assistant_message(chat_id)
-                notified_chat_ids.append(chat_id)
+                notified_owner_chat_ids.append(chat_id)
             self._record_routine_execution(
                 customer_id=customer_id,
                 event_type=event_type,
                 payload=queue_payload,
                 notification_status="sent",
-                notified_chat_ids=notified_chat_ids,
+                notified_chat_ids=notified_owner_chat_ids,
             )
             return
 
@@ -378,10 +391,10 @@ class WakeOrchestrator:
             )
             return
 
-        slots: list[dict[str, Any]] = []
+        routine_slots: list[dict[str, Any]] = []
         with suppress(Exception):
-            slots = self._get_telegram_chat().find_session_slots(customer_id)
-        if not slots:
+            routine_slots = self._get_telegram_chat().find_session_slots(customer_id)
+        if not routine_slots:
             self._record_routine_execution(
                 customer_id=customer_id,
                 event_type=event_type,
@@ -391,8 +404,8 @@ class WakeOrchestrator:
             )
             return
 
-        notified_chat_ids: list[int] = []
-        for slot in slots:
+        notified_routine_chat_ids: list[int] = []
+        for slot in routine_slots:
             chat_id = int(slot["chat_id"])
             await self._get_telegram_client().send_message(
                 chat_id=chat_id,
@@ -401,13 +414,13 @@ class WakeOrchestrator:
             )
             with suppress(Exception):
                 self._get_telegram_chat().touch_assistant_message(chat_id)
-            notified_chat_ids.append(chat_id)
+            notified_routine_chat_ids.append(chat_id)
         self._record_routine_execution(
             customer_id=customer_id,
             event_type=event_type,
             payload=queue_payload,
             notification_status="sent",
-            notified_chat_ids=notified_chat_ids,
+            notified_chat_ids=notified_routine_chat_ids,
         )
 
 

--- a/src/opentulpa/context/customer_profile_models.py
+++ b/src/opentulpa/context/customer_profile_models.py
@@ -25,6 +25,11 @@ class TimeProfileSetRequest(CustomerScopedMutationRequest):
     utc_offset: str = Field(pattern=r"^[+-]\d{2}:\d{2}$")
 
 
+class TelegramBindingRequest(_ProfileModel):
+    user_id: str = Field(min_length=1)
+    telegram_user_id: str = Field(min_length=1)
+
+
 class CustomerProfileRecord(_ProfileModel):
     customer_id: str
     directive_text: str | None = None
@@ -53,6 +58,28 @@ class CustomerScopedClearResponse(CustomerScopedOkResponse):
 
 class TimeProfileSetResponse(CustomerScopedOkResponse):
     utc_offset: str
+
+
+class IdentityBindingRecord(_ProfileModel):
+    user_id: str
+    alias_user_id: str
+    storage_user_id: str
+    alias_kind: str
+    provider: str | None = None
+    provider_user_id: str | None = None
+    updated_at: str
+
+
+class ProfileIdentityRecord(_ProfileModel):
+    user_id: str
+    storage_user_id: str
+    telegram_user_id: str | None = None
+    aliases: list[str] = Field(default_factory=list)
+
+
+class ProfilesListResponse(_ProfileModel):
+    profiles: list[ProfileIdentityRecord] = Field(default_factory=list)
+    bindings: list[IdentityBindingRecord] = Field(default_factory=list)
 
 
 class LegacyProfileImportSummary(_ProfileModel):

--- a/src/opentulpa/context/customer_profiles.py
+++ b/src/opentulpa/context/customer_profiles.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import re
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 
 from opentulpa.context.customer_profile_models import (
     CustomerProfileRecord,
+    IdentityBindingRecord,
     LegacyProfileImportSummary,
+    ProfileIdentityRecord,
 )
+from opentulpa.persistence.sqlite import connect_sqlite
 
 
 def _normalize_utc_offset(value: str) -> str:
@@ -55,6 +56,21 @@ class CustomerProfileService:
                     source TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
+                CREATE TABLE IF NOT EXISTS customer_identity_aliases (
+                    alias_user_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    storage_user_id TEXT NOT NULL,
+                    alias_kind TEXT NOT NULL,
+                    provider TEXT,
+                    provider_user_id TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_identity_aliases_provider
+                    ON customer_identity_aliases(provider, provider_user_id)
+                    WHERE provider IS NOT NULL AND provider_user_id IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS idx_customer_identity_aliases_storage
+                    ON customer_identity_aliases(storage_user_id);
                 """
             )
 
@@ -69,6 +85,236 @@ class CustomerProfileService:
         text = str(value).strip()
         return text or None
 
+    @staticmethod
+    def _telegram_alias(telegram_user_id: str | int) -> str:
+        tid = str(telegram_user_id or "").strip()
+        if not tid:
+            raise ValueError("telegram_user_id is required")
+        return f"telegram_{tid}"
+
+    def resolve_customer_id(self, customer_id: str) -> str:
+        cid = str(customer_id or "").strip()
+        if not cid:
+            return ""
+        with self._conn() as conn:
+            row = conn.execute(
+                """
+                SELECT storage_user_id
+                FROM customer_identity_aliases
+                WHERE alias_user_id=?
+                """,
+                (cid,),
+            ).fetchone()
+        return str(row["storage_user_id"]) if row else cid
+
+    def resolve_telegram_customer_id(self, telegram_user_id: str | int) -> str:
+        return self.resolve_customer_id(self._telegram_alias(telegram_user_id))
+
+    def alias_user_ids(self, customer_id: str) -> list[str]:
+        cid = str(customer_id or "").strip()
+        if not cid:
+            return []
+        storage_user_id = self.resolve_customer_id(cid)
+        with self._conn() as conn:
+            rows = conn.execute(
+                """
+                SELECT alias_user_id
+                FROM customer_identity_aliases
+                WHERE storage_user_id=?
+                ORDER BY alias_kind, alias_user_id
+                """,
+                (storage_user_id,),
+            ).fetchall()
+        aliases = [str(row["alias_user_id"]) for row in rows]
+        if cid not in aliases:
+            aliases.insert(0, cid)
+        if storage_user_id and storage_user_id not in aliases:
+            aliases.append(storage_user_id)
+        return aliases
+
+    def _profile_exists(self, conn: sqlite3.Connection, customer_id: str) -> bool:
+        row = conn.execute(
+            "SELECT 1 FROM customer_profiles WHERE customer_id=?",
+            (customer_id,),
+        ).fetchone()
+        return row is not None
+
+    def _select_identity_storage(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        user_id: str,
+        telegram_alias: str,
+    ) -> str:
+        assert user_id
+        assert telegram_alias
+        uid_row = conn.execute(
+            "SELECT storage_user_id FROM customer_identity_aliases WHERE alias_user_id=?",
+            (user_id,),
+        ).fetchone()
+        telegram_row = conn.execute(
+            "SELECT storage_user_id FROM customer_identity_aliases WHERE alias_user_id=?",
+            (telegram_alias,),
+        ).fetchone()
+        uid_storage = str(uid_row["storage_user_id"]) if uid_row else ""
+        telegram_storage = str(telegram_row["storage_user_id"]) if telegram_row else ""
+        if uid_storage and telegram_storage and uid_storage != telegram_storage:
+            raise ValueError("identity aliases already point at different storage_user_id values")
+        if uid_storage:
+            return uid_storage
+        if telegram_storage:
+            return telegram_storage
+        if self._profile_exists(conn, user_id) and self._profile_exists(conn, telegram_alias):
+            raise ValueError("generic and telegram profiles both exist; manual merge is required")
+        if self._profile_exists(conn, user_id):
+            return user_id
+        if self._profile_exists(conn, telegram_alias):
+            return telegram_alias
+        return user_id
+
+    def _upsert_identity_alias(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        alias_user_id: str,
+        user_id: str,
+        storage_user_id: str,
+        alias_kind: str,
+        provider: str | None,
+        provider_user_id: str | None,
+        now: str,
+    ) -> None:
+        assert alias_user_id
+        assert storage_user_id
+        conn.execute(
+            """
+            INSERT INTO customer_identity_aliases (
+                alias_user_id, user_id, storage_user_id, alias_kind,
+                provider, provider_user_id, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(alias_user_id)
+            DO UPDATE SET
+                user_id=excluded.user_id,
+                storage_user_id=excluded.storage_user_id,
+                alias_kind=excluded.alias_kind,
+                provider=excluded.provider,
+                provider_user_id=excluded.provider_user_id,
+                updated_at=excluded.updated_at
+            """,
+            (
+                alias_user_id,
+                user_id,
+                storage_user_id,
+                alias_kind,
+                provider,
+                provider_user_id,
+                now,
+                now,
+            ),
+        )
+
+    def bind_telegram_user_id(self, *, user_id: str, telegram_user_id: str | int) -> IdentityBindingRecord:
+        uid = str(user_id or "").strip()
+        telegram_id = str(telegram_user_id or "").strip()
+        if not uid:
+            raise ValueError("user_id is required")
+        telegram_alias = self._telegram_alias(telegram_id)
+        if uid == telegram_alias:
+            raise ValueError("user_id must be generic, not telegram-derived")
+
+        now = self._utc_now_iso()
+        with self._conn() as conn:
+            storage_user_id = self._select_identity_storage(
+                conn,
+                user_id=uid,
+                telegram_alias=telegram_alias,
+            )
+            assert uid
+            assert telegram_alias
+            for alias_user_id, alias_kind, provider, provider_user_id in (
+                (uid, "generic", None, None),
+                (telegram_alias, "telegram", "telegram", telegram_id),
+            ):
+                self._upsert_identity_alias(
+                    conn,
+                    alias_user_id=alias_user_id,
+                    user_id=uid,
+                    storage_user_id=storage_user_id,
+                    alias_kind=alias_kind,
+                    provider=provider,
+                    provider_user_id=provider_user_id,
+                    now=now,
+                )
+            conn.commit()
+        return IdentityBindingRecord(
+            user_id=uid,
+            alias_user_id=telegram_alias,
+            storage_user_id=storage_user_id,
+            alias_kind="telegram",
+            provider="telegram",
+            provider_user_id=telegram_id,
+            updated_at=now,
+        )
+
+    def list_identity_bindings(self) -> list[IdentityBindingRecord]:
+        with self._conn() as conn:
+            rows = conn.execute(
+                """
+                SELECT alias_user_id, user_id, storage_user_id, alias_kind,
+                       provider, provider_user_id, updated_at
+                FROM customer_identity_aliases
+                ORDER BY user_id, alias_kind, alias_user_id
+                """
+            ).fetchall()
+        return [
+            IdentityBindingRecord(
+                user_id=str(row["user_id"]),
+                alias_user_id=str(row["alias_user_id"]),
+                storage_user_id=str(row["storage_user_id"]),
+                alias_kind=str(row["alias_kind"]),
+                provider=self._optional_text(row["provider"]),
+                provider_user_id=self._optional_text(row["provider_user_id"]),
+                updated_at=str(row["updated_at"]),
+            )
+            for row in rows
+        ]
+
+    def list_profiles(self) -> list[ProfileIdentityRecord]:
+        bindings = self.list_identity_bindings()
+        by_user: dict[str, ProfileIdentityRecord] = {}
+        for binding in bindings:
+            item = by_user.setdefault(
+                binding.user_id,
+                ProfileIdentityRecord(
+                    user_id=binding.user_id,
+                    storage_user_id=binding.storage_user_id,
+                    aliases=[],
+                ),
+            )
+            item.aliases.append(binding.alias_user_id)
+            if binding.provider == "telegram":
+                item.telegram_user_id = binding.provider_user_id
+
+        known = set(by_user)
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT customer_id FROM customer_profiles ORDER BY customer_id"
+            ).fetchall()
+        for row in rows:
+            cid = str(row["customer_id"])
+            storage = self.resolve_customer_id(cid)
+            if cid in known or any(cid in item.aliases for item in by_user.values()):
+                continue
+            by_user[cid] = ProfileIdentityRecord(
+                user_id=cid,
+                storage_user_id=storage,
+                telegram_user_id=cid.removeprefix("telegram_") if cid.startswith("telegram_") else None,
+                aliases=[cid],
+            )
+
+        return sorted(by_user.values(), key=lambda item: item.user_id)
+
     def _upsert(
         self,
         customer_id: str,
@@ -78,7 +324,7 @@ class CustomerProfileService:
         locale: str | None = None,
         source: str = "agent",
     ) -> CustomerProfileRecord:
-        cid = str(customer_id or "").strip()
+        cid = self.resolve_customer_id(customer_id)
         if not cid:
             raise ValueError("customer_id is required")
         updated_at = self._utc_now_iso()
@@ -132,7 +378,7 @@ class CustomerProfileService:
         )
 
     def get_profile(self, customer_id: str) -> CustomerProfileRecord | None:
-        cid = str(customer_id or "").strip()
+        cid = self.resolve_customer_id(customer_id)
         if not cid:
             return None
         with self._conn() as conn:

--- a/src/opentulpa/context/customer_profiles.py
+++ b/src/opentulpa/context/customer_profiles.py
@@ -158,17 +158,23 @@ class CustomerProfileService:
         ).fetchone()
         uid_storage = str(uid_row["storage_user_id"]) if uid_row else ""
         telegram_storage = str(telegram_row["storage_user_id"]) if telegram_row else ""
+        uid_has_profile = self._profile_exists(conn, user_id)
+        telegram_has_profile = self._profile_exists(conn, telegram_alias)
         if uid_storage and telegram_storage and uid_storage != telegram_storage:
             raise ValueError("identity aliases already point at different storage_user_id values")
         if uid_storage:
+            if telegram_has_profile and telegram_alias != uid_storage:
+                raise ValueError("generic and telegram profiles both exist; manual merge is required")
             return uid_storage
         if telegram_storage:
+            if uid_has_profile and user_id != telegram_storage:
+                raise ValueError("generic and telegram profiles both exist; manual merge is required")
             return telegram_storage
-        if self._profile_exists(conn, user_id) and self._profile_exists(conn, telegram_alias):
+        if uid_has_profile and telegram_has_profile:
             raise ValueError("generic and telegram profiles both exist; manual merge is required")
-        if self._profile_exists(conn, user_id):
+        if uid_has_profile:
             return user_id
-        if self._profile_exists(conn, telegram_alias):
+        if telegram_has_profile:
             return telegram_alias
         return user_id
 

--- a/src/opentulpa/interfaces/telegram/business.py
+++ b/src/opentulpa/interfaces/telegram/business.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Callable
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -45,9 +46,16 @@ def _message_text(message: dict[str, Any]) -> str:
 class TelegramBusinessService:
     """Persist Telegram Business connections and normalized message state."""
 
-    def __init__(self, *, db_path: Path, owner_customer_id: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        owner_customer_id: str | None = None,
+        resolve_customer_id: Callable[[str], str] | None = None,
+    ) -> None:
         self._db_path = db_path.resolve()
         self._owner_customer_id = str(owner_customer_id or "").strip()
+        self._resolve_customer_id_callback = resolve_customer_id
         self.client: Any | None = None
         self._init_db()
         self._bind_existing_connections_to_owner()
@@ -97,12 +105,49 @@ class TelegramBusinessService:
 
     def _customer_id_from_connection(self, connection: dict[str, Any]) -> str:
         if self._owner_customer_id:
-            return self._owner_customer_id
+            return self._resolve_customer_id(self._owner_customer_id)
         user = _safe_dict(connection.get("user"))
         user_id = str(user.get("id", "") or "").strip()
         if not user_id:
             return ""
-        return f"telegram_{user_id}"
+        return self._resolve_customer_id(f"telegram_{user_id}")
+
+    def _resolve_customer_id(self, customer_id: str) -> str:
+        safe_customer = str(customer_id or "").strip()
+        if not safe_customer or self._resolve_customer_id_callback is None:
+            return safe_customer
+        resolved = str(self._resolve_customer_id_callback(safe_customer) or "").strip()
+        return resolved or safe_customer
+
+    def _rebind_connection_customer_id(
+        self,
+        *,
+        business_connection_id: str,
+        customer_id: str,
+    ) -> None:
+        safe_business_connection_id = str(business_connection_id or "").strip()
+        safe_customer = str(customer_id or "").strip()
+        if not safe_business_connection_id or not safe_customer:
+            return
+        now = _utc_now_iso()
+        with self._conn() as conn:
+            conn.execute(
+                """
+                UPDATE telegram_business_connections
+                SET customer_id = ?, updated_at = ?
+                WHERE business_connection_id = ?
+                """,
+                (safe_customer, now, safe_business_connection_id),
+            )
+            conn.execute(
+                """
+                UPDATE telegram_business_messages
+                SET customer_id = ?, updated_at = ?
+                WHERE business_connection_id = ?
+                """,
+                (safe_customer, now, safe_business_connection_id),
+            )
+            conn.commit()
 
     def _bind_existing_connections_to_owner(self) -> None:
         if not self._owner_customer_id:
@@ -530,16 +575,22 @@ class TelegramBusinessService:
                     "user_chat_id": "",
                     "trigger_workflows": False,
                 }
+            customer_id = self._resolve_customer_id(str(connection_record.get("customer_id", "") or ""))
+            if customer_id and customer_id != str(connection_record.get("customer_id", "") or ""):
+                self._rebind_connection_customer_id(
+                    business_connection_id=business_connection_id,
+                    customer_id=customer_id,
+                )
             record = self.upsert_message(
                 business_connection_id=business_connection_id,
-                customer_id=str(connection_record.get("customer_id", "") or ""),
+                customer_id=customer_id,
                 message=message,
             )
             return {
                 "handled": True,
                 "kind": key,
                 "business_connection_id": business_connection_id,
-                "customer_id": str(connection_record.get("customer_id", "") or ""),
+                "customer_id": customer_id,
                 "user_chat_id": str(connection_record.get("user_chat_id", "") or ""),
                 "chat_id": str(record.get("chat_id", "") or ""),
                 "message_id": str(record.get("message_id", "") or ""),

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -110,6 +110,8 @@ def _reset_chat_session_context(
     chat_id: int,
     user_id: int,
     username: str | None = None,
+    resolve_customer_id: Callable[[str], str] | None = None,
+    resolve_telegram_customer_id: Callable[[int], str] | None = None,
 ) -> tuple[str, str]:
     sessions = state.get("sessions")
     if not isinstance(sessions, dict):
@@ -118,7 +120,17 @@ def _reset_chat_session_context(
     slot = sessions.get(chat_key)
     if not isinstance(slot, dict):
         slot = {}
-    customer_id = str(slot.get("customer_id", "")).strip() or f"telegram_{user_id}"
+    existing_customer_id = str(slot.get("customer_id", "")).strip()
+    if existing_customer_id and resolve_customer_id is not None:
+        customer_id = str(resolve_customer_id(existing_customer_id) or "").strip()
+    elif existing_customer_id:
+        customer_id = existing_customer_id
+    elif resolve_telegram_customer_id is not None:
+        customer_id = str(resolve_telegram_customer_id(user_id) or "").strip()
+    else:
+        customer_id = f"telegram_{user_id}"
+    if not customer_id:
+        customer_id = f"telegram_{user_id}"
     now_utc_iso = datetime.now(UTC).isoformat()
     thread_id = new_short_id("chat")
     wake_thread_id = new_short_id("wake")
@@ -1098,6 +1110,8 @@ async def handle_telegram_text(
     support_customer_listing: Callable[[], list[dict[str, Any]]] | None = None,
     workflow_setup_status: Callable[..., dict[str, Any]] | None = None,
     workflow_setup_after_reply: Callable[..., dict[str, Any]] | None = None,
+    resolve_customer_id: Callable[[str], str] | None = None,
+    resolve_telegram_customer_id: Callable[[int], str] | None = None,
 ) -> str | None:
     parsed = parse_telegram_update(body)
     if not parsed:
@@ -1192,6 +1206,8 @@ async def handle_telegram_text(
                 chat_id=ctx.chat_id,
                 user_id=ctx.user_id,
                 username=ctx.username,
+                resolve_customer_id=resolve_customer_id,
+                resolve_telegram_customer_id=resolve_telegram_customer_id,
             )
         )
         if interactive_inbox is not None:
@@ -1235,7 +1251,17 @@ async def handle_telegram_text(
             slot = {}
         thread_id = _clean_thread_id(slot.get("thread_id")) or f"chat-{ctx.chat_id}"
         wake_thread_id = _clean_thread_id(slot.get("wake_thread_id")) or None
-        customer_id = str(slot.get("customer_id", "")).strip() or f"telegram_{ctx.user_id}"
+        existing_customer_id = str(slot.get("customer_id", "")).strip()
+        if existing_customer_id and resolve_customer_id is not None:
+            customer_id = str(resolve_customer_id(existing_customer_id) or "").strip()
+        elif existing_customer_id:
+            customer_id = existing_customer_id
+        elif resolve_telegram_customer_id is not None:
+            customer_id = str(resolve_telegram_customer_id(ctx.user_id) or "").strip()
+        else:
+            customer_id = f"telegram_{ctx.user_id}"
+        if not customer_id:
+            customer_id = f"telegram_{ctx.user_id}"
         now_utc_iso = datetime.now(UTC).isoformat()
         sessions[str(ctx.chat_id)] = {
             "user_id": ctx.user_id,
@@ -1438,7 +1464,7 @@ async def handle_telegram_text(
                 thread_id=thread_id,
                 reply_text=str(response or ""),
             )
-        return response
+        return str(response) if response is not None else None
     except Exception as exc:
         logger.exception(
             "Telegram non-streaming reply failed (chat_id=%s, thread_id=%s): %s",
@@ -1461,6 +1487,9 @@ class TelegramChatService:
         support_customer_listing: Callable[[], list[dict[str, Any]]] | None = None,
         workflow_setup_status: Callable[..., dict[str, Any]] | None = None,
         workflow_setup_after_reply: Callable[..., dict[str, Any]] | None = None,
+        resolve_customer_id: Callable[[str], str] | None = None,
+        resolve_telegram_customer_id: Callable[[int], str] | None = None,
+        alias_user_ids: Callable[[str], list[str]] | None = None,
     ) -> None:
         self.bot_token = str(bot_token or "").strip()
         self.file_vault = file_vault
@@ -1468,10 +1497,27 @@ class TelegramChatService:
         self.support_customer_listing = support_customer_listing
         self.workflow_setup_status = workflow_setup_status
         self.workflow_setup_after_reply = workflow_setup_after_reply
+        self.resolve_customer_id = resolve_customer_id
+        self.resolve_telegram_customer_id = resolve_telegram_customer_id
+        self.alias_user_ids = alias_user_ids
         self._interactive_inbox = TelegramInteractiveInbox()
 
     def find_session_slots(self, customer_id: str) -> list[dict[str, Any]]:
-        return find_session_slots_for_customer_id(customer_id)
+        aliases = (
+            self.alias_user_ids(customer_id)
+            if self.alias_user_ids is not None
+            else [customer_id]
+        )
+        slots: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for alias in aliases:
+            for slot in find_session_slots_for_customer_id(alias):
+                key = str(slot.get("chat_id", ""))
+                if key in seen:
+                    continue
+                seen.add(key)
+                slots.append(slot)
+        return slots
 
     def get_session_slot(self, chat_id: int) -> dict[str, Any] | None:
         return get_session_slot_for_chat_id(chat_id)
@@ -1491,11 +1537,13 @@ class TelegramChatService:
         payload: dict[str, Any],
         agent_runtime: Any | None = None,
     ) -> list[dict[str, Any]]:
-        return await relay_task_event_via_main_agent(
+        return await _relay_task_event_via_main_agent(
             customer_id=customer_id,
             task_id=task_id,
             event_type=event_type,
             payload=payload,
+            state_store=STATE_STORE,
+            find_session_slots=self.find_session_slots,
             agent_runtime=agent_runtime,
         )
 
@@ -1507,10 +1555,12 @@ class TelegramChatService:
         payload: dict[str, Any],
         agent_runtime: Any | None = None,
     ) -> list[dict[str, Any]]:
-        return await relay_event_via_main_agent(
+        return await _relay_event_via_main_agent(
             customer_id=customer_id,
             event_label=event_label,
             payload=payload,
+            state_store=STATE_STORE,
+            find_session_slots=self.find_session_slots,
             agent_runtime=agent_runtime,
         )
 
@@ -1538,4 +1588,6 @@ class TelegramChatService:
             support_customer_listing=self.support_customer_listing,
             workflow_setup_status=self.workflow_setup_status,
             workflow_setup_after_reply=self.workflow_setup_after_reply,
+            resolve_customer_id=self.resolve_customer_id,
+            resolve_telegram_customer_id=self.resolve_telegram_customer_id,
         )

--- a/tests/e2e/scenarios/test_telegram_intake_debounce.py
+++ b/tests/e2e/scenarios/test_telegram_intake_debounce.py
@@ -13,6 +13,7 @@ from harness.runner import E2EHarness
 from mocks.telegram import FakeTelegramClient
 
 from opentulpa.api.app import create_app
+from opentulpa.context.customer_profiles import CustomerProfileService
 from opentulpa.core.config import get_settings
 from opentulpa.intake import service as intake_service_module
 from opentulpa.scheduler.service import SchedulerService
@@ -260,6 +261,7 @@ def _create_fake_telegram_app(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     runtime: Any,
+    customer_profiles: CustomerProfileService | None = None,
 ) -> tuple[Any, FakeTelegramClient]:
     from opentulpa.api import app as app_module
     from opentulpa.tasks import sandbox as sandbox_module
@@ -280,7 +282,11 @@ def _create_fake_telegram_app(
     get_settings.cache_clear()
 
     scheduler = SchedulerService(db_path=tmp_path / "scheduler.sqlite")
-    app = create_app(agent_runtime=runtime, scheduler=scheduler)
+    app = create_app(
+        agent_runtime=runtime,
+        scheduler=scheduler,
+        customer_profile_service=customer_profiles,
+    )
     return app, fake_telegram
 
 
@@ -604,6 +610,119 @@ def test_telegram_business_intake_worker_does_not_block_unrelated_leads(
         f"Reply for {second['lead_chat_id']}",
     }
     assert runtime.max_active >= 2
+
+
+def test_telegram_business_intake_uses_generic_user_id_after_late_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _ParallelRuntime()
+    profiles = CustomerProfileService(tmp_path / "profiles.sqlite")
+    app, fake_telegram = _create_fake_telegram_app(
+        tmp_path,
+        monkeypatch,
+        runtime,
+        customer_profiles=profiles,
+    )
+    generic_user_id = "usr_default"
+    owner_user_id = 631
+    owner_chat_id = 6631
+    lead_chat_id = 783
+    lead_user_id = 893
+    business_connection_id = "bc_e2e_generic_late_bind"
+
+    with TestClient(app) as client:
+        connection = app.state.telegram_business.upsert_connection(
+            {
+                "id": business_connection_id,
+                "user_chat_id": owner_chat_id,
+                "is_enabled": True,
+                "user": {
+                    "id": owner_user_id,
+                    "is_bot": False,
+                    "first_name": "Generic Owner",
+                },
+                "rights": {"can_reply": True},
+            }
+        )
+        assert connection["customer_id"] == f"telegram_{owner_user_id}"
+
+        create = client.post(
+            "/internal/intake/workflows/upsert",
+            json={
+                "customer_id": generic_user_id,
+                "name": "Generic Telegram Intake",
+                "channel": "telegram_business_dm",
+                "provider": "telegram_bot_api",
+                "source_config": {"business_connection_id": business_connection_id},
+                "intent_description": "Handle Telegram Business intake requests for generic owner.",
+                "required_fields": ["time"],
+                "assistant_instructions": "Reply to the lead from generic owner storage.",
+                "sink_type": "local_csv",
+                "sink_config": {"file_path": "tulpa_stuff/generic_late_bind.csv"},
+            },
+        )
+        assert create.status_code == 200, create.text
+        workflow = create.json()["workflow"]
+        assert workflow["customer_id"] == generic_user_id
+
+        bind = client.post(
+            "/profiles/bind-telegram",
+            json={"user_id": generic_user_id, "telegram_user_id": str(owner_user_id)},
+        )
+        assert bind.status_code == 200, bind.text
+        assert profiles.resolve_customer_id(f"telegram_{owner_user_id}") == generic_user_id
+
+        message_status = client.post(
+            "/webhook/telegram",
+            headers={"x-telegram-bot-api-secret-token": "test-secret"},
+            json=_business_message(
+                business_connection_id=business_connection_id,
+                lead_chat_id=lead_chat_id,
+                lead_user_id=lead_user_id,
+                message_id=50,
+                text="Need detailing today",
+            ),
+        )
+        assert message_status.status_code == 200
+
+        assert _wait_until(
+            lambda: len(
+                [
+                    item
+                    for item in fake_telegram.sent_messages
+                    if str(item.get("business_connection_id", "")).strip() == business_connection_id
+                    and int(item.get("chat_id", 0)) == lead_chat_id
+                ]
+            )
+            == 1,
+            timeout_seconds=5.0,
+        )
+
+    assert runtime.calls
+    assert runtime.calls[0]["customer_id"] == generic_user_id
+    assert runtime.calls[0]["workflow"]["workflow_id"] == workflow["workflow_id"]
+    assert runtime.calls[0]["conversation"]["summary"]["conversation_id"] == str(lead_chat_id)
+
+    lead_replies = [
+        item
+        for item in fake_telegram.sent_messages
+        if str(item.get("business_connection_id", "")).strip() == business_connection_id
+        and int(item.get("chat_id", 0)) == lead_chat_id
+    ]
+    assert len(lead_replies) == 1
+    assert lead_replies[0]["reply_to_message_id"] == 50
+    assert lead_replies[0]["text"] == f"Reply for {lead_chat_id}"
+
+    stored_connection = app.state.telegram_business.get_connection(business_connection_id)
+    assert stored_connection is not None
+    assert stored_connection["customer_id"] == generic_user_id
+    conversation = app.state.telegram_business.get_conversation(
+        customer_id=generic_user_id,
+        business_connection_id=business_connection_id,
+        conversation_id=str(lead_chat_id),
+    )
+    assert conversation["ok"] is True
 
 
 @pytest.mark.live_llm

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from opentulpa.api.app import create_app
+from opentulpa.context.customer_profiles import CustomerProfileService
 from opentulpa.context.file_vault import FileVaultService
 from opentulpa.core.config import get_settings
 
@@ -107,6 +108,36 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert "event: final" in text
     assert runtime.calls[0]["customer_id"] == "telegram_1"
     assert runtime.calls[0]["thread_id"] == "dashboard-owner-1"
+
+
+def test_web_chat_resolves_bound_telegram_alias(monkeypatch: Any, tmp_path: Any) -> None:
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    get_settings.cache_clear()
+    runtime = _StreamingRuntime()
+    vault = FileVaultService(root_dir=tmp_path / "vault", db_path=tmp_path / "vault.db")
+    profiles = CustomerProfileService(tmp_path / "profiles.db")
+    profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="1")
+    app = create_app(
+        agent_runtime=runtime,
+        file_vault_service=vault,
+        customer_profile_service=profiles,
+    )
+    client = TestClient(app)
+
+    with client.stream(
+        "POST",
+        "/web/chat/turns",
+        headers={"authorization": "Bearer web-secret"},
+        json={
+            "customer_id": "telegram_1",
+            "thread_id": "dashboard-owner-1",
+            "text": "hi",
+        },
+    ) as response:
+        _ = response.read()
+
+    assert response.status_code == 200
+    assert runtime.calls[0]["customer_id"] == "usr_default"
 
 
 def test_web_file_upload_and_content_are_bearer_protected(monkeypatch: Any, tmp_path: Any) -> None:

--- a/tests/test_intake_workflow_routes.py
+++ b/tests/test_intake_workflow_routes.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from opentulpa.api.app import create_app
+from opentulpa.context.customer_profiles import CustomerProfileService
 from opentulpa.intake.service import IntakeWorkflowService
 from opentulpa.scheduler.service import SchedulerService
 from opentulpa.skills.service import SkillStoreService
@@ -17,7 +18,11 @@ class _DisabledComposio:
         return {"ok": True, "enabled": False}
 
 
-def _mk_client(tmp_path: Path) -> TestClient:
+def _mk_client(
+    tmp_path: Path,
+    *,
+    customer_profiles: CustomerProfileService | None = None,
+) -> TestClient:
     scheduler = SchedulerService(db_path=tmp_path / "scheduler.db")
     skills = SkillStoreService(
         db_path=tmp_path / "skills.db",
@@ -34,6 +39,7 @@ def _mk_client(tmp_path: Path) -> TestClient:
             composio=_DisabledComposio(),
         ),
         composio_service=_DisabledComposio(),
+        customer_profile_service=customer_profiles,
     )
     return TestClient(app)
 
@@ -79,6 +85,33 @@ def test_intake_workflow_routes_crud(tmp_path: Path) -> None:
         )
         assert deleted.status_code == 200
         assert deleted.json()["deleted"] is True
+
+
+def test_intake_workflow_routes_resolve_customer_alias(tmp_path: Path) -> None:
+    profiles = CustomerProfileService(tmp_path / "profiles.db")
+    profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="123")
+
+    with _mk_client(tmp_path, customer_profiles=profiles) as client:
+        upsert = client.post(
+            "/internal/intake/workflows/upsert",
+            json={
+                "customer_id": "telegram_123",
+                "name": "Alias Intake",
+                "intent_description": "Handle alias-routed requests.",
+                "required_fields": ["name"],
+                "sink_type": "local_csv",
+                "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+            },
+        )
+        assert upsert.status_code == 200
+        assert upsert.json()["workflow"]["customer_id"] == "usr_default"
+
+        listed = client.post(
+            "/internal/intake/workflows/list",
+            json={"customer_id": "usr_default", "include_disabled": True},
+        )
+        assert listed.status_code == 200
+        assert [item["name"] for item in listed.json()["workflows"]] == ["Alias Intake"]
 
 
 def test_telegram_business_workflow_route_requires_delete_then_recreate(tmp_path: Path) -> None:

--- a/tests/test_profile_routes.py
+++ b/tests/test_profile_routes.py
@@ -134,3 +134,41 @@ def test_profile_binding_rejects_separate_existing_profiles(tmp_path: Path) -> N
         assert "manual merge" in str(exc)
     else:
         raise AssertionError("expected separate profile bind to be rejected")
+
+
+def test_profile_binding_rejects_existing_generic_profile_when_telegram_alias_is_bound(
+    tmp_path: Path,
+) -> None:
+    _, profiles, _ = _mk_client(tmp_path)
+    profiles.set_directive("telegram_123", "legacy directive", source="test")
+    profiles.bind_telegram_user_id(user_id="usr_first", telegram_user_id="123")
+    profiles.set_directive("usr_second", "separate generic directive", source="test")
+
+    try:
+        profiles.bind_telegram_user_id(user_id="usr_second", telegram_user_id="123")
+    except ValueError as exc:
+        assert "manual merge" in str(exc)
+    else:
+        raise AssertionError("expected conflicting generic profile bind to be rejected")
+
+    assert profiles.resolve_customer_id("usr_second") == "usr_second"
+    assert profiles.get_directive("usr_second") == "separate generic directive"
+
+
+def test_profile_binding_rejects_existing_telegram_profile_when_generic_alias_is_bound(
+    tmp_path: Path,
+) -> None:
+    _, profiles, _ = _mk_client(tmp_path)
+    profiles.set_directive("usr_default", "generic directive", source="test")
+    profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="123")
+    profiles.set_directive("telegram_456", "separate telegram directive", source="test")
+
+    try:
+        profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="456")
+    except ValueError as exc:
+        assert "manual merge" in str(exc)
+    else:
+        raise AssertionError("expected conflicting telegram profile bind to be rejected")
+
+    assert profiles.resolve_customer_id("telegram_456") == "telegram_456"
+    assert profiles.get_directive("telegram_456") == "separate telegram directive"

--- a/tests/test_profile_routes.py
+++ b/tests/test_profile_routes.py
@@ -83,3 +83,54 @@ def test_profile_routes_reject_invalid_payloads_via_pydantic(tmp_path: Path) -> 
         json={"customer_id": "telegram_1", "utc_offset": "UTC+8"},
     )
     assert bad_offset.status_code == 422
+
+
+def test_profile_routes_bind_telegram_alias_to_generic_storage(tmp_path: Path) -> None:
+    client, profiles, _ = _mk_client(tmp_path)
+    profiles.set_directive("usr_default", "use generic storage", source="test")
+
+    bind = client.post(
+        "/profiles/bind-telegram",
+        json={"user_id": "usr_default", "telegram_user_id": "123"},
+    )
+    assert bind.status_code == 200
+    assert bind.json() == {"ok": True, "customer_id": "usr_default"}
+
+    assert profiles.resolve_customer_id("telegram_123") == "usr_default"
+    assert profiles.get_directive("telegram_123") == "use generic storage"
+
+    listed = client.get("/profiles")
+    assert listed.status_code == 200
+    body = listed.json()
+    assert body["profiles"] == [
+        {
+            "user_id": "usr_default",
+            "storage_user_id": "usr_default",
+            "telegram_user_id": "123",
+            "aliases": ["usr_default", "telegram_123"],
+        }
+    ]
+    assert body["bindings"][1]["alias_user_id"] == "telegram_123"
+
+
+def test_profile_binding_uses_legacy_telegram_storage_when_it_exists_first(tmp_path: Path) -> None:
+    _, profiles, _ = _mk_client(tmp_path)
+    profiles.set_directive("telegram_123", "legacy directive", source="test")
+
+    profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="123")
+
+    assert profiles.resolve_customer_id("usr_default") == "telegram_123"
+    assert profiles.get_directive("usr_default") == "legacy directive"
+
+
+def test_profile_binding_rejects_separate_existing_profiles(tmp_path: Path) -> None:
+    _, profiles, _ = _mk_client(tmp_path)
+    profiles.set_directive("usr_default", "generic directive", source="test")
+    profiles.set_directive("telegram_123", "telegram directive", source="test")
+
+    try:
+        profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="123")
+    except ValueError as exc:
+        assert "manual merge" in str(exc)
+    else:
+        raise AssertionError("expected separate profile bind to be rejected")

--- a/tests/test_scheduler_routine_scope.py
+++ b/tests/test_scheduler_routine_scope.py
@@ -5,11 +5,16 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from opentulpa.api.app import create_app
+from opentulpa.context.customer_profiles import CustomerProfileService
 from opentulpa.scheduler.models import Routine
 from opentulpa.scheduler.service import SchedulerService
 
 
-def _mk_client(tmp_path: Path) -> TestClient:
+def _mk_client(
+    tmp_path: Path,
+    *,
+    customer_profiles: CustomerProfileService | None = None,
+) -> TestClient:
     scheduler = SchedulerService(db_path=tmp_path / "scheduler.db")
     scheduler.add_routine(
         Routine(
@@ -29,7 +34,7 @@ def _mk_client(tmp_path: Path) -> TestClient:
             is_cron=True,
         )
     )
-    app = create_app(scheduler=scheduler)
+    app = create_app(scheduler=scheduler, customer_profile_service=customer_profiles)
     return TestClient(app)
 
 
@@ -54,6 +59,16 @@ def test_scheduler_routine_filter_and_owner_delete(tmp_path: Path) -> None:
         )
         assert deleted.status_code == 200
         assert deleted.json()["ok"] is True
+
+
+def test_scheduler_routine_filter_resolves_customer_alias(tmp_path: Path) -> None:
+    profiles = CustomerProfileService(tmp_path / "profiles.db")
+    profiles.bind_telegram_user_id(user_id="usr_default", telegram_user_id="1")
+
+    with _mk_client(tmp_path, customer_profiles=profiles) as client:
+        listed = client.get("/internal/scheduler/routines", params={"customer_id": "usr_default"})
+        assert listed.status_code == 200
+        assert {r["id"] for r in listed.json()["routines"]} == {"rtn_user1"}
 
 
 def test_scheduler_route_requires_instruction_payload(tmp_path: Path) -> None:

--- a/tests/test_telegram_support_bindings.py
+++ b/tests/test_telegram_support_bindings.py
@@ -110,6 +110,23 @@ async def test_support_commands_rejected_when_support_env_unset(
 
 
 @pytest.mark.asyncio
+async def test_owner_fresh_uses_bound_generic_customer_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_store = _FakeStateStore({"admin_user_id": 1, "sessions": {}, "pending_key_by_chat": {}})
+    monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
+
+    text = await chat_module.handle_telegram_text(
+        body=_body(chat_id=1000, user_id=123, username="owner", text="/fresh"),
+        allowed_user_ids_csv="123",
+        resolve_telegram_customer_id=lambda user_id: "usr_default",
+    )
+
+    assert "Started a fresh chat context" in str(text)
+    assert fake_store.state["sessions"]["1000"]["customer_id"] == "usr_default"
+
+
+@pytest.mark.asyncio
 async def test_support_bind_by_id_and_route_runtime_to_bound_customer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds profile identity aliases so OpenTulpa can run with a generic customer id while optionally binding that account to a Telegram user id later.

Key behavior:
- generic `user_id` can be the canonical OpenTulpa storage id
- `telegram_<telegram_user_id>` can bind to the generic id through alias resolution, not copied data
- existing Telegram-canonical users keep their existing storage when they existed first
- unsafe generic+Telegram double-existing profiles are rejected instead of silently merged
- customer-scoped API routes resolve aliases before reading/writing workflows, files, memory, skills, scheduler, web events, user context, wake/search, and related state
- Telegram chat/session lookup and Telegram Business ingestion are alias-aware
- Telegram capability still requires a real Telegram user id plus bot token/client; binding does not create Telegram capability by itself
- architecture docs now explain how to create generic ids, bind Telegram, inspect profiles, and avoid copying state

## Validation

- `uv run ruff check src/opentulpa/interfaces/telegram/business.py src/opentulpa/api/app.py tests/e2e/scenarios/test_telegram_intake_debounce.py docs/ARCHITECTURE.md`
- `uv run pytest tests/e2e/scenarios/test_telegram_intake_debounce.py::test_telegram_business_intake_uses_generic_user_id_after_late_binding --run-e2e -q`
- `uv run pytest tests/e2e/scenarios/test_telegram_intake_debounce.py --run-e2e -q`
- `uv run pytest tests/test_profile_routes.py tests/test_telegram_support_bindings.py tests/test_generic_chat_routes.py tests/test_intake_workflow_routes.py tests/test_scheduler_routine_scope.py tests/test_composio_routes.py tests/test_user_context_e2e_real_files.py tests/test_wake_orchestrator.py tests/test_web_events.py -q`
- `uv run pytest tests/e2e/scenarios/test_telegram_intake_debounce.py::test_live_llm_telegram_business_intake_suppresses_stale_split_reply --run-e2e --run-live-llm -q`
