### PR TITLE
Auto-bind Telegram username bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ PUBLIC_BASE_URL=
 TELEGRAM_ALLOWED_USERNAMES=
 # comma-separated numeric Telegram user IDs, e.g. 123456789
 TELEGRAM_ALLOWED_USER_IDS=
+# Optional generic owner id for dashboard deployments before Telegram numeric id is known.
+# With exactly one TELEGRAM_ALLOWED_USERNAMES value, first message from that username binds its numeric id here.
+OPENTULPA_OWNER_CUSTOMER_ID=
 # Optional: trusted support operators who can bind to customer tenants
 # comma-separated usernames (without @)
 TELEGRAM_SUPPORT_USERNAMES=

--- a/README.md
+++ b/README.md
@@ -119,11 +119,14 @@ Set these when prompted, or add them to `.env`:
 OPENAI_COMPATIBLE_API_KEY=...
 TELEGRAM_BOT_TOKEN=...
 TELEGRAM_ALLOWED_USERNAMES=your_handle
+OPENTULPA_OWNER_CUSTOMER_ID=usr_default
 COMPOSIO_API_KEY=...
 BROWSER_USE_API_KEY=...
 ```
 
 Telegram is optional for deployed web/API use. A Railway/dashboard deployment can start with `OPENTULPA_WEB_TOKEN`, `OPENAI_COMPATIBLE_API_KEY`, and `OPENTULPA_DATA_ROOT` only. Add Telegram env vars later when Telegram chat is enabled.
+
+For generic-first dashboard deployments, `OPENTULPA_OWNER_CUSTOMER_ID` lets the first message from the single allowed Telegram username bind that user's numeric Telegram id to the generic owner scope.
 
 **Composio is strongly recommended.** It unlocks app connectors for Google Workspace, Slack, Notion, Linear, HubSpot, Gmail, Instagram, and more without writing custom integration code.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,8 @@ Support operators are trusted operators configured by `TELEGRAM_SUPPORT_USER_IDS
 
 Normal Telegram access is controlled separately by `TELEGRAM_ALLOWED_USER_IDS` or `TELEGRAM_ALLOWED_USERNAMES`. Those users are allowed to use the bot as owners/operators, but they do not automatically share one owner tenant. A normal allowed chat creates or reuses its own owner session and defaults to `customer_id=telegram_<user_id>` when no existing mapping is present.
 
+Generic-first deployments can set `OPENTULPA_OWNER_CUSTOMER_ID=usr_default` and one `TELEGRAM_ALLOWED_USERNAMES` value before the owner's numeric Telegram id is known. When the first allowed username message arrives, including from a group mention, OpenTulpa binds the observed numeric Telegram id to the generic owner id. This bootstrap does not run when the owner id is already Telegram-derived, such as `telegram_123`, and it does not run for multiple allowed usernames.
+
 1. Support chat sends `/support_customers`
 2. Support binds to a customer with `/support_bind <number-or-customer_id>`
 3. Normal support messages run with `customer_id=<bound_customer_id>` and a support-specific `thread_id`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -248,6 +248,8 @@ If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml
 
 Allowed users are not automatically pooled into one owner tenant. Each normal allowed Telegram chat gets its own owner session by default, with a default `customer_id` shaped like `telegram_<user_id>`. If several humans should operate on the same customer tenant without sharing the owner's chat history, configure them as support operators instead and have them bind to that tenant.
 
