### PR TITLE
Allow web-only OpenTulpa server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ COMPOSIO_API_KEY=...
 BROWSER_USE_API_KEY=...
 ```
 
+Telegram is optional for deployed web/API use. A Railway/dashboard deployment can start with `OPENTULPA_WEB_TOKEN`, `OPENAI_COMPATIBLE_API_KEY`, and `OPENTULPA_DATA_ROOT` only. Add Telegram env vars later when Telegram chat is enabled.
+
 **Composio is strongly recommended.** It unlocks app connectors for Google Workspace, Slack, Notion, Linear, HubSpot, Gmail, Instagram, and more without writing custom integration code.
 
 **Browser Use Cloud is recommended for browser-heavy work.** With `BROWSER_USE_API_KEY`, OpenTulpa still owns the browser worker loop, but runs it against Browser Use Cloud hosted sessions for live owner handoff URLs, persisted browser profiles, proxying, and managed browser infrastructure.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -182,10 +182,14 @@ Railway builds from the included `Dockerfile` and starts through the same server
 ### Required settings
 
 - `OPENAI_COMPATIBLE_API_KEY`
+- `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
+- `OPENTULPA_WEB_TOKEN` for dashboard/web API access
+
+Telegram is optional in server mode. For web/API-only deployments, leave Telegram env vars empty. If Telegram is enabled, also set:
+
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_WEBHOOK_SECRET`
 - `PUBLIC_BASE_URL=https://your-service.up.railway.app` or Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
-- `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
 - `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`
 
 ### Recommended settings
@@ -209,14 +213,15 @@ If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml
 2. Add one volume mounted at `/app/opentulpa_data`
 3. Set:
    - `OPENAI_COMPATIBLE_API_KEY`
-   - `TELEGRAM_BOT_TOKEN`
-   - `TELEGRAM_WEBHOOK_SECRET`
-   - `PUBLIC_BASE_URL` if you do not want to rely on Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
    - `OPENTULPA_DATA_ROOT=/app/opentulpa_data`
-   - `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
+   - `OPENTULPA_WEB_TOKEN`
 4. Optionally set:
    - `COMPOSIO_API_KEY`
    - `COMPOSIO_DEFAULT_CALLBACK_URL`
+   - `TELEGRAM_BOT_TOKEN`
+   - `TELEGRAM_WEBHOOK_SECRET`
+   - `PUBLIC_BASE_URL` if you do not want to rely on Railway's `RAILWAY_PUBLIC_DOMAIN` fallback
+   - `TELEGRAM_ALLOWED_USERNAMES` or `TELEGRAM_ALLOWED_USER_IDS`
    - `TELEGRAM_SUPPORT_USER_IDS` or `TELEGRAM_SUPPORT_USERNAMES`
 5. Deploy
 

