### PR TITLE
Surface connected Composio toolkits in prompt context

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
+import time
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
@@ -75,6 +77,10 @@ from opentulpa.agent.workflow_setup_prompt_context import (
 )
 
 logger = logging.getLogger(__name__)
+
+_COMPOSIO_PROMPT_TOOLKIT_CACHE_SECONDS = 300
+_COMPOSIO_PROMPT_TOOLKIT_LIMIT = 20
+_COMPOSIO_PROMPT_TOOLKIT_TIMEOUT_SECONDS = 2.0
 
 
 def _graph_retry_budget(runtime: Any) -> int:
@@ -229,6 +235,7 @@ def _build_late_turn_control_text(
     turn_mode: str,
     customer_id: str,
     live_time: dict[str, str],
+    connected_composio_toolkits_context: str = "",
 ) -> str:
     parts: list[str] = [
         PROMPT_DYNAMIC_BOUNDARY,
@@ -238,6 +245,7 @@ def _build_late_turn_control_text(
             f"customer_id={customer_id}. "
             "Customer scope for customer-scoped tools is resolved automatically from runtime state."
         ),
+        connected_composio_toolkits_context,
         (
             "Live time context (auto-injected this turn):\n"
             f"- server_time_local_iso: {live_time['server_time_local_iso']}\n"
@@ -250,6 +258,66 @@ def _build_late_turn_control_text(
         ),
     ]
     return "\n\n".join(str(part).strip() for part in parts if str(part).strip())
+
+
+async def _build_connected_composio_toolkits_context(runtime: Any, customer_id: str) -> str:
+    cid = str(customer_id or "").strip()
+    if not cid:
+        return ""
+    now = time.monotonic()
+    cache = getattr(runtime, "_composio_prompt_toolkit_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        runtime._composio_prompt_toolkit_cache = cache
+    cached = cache.get(cid)
+    if (
+        isinstance(cached, tuple)
+        and len(cached) == 2
+        and isinstance(cached[0], int | float)
+        and isinstance(cached[1], list)
+        and now - float(cached[0]) < _COMPOSIO_PROMPT_TOOLKIT_CACHE_SECONDS
+    ):
+        toolkits = [str(item) for item in cached[1] if str(item).strip()]
+    else:
+        toolkits = []
+        composio = getattr(runtime, "_composio_service", None)
+        list_connected_accounts = getattr(composio, "list_connected_accounts", None)
+        if bool(getattr(composio, "enabled", False)) and callable(list_connected_accounts):
+            try:
+                response = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        list_connected_accounts,
+                        customer_id=cid,
+                        statuses=["ACTIVE"],
+                        limit=_COMPOSIO_PROMPT_TOOLKIT_LIMIT,
+                    ),
+                    timeout=_COMPOSIO_PROMPT_TOOLKIT_TIMEOUT_SECONDS,
+                )
+                items = response.get("items") if isinstance(response, dict) else []
+                seen: set[str] = set()
+                for item in items[:_COMPOSIO_PROMPT_TOOLKIT_LIMIT] if isinstance(items, list) else []:
+                    if not isinstance(item, dict):
+                        continue
+                    status = str(item.get("status", "") or "").strip().upper()
+                    slug = str(item.get("toolkit_slug", "") or "").strip().lower()
+                    if (not status or status == "ACTIVE") and slug and slug not in seen:
+                        seen.add(slug)
+                        toolkits.append(slug)
+            except Exception as exc:
+                logger.debug("Composio prompt toolkit lookup failed: %s", exc)
+        assert len(toolkits) <= _COMPOSIO_PROMPT_TOOLKIT_LIMIT
+        cache[cid] = (now, toolkits)
+
+    if not toolkits:
+        return ""
+    assert all(toolkit == toolkit.strip().lower() for toolkit in toolkits)
+    return (
+        "Available via Composio tool for this customer: "
+        f"{', '.join(toolkits)}. "
+        "For private or authenticated resources in these services, prefer "
+        'tool_group_exec(group="composio") with composio_tool_search/composio_tool_execute '
+        "before anonymous web or browser access."
+    )
 
 
 def _prompt_overhead_tokens(messages: list[AnyMessage]) -> int:
@@ -823,6 +891,10 @@ def build_runtime_graph(runtime: Any):
                 else None
             )
             live_time = await runtime._build_live_time_context(customer_id)