+For generic-first dashboard deployments, set `OPENTULPA_OWNER_CUSTOMER_ID=usr_default` plus a single `TELEGRAM_ALLOWED_USERNAMES` value when the owner's numeric Telegram id is not known yet. The first message from that username, including a group message that mentions the bot, binds the observed numeric Telegram id to `usr_default`. If the deployment already uses a Telegram-derived owner id like `telegram_123`, this username bootstrap is skipped.
+
 ## Support operator access
 
 Support mode is optional. If no support allowlist is configured, support commands are disabled.

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -223,6 +223,9 @@ def create_app(
     profile_service = customer_profile_service or CustomerProfileService(
         db_path=PROJECT_ROOT / ".opentulpa" / "customer_profiles.db"
     )
+    configured_owner_customer_id = str(
+        getattr(settings, "opentulpa_owner_customer_id", None) or ""
+    ).strip()
     vault_service = file_vault_service or FileVaultService(
         root_dir=PROJECT_ROOT / ".opentulpa" / "file_vault",
         db_path=PROJECT_ROOT / ".opentulpa" / "file_vault.db",
@@ -276,8 +279,10 @@ def create_app(
             bot_token=settings.telegram_bot_token,
             file_vault=vault_service,
             memory=memory_service,
+            owner_customer_id=configured_owner_customer_id,
             resolve_customer_id=profile_service.resolve_customer_id,
             resolve_telegram_customer_id=profile_service.resolve_telegram_customer_id,
+            bind_telegram_customer_id=profile_service.bind_telegram_user_id,
             alias_user_ids=profile_service.alias_user_ids,
         )
         if settings.telegram_bot_token
@@ -332,7 +337,8 @@ def create_app(
     telegram_business = TelegramBusinessService(
         db_path=PROJECT_ROOT / ".opentulpa" / "telegram_business.db",
         owner_customer_id=profile_service.resolve_customer_id(
-            _telegram_business_owner_customer_id(
+            configured_owner_customer_id
+            or _telegram_business_owner_customer_id(
                 allowed_usernames=settings.telegram_allowed_usernames,
                 allowed_user_ids=settings.telegram_allowed_user_ids,
                 state_path=PROJECT_ROOT / ".opentulpa" / "telegram_state.json",

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -135,6 +135,14 @@ class Settings(BaseSettings):
         default=None,
         description="Optional secret for webhook path",
     )
+    opentulpa_owner_customer_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional canonical owner customer id for generic-first deployments. "
+            "When set to a non-telegram id, an allowed Telegram username can bootstrap "
+            "a numeric Telegram id binding on first message."
+        ),
+    )
     opentulpa_web_token: str | None = Field(
         default=None,
         description="Bearer token required for dashboard web operations against this deployment.",

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -352,6 +352,33 @@ def _is_support_user(
     return bool(username and username.lower() in support_usernames)
 
 
+def _maybe_auto_bind_allowed_username(
+    *,
+    owner_customer_id: str | None,
+    allowed_usernames_csv: str | None,
+    username: str | None,
+    user_id: int,
+    bind_telegram_customer_id: Callable[..., Any] | None,
+) -> None:
+    owner_id = str(owner_customer_id or "").strip()
+    if not owner_id or owner_id.startswith("telegram_") or bind_telegram_customer_id is None:
+        return
+    allowed_usernames = parse_csv_set(allowed_usernames_csv, normalize_username=True)
+    safe_username = str(username or "").strip().removeprefix("@").lower()
+    if len(allowed_usernames) != 1 or safe_username not in allowed_usernames:
+        return
+    try:
+        bind_telegram_customer_id(user_id=owner_id, telegram_user_id=int(user_id))
+    except ValueError as exc:
+        logger.warning(
+            "Telegram username bootstrap bind skipped for customer_id=%s username=%s user_id=%s: %s",
+            owner_id,
+            safe_username,
+            user_id,
+            exc,
+        )
+
+
 def _support_bindings(state: dict[str, Any]) -> dict[str, Any]:
     bindings = state.get("support_bindings")
     if not isinstance(bindings, dict):
@@ -1181,6 +1208,8 @@ async def handle_telegram_text(
     workflow_setup_after_reply: Callable[..., dict[str, Any]] | None = None,
     resolve_customer_id: Callable[[str], str] | None = None,
     resolve_telegram_customer_id: Callable[[int], str] | None = None,
+    owner_customer_id: str | None = None,
+    bind_telegram_customer_id: Callable[..., Any] | None = None,
 ) -> str | None:
     parsed = parse_telegram_update(body)
     if not parsed:
@@ -1225,6 +1254,14 @@ async def handle_telegram_text(
     )
     if not normal_allowed and not support_allowed:
         return "This bot is restricted and your Telegram account is not allowed."
+    if normal_allowed and not support_allowed:
+        _maybe_auto_bind_allowed_username(
+            owner_customer_id=owner_customer_id,
+            allowed_usernames_csv=allowed_usernames_csv,
+            username=ctx.username,
+            user_id=ctx.user_id,
+            bind_telegram_customer_id=bind_telegram_customer_id,
+        )
     if support_allowed:
         await _maybe_configure_support_commands_for_chat(
             bot_token=bot_token,
@@ -1567,6 +1604,8 @@ class TelegramChatService:
         workflow_setup_after_reply: Callable[..., dict[str, Any]] | None = None,
         resolve_customer_id: Callable[[str], str] | None = None,
         resolve_telegram_customer_id: Callable[[int], str] | None = None,
+        owner_customer_id: str | None = None,
+        bind_telegram_customer_id: Callable[..., Any] | None = None,
         alias_user_ids: Callable[[str], list[str]] | None = None,
     ) -> None:
         self.bot_token = str(bot_token or "").strip()
@@ -1577,6 +1616,8 @@ class TelegramChatService:
         self.workflow_setup_after_reply = workflow_setup_after_reply
         self.resolve_customer_id = resolve_customer_id
         self.resolve_telegram_customer_id = resolve_telegram_customer_id
+        self.owner_customer_id = str(owner_customer_id or "").strip()
+        self.bind_telegram_customer_id = bind_telegram_customer_id
         self.alias_user_ids = alias_user_ids
         self._interactive_inbox = TelegramInteractiveInbox()
 
@@ -1668,4 +1709,6 @@ class TelegramChatService:
             workflow_setup_after_reply=self.workflow_setup_after_reply,
             resolve_customer_id=self.resolve_customer_id,
             resolve_telegram_customer_id=self.resolve_telegram_customer_id,
+            owner_customer_id=self.owner_customer_id,
+            bind_telegram_customer_id=self.bind_telegram_customer_id,
         )

--- a/tests/test_telegram_interactive_mailbox.py
+++ b/tests/test_telegram_interactive_mailbox.py
@@ -266,6 +266,97 @@ async def test_telegram_group_message_without_bot_mention_is_ignored(
 
 
 @pytest.mark.asyncio
+async def test_telegram_allowed_username_auto_binds_generic_owner_from_group_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
+    runtime = _InteractiveRuntime()
+    bindings: dict[str, str] = {}
+    stream_customers: list[str] = []
+    service = chat_module.TelegramChatService(
+        bot_token="123:abc",
+        file_vault=object(),
+        memory=None,
+        owner_customer_id="usr_default",
+        resolve_telegram_customer_id=lambda user_id: bindings.get(
+            f"telegram_{user_id}", f"telegram_{user_id}"
+        ),
+        bind_telegram_customer_id=lambda **kwargs: bindings.__setitem__(
+            f"telegram_{kwargs['telegram_user_id']}", str(kwargs["user_id"])
+        ),
+    )
+
+    monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
+    monkeypatch.setattr(chat_module, "get_openai_compatible_api_key_from_env", lambda: "key")
+
+    async def _fake_resolve_bot_username(bot_token: str | None) -> str:
+        del bot_token
+        return "OpenTulpaBot"
+
+    async def _fake_stream_langgraph_reply_to_telegram(**kwargs: Any) -> tuple[str | None, bool]:
+        stream_customers.append(str(kwargs.get("customer_id", "")))
+        return "done", False
+
+    monkeypatch.setattr(chat_module, "_resolve_bot_username", _fake_resolve_bot_username)
+    monkeypatch.setattr(
+        chat_module, "stream_langgraph_reply_to_telegram", _fake_stream_langgraph_reply_to_telegram
+    )
+
+    result = await service.handle_update(
+        body={
+            "message": {
+                "chat": {"id": -1001, "type": "supergroup"},
+                "from": {"id": 100, "username": "owner"},
+                "text": "@OpenTulpaBot list my sheets",
+                "entities": [{"type": "mention", "offset": 0, "length": 14}],
+            }
+        },
+        allowed_usernames_csv="owner",
+        agent_runtime=runtime,
+    )
+
+    assert result is None
+    assert bindings == {"telegram_100": "usr_default"}
+    assert stream_customers == ["usr_default"]
+    assert fake_store.state["sessions"]["-1001"]["customer_id"] == "usr_default"
+
+
+def test_telegram_allowed_username_auto_bind_skips_telegram_owner_id() -> None:
+    calls: list[dict[str, Any]] = []
+
+    chat_module._maybe_auto_bind_allowed_username(
+        owner_customer_id="telegram_100",
+        allowed_usernames_csv="owner",
+        username="owner",
+        user_id=100,
+        bind_telegram_customer_id=lambda **kwargs: calls.append(dict(kwargs)),
+    )
+
+    assert calls == []
+
+
+def test_telegram_allowed_username_auto_bind_requires_single_matching_username() -> None:
+    calls: list[dict[str, Any]] = []
+
+    chat_module._maybe_auto_bind_allowed_username(
+        owner_customer_id="usr_default",
+        allowed_usernames_csv="owner,helper",
+        username="owner",
+        user_id=100,
+        bind_telegram_customer_id=lambda **kwargs: calls.append(dict(kwargs)),
+    )
+    chat_module._maybe_auto_bind_allowed_username(
+        owner_customer_id="usr_default",
+        allowed_usernames_csv="owner",
+        username="other",
+        user_id=101,
+        bind_telegram_customer_id=lambda **kwargs: calls.append(dict(kwargs)),
+    )
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_telegram_interactive_failed_voice_reply_does_not_stream_reply_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add optional generic owner customer id config for username-only Telegram bootstrap
- bind the first matching allowed Telegram username's numeric id to the generic owner customer id
- skip bootstrap for Telegram-derived owner ids, multiple usernames, or nonmatching usernames
- document the generic-first Telegram bootstrap behavior

## Tests
- `uv run pytest tests/test_telegram_interactive_mailbox.py tests/test_profile_routes.py -q`
- `TELEGRAM_ALLOWED_USERNAMES= TELEGRAM_ALLOWED_USER_IDS= OPENTULPA_OWNER_CUSTOMER_ID= uv run pytest tests/test_telegram_interactive_mailbox.py tests/test_profile_routes.py tests/test_telegram_business_routes.py -q`
- `TELEGRAM_ALLOWED_USERNAMES= TELEGRAM_ALLOWED_USER_IDS= OPENTULPA_OWNER_CUSTOMER_ID= uv run pytest -q`
- `uv run ruff check src/opentulpa/interfaces/telegram/chat_service.py src/opentulpa/api/app.py src/opentulpa/core/config.py tests/test_telegram_interactive_mailbox.py`
- `python3 -m py_compile src/opentulpa/interfaces/telegram/chat_service.py src/opentulpa/api/app.py src/opentulpa/core/config.py`

Note: full `uv run ruff check .` still reports pre-existing unrelated lint issues outside this change.