--- a/start.sh
+++ b/start.sh
@@ -119,7 +119,7 @@ public_base_url_is_set() {
 }
 
 server_telegram_enabled() {
-  env_is_set "TELEGRAM_BOT_TOKEN" || env_is_set "TELEGRAM_WEBHOOK_SECRET" || telegram_allowlist_is_set
+  env_is_set "TELEGRAM_BOT_TOKEN" || telegram_allowlist_is_set
 }
 
 yaml_value_is_set() {

--- a/start.sh
+++ b/start.sh
@@ -118,6 +118,10 @@ public_base_url_is_set() {
   env_is_set "PUBLIC_BASE_URL" || env_is_set "RAILWAY_PUBLIC_DOMAIN"
 }
 
+server_telegram_enabled() {
+  env_is_set "TELEGRAM_BOT_TOKEN" || env_is_set "TELEGRAM_WEBHOOK_SECRET" || telegram_allowlist_is_set
+}
+
 yaml_value_is_set() {
   local key="$1"
   local line value
@@ -520,12 +524,16 @@ ensure_required_env() {
   fi
 
   if [[ "${runtime}" == "server" ]]; then
-    env_is_set "TELEGRAM_BOT_TOKEN" || missing+=("TELEGRAM_BOT_TOKEN")
-    env_is_set "TELEGRAM_WEBHOOK_SECRET" || missing+=("TELEGRAM_WEBHOOK_SECRET")
-    public_base_url_is_set || missing+=("PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN")
     env_is_set "OPENTULPA_DATA_ROOT" || missing+=("OPENTULPA_DATA_ROOT")
-    if ! telegram_allowlist_is_set; then
-      missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
+    if server_telegram_enabled; then
+      env_is_set "TELEGRAM_BOT_TOKEN" || missing+=("TELEGRAM_BOT_TOKEN")
+      env_is_set "TELEGRAM_WEBHOOK_SECRET" || missing+=("TELEGRAM_WEBHOOK_SECRET")
+      public_base_url_is_set || missing+=("PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN")
+      if ! telegram_allowlist_is_set; then
+        missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
+      fi
+    else
+      log "server Telegram disabled; web/API startup does not require Telegram env."
     fi
   fi
 
@@ -666,8 +674,12 @@ run_doctor() {
   fi
   load_dotenv
   doctor_check "OPENAI_COMPATIBLE_API_KEY is set" "$(env_is_set "OPENAI_COMPATIBLE_API_KEY" && echo 1 || echo 0)" "set OPENAI_COMPATIBLE_API_KEY in .env" || failures=$((failures + 1))
-  doctor_check "TELEGRAM_BOT_TOKEN is set" "$(env_is_set "TELEGRAM_BOT_TOKEN" && echo 1 || echo 0)" "set TELEGRAM_BOT_TOKEN in .env" || failures=$((failures + 1))
-  doctor_check "Telegram allowlist is set" "$(telegram_allowlist_is_set && echo 1 || echo 0)" "set TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS in .env" || failures=$((failures + 1))
+  if [[ "${runtime}" != "server" ]] || server_telegram_enabled; then
+    doctor_check "TELEGRAM_BOT_TOKEN is set" "$(env_is_set "TELEGRAM_BOT_TOKEN" && echo 1 || echo 0)" "set TELEGRAM_BOT_TOKEN in .env" || failures=$((failures + 1))
+    doctor_check "Telegram allowlist is set" "$(telegram_allowlist_is_set && echo 1 || echo 0)" "set TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS in .env" || failures=$((failures + 1))
+  else
+    echo "[doctor] info: server Telegram disabled; skipping Telegram token and allowlist checks"
+  fi
   if env_is_set "COMPOSIO_API_KEY"; then
     echo "[doctor] ok: COMPOSIO_API_KEY is set"
   else
@@ -676,8 +688,12 @@ run_doctor() {
   emit_model_config_notice
   check_model_catalog
   if [[ "${runtime}" == "server" ]]; then
-    doctor_check "TELEGRAM_WEBHOOK_SECRET is set" "$(env_is_set "TELEGRAM_WEBHOOK_SECRET" && echo 1 || echo 0)" "set a stable TELEGRAM_WEBHOOK_SECRET in .env" || failures=$((failures + 1))
-    doctor_check "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN is set" "$(public_base_url_is_set && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL, or rely on Railway's RAILWAY_PUBLIC_DOMAIN" || failures=$((failures + 1))
+    if server_telegram_enabled; then
+      doctor_check "TELEGRAM_WEBHOOK_SECRET is set" "$(env_is_set "TELEGRAM_WEBHOOK_SECRET" && echo 1 || echo 0)" "set a stable TELEGRAM_WEBHOOK_SECRET in .env" || failures=$((failures + 1))
+      doctor_check "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN is set" "$(public_base_url_is_set && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL, or rely on Railway's RAILWAY_PUBLIC_DOMAIN" || failures=$((failures + 1))
+    else
+      echo "[doctor] info: server Telegram disabled; skipping webhook URL/secret checks"
+    fi
     doctor_check "OPENTULPA_DATA_ROOT is set" "$(env_is_set "OPENTULPA_DATA_ROOT" && echo 1 || echo 0)" "set OPENTULPA_DATA_ROOT=/app/opentulpa_data and mount persistent storage there" || failures=$((failures + 1))
     if env_is_set "OPENTULPA_DATA_ROOT"; then
       doctor_check "OPENTULPA_DATA_ROOT is writable" "$(mkdir -p "${OPENTULPA_DATA_ROOT}" 2>/dev/null && [[ -w "${OPENTULPA_DATA_ROOT}" ]] && echo 1 || echo 0)" "mount a writable persistent volume at OPENTULPA_DATA_ROOT" || failures=$((failures + 1))

--- a/start.sh
+++ b/start.sh
@@ -533,6 +533,7 @@ ensure_required_env() {
         missing+=("TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS")
       fi
     else
+      env_is_set "OPENTULPA_WEB_TOKEN" || missing+=("OPENTULPA_WEB_TOKEN")
       log "server Telegram disabled; web/API startup does not require Telegram env."
     fi
   fi
@@ -557,15 +558,23 @@ ensure_required_env() {
   fi
 
   env_is_set "OPENAI_COMPATIBLE_API_KEY" || prompt_env_value "OPENAI_COMPATIBLE_API_KEY" "OPENAI_COMPATIBLE_API_KEY" 1
-  if [[ "${runtime}" == "local" || "${runtime}" == "server" ]]; then
+  if [[ "${runtime}" == "local" ]]; then
     env_is_set "TELEGRAM_BOT_TOKEN" || prompt_env_value "TELEGRAM_BOT_TOKEN" "TELEGRAM_BOT_TOKEN" 1
     if ! telegram_allowlist_is_set; then
       prompt_env_value "TELEGRAM_ALLOWED_USERNAMES" "TELEGRAM_ALLOWED_USERNAMES (comma-separated, no @)"
     fi
   fi
   if [[ "${runtime}" == "server" ]]; then
-    env_is_set "TELEGRAM_WEBHOOK_SECRET" || prompt_env_value "TELEGRAM_WEBHOOK_SECRET" "TELEGRAM_WEBHOOK_SECRET" 1
-    public_base_url_is_set || prompt_env_value "PUBLIC_BASE_URL" "PUBLIC_BASE_URL"
+    if server_telegram_enabled; then
+      env_is_set "TELEGRAM_BOT_TOKEN" || prompt_env_value "TELEGRAM_BOT_TOKEN" "TELEGRAM_BOT_TOKEN" 1
+      if ! telegram_allowlist_is_set; then
+        prompt_env_value "TELEGRAM_ALLOWED_USERNAMES" "TELEGRAM_ALLOWED_USERNAMES (comma-separated, no @)"
+      fi
+      env_is_set "TELEGRAM_WEBHOOK_SECRET" || prompt_env_value "TELEGRAM_WEBHOOK_SECRET" "TELEGRAM_WEBHOOK_SECRET" 1
+      public_base_url_is_set || prompt_env_value "PUBLIC_BASE_URL" "PUBLIC_BASE_URL"
+    else
+      env_is_set "OPENTULPA_WEB_TOKEN" || prompt_env_value "OPENTULPA_WEB_TOKEN" "OPENTULPA_WEB_TOKEN" 1
+    fi
     env_is_set "OPENTULPA_DATA_ROOT" || prompt_env_value "OPENTULPA_DATA_ROOT" "OPENTULPA_DATA_ROOT" 0 "/app/opentulpa_data"
   fi
 }
@@ -693,6 +702,7 @@ run_doctor() {
       doctor_check "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN is set" "$(public_base_url_is_set && echo 1 || echo 0)" "set PUBLIC_BASE_URL to the public HTTPS URL, or rely on Railway's RAILWAY_PUBLIC_DOMAIN" || failures=$((failures + 1))
     else
       echo "[doctor] info: server Telegram disabled; skipping webhook URL/secret checks"
+      doctor_check "OPENTULPA_WEB_TOKEN is set" "$(env_is_set "OPENTULPA_WEB_TOKEN" && echo 1 || echo 0)" "set OPENTULPA_WEB_TOKEN for web/API access" || failures=$((failures + 1))
     fi
     doctor_check "OPENTULPA_DATA_ROOT is set" "$(env_is_set "OPENTULPA_DATA_ROOT" && echo 1 || echo 0)" "set OPENTULPA_DATA_ROOT=/app/opentulpa_data and mount persistent storage there" || failures=$((failures + 1))
     if env_is_set "OPENTULPA_DATA_ROOT"; then

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -11,6 +11,7 @@ EMPTY_REQUIRED_ENV = {
     "TELEGRAM_WEBHOOK_SECRET": "",
     "PUBLIC_BASE_URL": "",
     "OPENTULPA_DATA_ROOT": "",
+    "OPENTULPA_WEB_TOKEN": "",
     "COMPOSIO_API_KEY": "",
     "TELEGRAM_ALLOWED_USERNAMES": "",
     "TELEGRAM_ALLOWED_USER_IDS": "",
@@ -73,6 +74,7 @@ def test_start_script_dry_run_server_mode_allows_web_only_without_telegram() -> 
     assert result.returncode == 0
     assert "required .env value(s) missing for server:" in result.stdout
     assert "OPENAI_COMPATIBLE_API_KEY" in result.stdout
+    assert "OPENTULPA_WEB_TOKEN" in result.stdout
     assert "OPENTULPA_DATA_ROOT" in result.stdout
     assert "TELEGRAM_BOT_TOKEN" not in result.stdout
     assert "TELEGRAM_WEBHOOK_SECRET" not in result.stdout
@@ -80,6 +82,39 @@ def test_start_script_dry_run_server_mode_allows_web_only_without_telegram() -> 
     assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" not in result.stdout
     assert "server Telegram disabled; web/API startup does not require Telegram env." in result.stdout
     assert "uv run python -m opentulpa" in result.stdout
+
+
+def test_start_script_dry_run_server_mode_accepts_web_only_env() -> None:
+    result = _run_start(
+        "server",
+        "--dry-run",
+        env={
+            **EMPTY_REQUIRED_ENV,
+            "OPENAI_COMPATIBLE_API_KEY": "test-key",
+            "OPENTULPA_DATA_ROOT": "/tmp/opentulpa-test-data",
+            "OPENTULPA_WEB_TOKEN": "test-web-token",
+        },
+    )
+
+    assert result.returncode == 0
+    assert "required .env value(s) missing for server:" not in result.stdout
+    assert "TELEGRAM_BOT_TOKEN" not in result.stdout
+    assert "TELEGRAM_WEBHOOK_SECRET" not in result.stdout
+    assert "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN" not in result.stdout
+    assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" not in result.stdout
+    assert "server Telegram disabled; web/API startup does not require Telegram env." in result.stdout
+    assert "uv run python -m opentulpa" in result.stdout
+
+
+def test_start_script_doctor_server_web_only_requires_web_token() -> None:
+    result = _run_start("doctor", "server", env=EMPTY_REQUIRED_ENV)
+
+    assert result.returncode == 1
+    assert "server Telegram disabled; skipping Telegram token and allowlist checks" in result.stdout
+    assert "server Telegram disabled; skipping webhook URL/secret checks" in result.stdout
+    assert "fail: OPENTULPA_WEB_TOKEN is set" in result.stdout
+    assert "TELEGRAM_BOT_TOKEN is set" not in result.stdout
+    assert "TELEGRAM_WEBHOOK_SECRET is set" not in result.stdout
 
 
 def test_start_script_dry_run_local_mode() -> None:

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -260,7 +260,10 @@ def test_start_script_run_server_accepts_platform_env_without_dotenv(tmp_path: P
 def test_start_script_server_accepts_railway_public_domain_fallback() -> None:
     env = {
         **EMPTY_REQUIRED_ENV,
+        "TELEGRAM_BOT_TOKEN": "test-token",
+        "TELEGRAM_WEBHOOK_SECRET": "test-secret",
         "RAILWAY_PUBLIC_DOMAIN": "opentulpa.example.railway.app",
+        "TELEGRAM_ALLOWED_USERNAMES": "owner",
     }
 
     result = _run_start("server", "--dry-run", env=env)

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -47,7 +47,7 @@ def test_start_script_dry_run_server_mode() -> None:
     result = _run_start(
         "server",
         "--dry-run",
-        env=EMPTY_REQUIRED_ENV,
+        env={**EMPTY_REQUIRED_ENV, "TELEGRAM_BOT_TOKEN": "test-token"},
     )
 
     assert result.returncode == 0
@@ -61,6 +61,25 @@ def test_start_script_dry_run_server_mode() -> None:
     assert "[start] running server mode." in result.stdout
     assert "uv run python -m opentulpa" in result.stdout
     assert "scripts/manager.py" not in result.stdout
+
+
+def test_start_script_dry_run_server_mode_allows_web_only_without_telegram() -> None:
+    result = _run_start(
+        "server",
+        "--dry-run",
+        env=EMPTY_REQUIRED_ENV,
+    )
+
+    assert result.returncode == 0
+    assert "required .env value(s) missing for server:" in result.stdout
+    assert "OPENAI_COMPATIBLE_API_KEY" in result.stdout
+    assert "OPENTULPA_DATA_ROOT" in result.stdout
+    assert "TELEGRAM_BOT_TOKEN" not in result.stdout
+    assert "TELEGRAM_WEBHOOK_SECRET" not in result.stdout
+    assert "PUBLIC_BASE_URL or RAILWAY_PUBLIC_DOMAIN" not in result.stdout
+    assert "TELEGRAM_ALLOWED_USERNAMES or TELEGRAM_ALLOWED_USER_IDS" not in result.stdout
+    assert "server Telegram disabled; web/API startup does not require Telegram env." in result.stdout
+    assert "uv run python -m opentulpa" in result.stdout
 
 
 def test_start_script_dry_run_local_mode() -> None:


### PR DESCRIPTION
## Summary

Allows deployed OpenTulpa server mode to start without Telegram configuration for dashboard/web-only deployments.

Changes:
- removes hard Telegram requirement from server startup
- server mode always requires `OPENAI_COMPATIBLE_API_KEY` and `OPENTULPA_DATA_ROOT`
- Telegram server requirements are enforced only when Telegram env is present (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, or allowlist)
- doctor mode skips Telegram checks for web-only server deployments
- docs now describe web/API-only Railway startup without Telegram env vars

## Validation

- `uv run pytest tests/test_start_script.py -q`
- `bash -n start.sh`