+            connected_composio_toolkits_context = await _build_connected_composio_toolkits_context(
+                runtime,
+                customer_id,
+            )
             pending_context_summary = (
                 str(state.get("pending_context_summary", "")).strip()
                 if context_engineer.should_include_optional_context(
@@ -968,12 +1040,18 @@ def build_runtime_graph(runtime: Any):
                     turn_mode=turn_mode,
                     customer_id=customer_id,
                     live_time=live_time,
+                    connected_composio_toolkits_context=connected_composio_toolkits_context,
                 ),
                 "late_control_sections": [
                     "volatile_injected",
                     f"prompt_mode:{prompt_mode}",
                     f"turn_mode:{turn_mode}",
                     "customer_scope",
+                    *(
+                        ["connected_composio_toolkits"]
+                        if connected_composio_toolkits_context
+                        else []
+                    ),
                     "live_time",
                 ],
                 "stable_entries": stable_entries,

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -270,6 +270,8 @@ def create_app(
     skill_service.ensure_default_skill()
     if runtime is not None and getattr(runtime, "_link_alias_service", None) is None:
         runtime._link_alias_service = alias_service  # type: ignore[attr-defined]
+    if runtime is not None:
+        runtime._composio_service = composio  # type: ignore[attr-defined]
 
     telegram_client = (
         TelegramClient(settings.telegram_bot_token) if settings.telegram_bot_token else None

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -4,10 +4,38 @@ from __future__ import annotations
 
 import pytest
 
+from opentulpa.agent.graph_builder import (
+    _build_connected_composio_toolkits_context,
+    _build_late_turn_control_text,
+)
 from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
 from opentulpa.agent.prompt_policy import build_system_prompt_message
 from opentulpa.agent.prompt_sections import PROMPT_DYNAMIC_BOUNDARY
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
+
+
+class _PromptComposio:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def list_connected_accounts(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(dict(kwargs))
+        return {
+            "items": [
+                {"toolkit_slug": "github", "status": "ACTIVE"},
+                {"toolkit_slug": "instagram", "status": "ACTIVE"},
+                {"toolkit_slug": "github", "status": "ACTIVE"},
+                {"toolkit_slug": "googlesheets", "status": "INACTIVE"},
+                {"toolkit_slug": "", "status": "ACTIVE"},
+            ]
+        }
+
+
+class _PromptComposioRuntime:
+    def __init__(self, composio: _PromptComposio | None) -> None:
+        self._composio_service = composio
 
 
 def test_prompt_dynamic_boundary_marker_is_single_line_prefix() -> None:
@@ -21,6 +49,50 @@ def test_full_runtime_policy_retains_hardened_rules() -> None:
     assert "[SECTION C] Tool Selection" in text
     assert "[SECTION D] Claim Discipline And Execution" in text
     assert PROMPT_DYNAMIC_BOUNDARY not in text
+    assert "Available via Composio tool for this customer" not in text
+
+
+@pytest.mark.asyncio
+async def test_connected_composio_toolkits_context_is_dynamic_and_cached() -> None:
+    composio = _PromptComposio()
+    runtime = _PromptComposioRuntime(composio)
+
+    text = await _build_connected_composio_toolkits_context(runtime, "telegram_1")
+
+    assert text.startswith("Available via Composio tool for this customer: github, instagram.")
+    assert 'tool_group_exec(group="composio")' in text
+    assert "googlesheets" not in text
+    assert composio.calls == [
+        {
+            "customer_id": "telegram_1",
+            "statuses": ["ACTIVE"],
+            "limit": 20,
+        }
+    ]
+
+    cached_text = await _build_connected_composio_toolkits_context(runtime, "telegram_1")
+    assert cached_text == text
+    assert len(composio.calls) == 1
+
+
+def test_late_turn_control_can_include_connected_composio_toolkits() -> None:
+    text = _build_late_turn_control_text(
+        prompt_mode="default",
+        turn_mode="interactive",
+        customer_id="telegram_1",
+        connected_composio_toolkits_context="Available via Composio tool for this customer: github.",
+        live_time={
+            "server_time_local_iso": "2026-05-18T10:00:00+08:00",
+            "server_time_utc_iso": "2026-05-18T02:00:00+00:00",
+            "server_utc_offset": "+08:00",
+            "user_time_local_iso": "2026-05-18T10:00:00+08:00",
+            "user_utc_offset": "+08:00",
+            "user_time_source": "server_default",
+        },
+    )
+
+    assert PROMPT_DYNAMIC_BOUNDARY in text
+    assert "Available via Composio tool for this customer: github." in text
 
 
 def test_model_invoke_extras_empty_when_caching_disabled() -> None:


### PR DESCRIPTION
## Summary
- inject active connected Composio toolkit slugs into the dynamic per-turn prompt context
- keep customer-specific Composio state out of the stable/cacheable system policy
- wire the app Composio service onto the runtime so prompt context can inspect active accounts

## Verification
- uv run pytest -q tests/test_prompt_cache_split.py tests/test_prompt_policy_hardening.py
- uv run ruff check src/opentulpa/agent/graph_builder.py src/opentulpa/api/app.py tests/test_prompt_cache_split.py

Linear: OPE-92