### PR TITLE
Persist interactive chat style preferences

### DIFF
--- a/src/opentulpa/agent/tools/memory_tools.py
+++ b/src/opentulpa/agent/tools/memory_tools.py
@@ -28,7 +28,11 @@ def register_memory_tools(runtime: Any) -> dict[str, Any]:
 
     @tool
     async def memory_add(summary: str) -> Any:
-        """Store a concise durable user memory summary for future conversations."""
+        """Store a concise durable user memory summary for future conversations.
+
+        Use this for stable preferences, style instructions, important facts, and reusable context
+        the user expects OpenTulpa to remember in normal interactive chat.
+        """
         customer_id = require_customer_id(runtime)
         retryable_errors = (
             httpx.ConnectError,

--- a/src/opentulpa/agent/turn_policy.py
+++ b/src/opentulpa/agent/turn_policy.py
@@ -77,6 +77,9 @@ def build_turn_mode_system_message(turn_mode: str | None) -> SystemMessage:
             "Turn mode: interactive.\n"
             "This is a live user-guided turn.\n"
             "For long-running work with multiple tool calls, attach one concise visible progress sentence to the tool-call step or call send_owner_update as the first tool call before continuing.\n"
+            "Apply retrieved user preferences, directive facts, and style facts to the current reply unless the latest user message overrides them.\n"
+            "If the user gives a durable preference for normal chat style, such as asking OpenTulpa to write naturally or stop making Telegram answers look like Markdown documents, store a concise preference with tool_group_exec(group=\"memory\", command=\"memory_add\", args_json={\"summary\": \"User prefers ...\"}) before or while following it.\n"
+            "For natural Telegram chat, avoid headings, horizontal rules, bold/italic marker style, and report-like templates unless the user explicitly asks for a structured document. Lists are fine when they fit the answer naturally.\n"
             "If the user intent is ambiguous about acting now vs drafting/planning, ask one concise clarifying question before taking side-effecting action."
         )
     )

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -4017,12 +4017,19 @@ class IntakeWorkflowService:
             return f"failed to send Telegram Business reply: {exc}"
         if not sent:
             return "Telegram Business reply failed"
-        result_message = {}
+        result_messages: list[dict[str, Any]] = []
         if isinstance(sent, dict):
-            candidate = sent.get("result")
-            if isinstance(candidate, dict):
-                result_message = dict(candidate)
-        if result_message:
+            candidates = sent.get("results")
+            if isinstance(candidates, list):
+                for candidate in candidates:
+                    if not isinstance(candidate, dict):
+                        continue
+                    result = candidate.get("result")
+                    if isinstance(result, dict):
+                        result_messages.append(dict(result))
+            elif isinstance(sent.get("result"), dict):
+                result_messages.append(dict(sent["result"]))
+        for result_message in result_messages:
             result_message.setdefault("message_id", new_short_id("tgmsg"))
             result_message.setdefault("date", int(_utc_now().timestamp()))
             result_message.setdefault(

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -11,7 +11,10 @@ from typing import Any
 
 import httpx
 
-from opentulpa.interfaces.telegram.formatter import prepare_text_and_mode
+from opentulpa.interfaces.telegram.formatter import (
+    prepare_text_and_mode,
+    prepare_text_chunks_and_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,19 +142,27 @@ class TelegramClient:
         business_connection_id: str | None = None,
         reply_to_message_id: int | None = None,
     ) -> dict[str, Any] | None:
-        final_text, final_mode = prepare_text_and_mode(text, parse_mode)
-        payload: dict[str, Any] = {"chat_id": chat_id, "text": final_text}
-        if final_mode:
-            payload["parse_mode"] = final_mode
-        if isinstance(reply_markup, dict):
-            payload["reply_markup"] = reply_markup
         safe_business_connection_id = str(business_connection_id or "").strip()
-        if safe_business_connection_id:
-            payload["business_connection_id"] = safe_business_connection_id
-        if isinstance(reply_to_message_id, int) and reply_to_message_id > 0:
-            payload["reply_parameters"] = {"message_id": reply_to_message_id}
-        data = await self._post("sendMessage", payload)
-        return data if isinstance(data, dict) else None
+        chunks, final_mode = prepare_text_chunks_and_mode(text, parse_mode)
+        if not chunks:
+            return None
+        first_data: dict[str, Any] | None = None
+        for idx, final_text in enumerate(chunks):
+            payload: dict[str, Any] = {"chat_id": chat_id, "text": final_text}
+            if final_mode:
+                payload["parse_mode"] = final_mode
+            if idx == 0 and isinstance(reply_markup, dict):
+                payload["reply_markup"] = reply_markup
+            if safe_business_connection_id:
+                payload["business_connection_id"] = safe_business_connection_id
+            if idx == 0 and isinstance(reply_to_message_id, int) and reply_to_message_id > 0:
+                payload["reply_parameters"] = {"message_id": reply_to_message_id}
+            data = await self._post("sendMessage", payload)
+            if not isinstance(data, dict):
+                return first_data
+            if first_data is None:
+                first_data = data
+        return first_data
 
     async def send_message_draft(
         self,

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -159,7 +159,7 @@ class TelegramClient:
                 payload["reply_parameters"] = {"message_id": reply_to_message_id}
             data = await self._post("sendMessage", payload)
             if not isinstance(data, dict):
-                return first_data
+                return None
             if first_data is None:
                 first_data = data
         return first_data

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -147,6 +147,7 @@ class TelegramClient:
         if not chunks:
             return None
         first_data: dict[str, Any] | None = None
+        sent_results: list[dict[str, Any]] = []
         for idx, final_text in enumerate(chunks):
             payload: dict[str, Any] = {"chat_id": chat_id, "text": final_text}
             if final_mode:
@@ -160,8 +161,12 @@ class TelegramClient:
             data = await self._post("sendMessage", payload)
             if not isinstance(data, dict):
                 return None
+            sent_results.append(data)
             if first_data is None:
                 first_data = data
+        if first_data is not None and len(sent_results) > 1:
+            first_data = dict(first_data)
+            first_data["results"] = sent_results
         return first_data
 
     async def send_message_draft(

--- a/src/opentulpa/interfaces/telegram/formatter.py
+++ b/src/opentulpa/interfaces/telegram/formatter.py
@@ -73,6 +73,7 @@ def markdownish_to_html(text: str) -> str:
     working = re.sub(r"~~([^\n]+?)~~", r"<s>\1</s>", working)
     working = re.sub(r"(?<!\*)\*([^\n*]+?)\*(?!\*)", r"<i>\1</i>", working)
     working = re.sub(r"(?<!\w)_([^_\n]+?)_(?!\w)", r"<i>\1</i>", working)
+    working = working.replace("**", "")
 
     # Line-oriented transforms.
     lines = working.splitlines()
@@ -98,6 +99,64 @@ def markdownish_to_html(text: str) -> str:
         working = working.replace(f"%%LINK_{idx}%%", html_link)
 
     return working
+
+
+def split_text_for_telegram(text: str, *, max_chars: int = TELEGRAM_TEXT_CHAR_LIMIT) -> list[str]:
+    raw = str(text or "").strip()
+    if not raw:
+        return []
+    limit = max(120, int(max_chars))
+    chunks: list[str] = []
+    remaining = raw
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining.strip())
+            break
+        clipped = remaining[:limit].rstrip()
+        boundary_floor = max(0, int(limit * 0.55))
+        cut_positions = [
+            clipped.rfind("\n\n", boundary_floor),
+            clipped.rfind("\n", boundary_floor),
+            clipped.rfind(". ", boundary_floor),
+            clipped.rfind("! ", boundary_floor),
+            clipped.rfind("? ", boundary_floor),
+            clipped.rfind("; ", boundary_floor),
+            clipped.rfind(", ", boundary_floor),
+            clipped.rfind(" ", boundary_floor),
+        ]
+        best_cut = max(cut_positions)
+        if best_cut <= 0:
+            best_cut = limit
+        chunk = remaining[:best_cut].strip()
+        if chunk:
+            chunks.append(chunk)
+        remaining = remaining[best_cut:].strip()
+    return chunks
+
+
+def prepare_text_chunks_and_mode(text: str, parse_mode: str | None) -> tuple[list[str], str | None]:
+    raw = str(text or "").strip()
+    if not raw:
+        return [], parse_mode
+    mode = (parse_mode or "HTML").upper()
+    if mode != "HTML":
+        return split_text_for_telegram(raw), parse_mode
+    formatted = markdownish_to_html(raw)
+    if len(formatted) <= TELEGRAM_TEXT_CHAR_LIMIT:
+        return [formatted], "HTML"
+    out: list[str] = []
+    pending = split_text_for_telegram(raw, max_chars=TELEGRAM_TEXT_CHAR_LIMIT - 700)
+    while pending:
+        chunk = pending.pop(0)
+        formatted_chunk = markdownish_to_html(chunk)
+        if len(formatted_chunk) <= TELEGRAM_TEXT_CHAR_LIMIT:
+            out.append(formatted_chunk)
+            continue
+        if len(chunk) <= 120:
+            out.append(escape(_truncate_plain_text(chunk, max_chars=TELEGRAM_TEXT_CHAR_LIMIT - 32)))
+            continue
+        pending = split_text_for_telegram(chunk, max_chars=max(120, len(chunk) // 2)) + pending
+    return out, "HTML"
 
 
 def prepare_text_and_mode(text: str, parse_mode: str | None) -> tuple[str, str | None]:

--- a/src/opentulpa/interfaces/telegram/formatter.py
+++ b/src/opentulpa/interfaces/telegram/formatter.py
@@ -80,7 +80,6 @@ def markdownish_to_html(text: str) -> str:
     out_lines: list[str] = []
     for line in lines:
         if re.fullmatch(r"\s*([-*_]\s*){3,}\s*", line):
-            out_lines.append("────────")
             continue
         heading = re.match(r"^\s*#{1,6}\s+(.+)$", line)
         if heading:

--- a/tests/e2e/harness/runner.py
+++ b/tests/e2e/harness/runner.py
@@ -425,6 +425,7 @@ def build_harness(
     monkeypatch: Any,
     scenario_name: str,
     composio_service: Any | None = None,
+    memory_service: Any | None = None,
 ) -> E2EHarness:
     from opentulpa.api import app as app_module
     from opentulpa.interfaces.telegram import attachments as attachments_module
@@ -481,7 +482,12 @@ def build_harness(
         behavior_log_path=str(behavior_log_path),
     )
     scheduler = SchedulerService(db_path=tmp_path / f"{scenario_name}_scheduler.sqlite")
-    app = create_app(agent_runtime=runtime, scheduler=scheduler, composio_service=composio)
+    app = create_app(
+        agent_runtime=runtime,
+        scheduler=scheduler,
+        composio_service=composio,
+        memory=memory_service,
+    )
     patch_runtime_internal_api(runtime=runtime, app=app, recorder=recorder)
     client = TestClient(app)
     client.__enter__()

--- a/tests/e2e/scenarios/test_telegram_interactive_owner_update.py
+++ b/tests/e2e/scenarios/test_telegram_interactive_owner_update.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -9,7 +10,7 @@ from typing import Any
 import httpx
 import pytest
 from fastapi.testclient import TestClient
-from harness.runner import E2EHarness, load_jsonl
+from harness.runner import E2EHarness, build_harness, close_harness, load_jsonl
 from langgraph.checkpoint.memory import InMemorySaver
 from mocks.telegram import FakeTelegramClient
 
@@ -52,6 +53,82 @@ def _wait_until(predicate: Any, timeout_seconds: float = 60.0) -> bool:
             return True
         time.sleep(0.2)
     return bool(predicate())
+
+
+class _RecordingMemory:
+    user_id = "default"
+
+    def __init__(self) -> None:
+        self.entries: list[dict[str, Any]] = []
+        self.searches: list[dict[str, Any]] = []
+
+    def add(
+        self,
+        messages: list[dict[str, Any]],
+        user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        infer: bool = True,
+        retries: int = 1,
+    ) -> dict[str, Any]:
+        del infer, retries
+        text = "\n".join(
+            str(message.get("content", "") or "").strip()
+            for message in messages
+            if isinstance(message, dict) and str(message.get("content", "") or "").strip()
+        ).strip()
+        record = {
+            "id": f"mem_{len(self.entries) + 1}",
+            "memory": text,
+            "text": text,
+            "score": 0.99,
+            "metadata": {"kind": "preference_fact", **dict(metadata or {})},
+            "user_id": str(user_id or self.user_id),
+        }
+        self.entries.append(record)
+        return {"results": [record]}
+
+    def add_text(
+        self,
+        text: str,
+        user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        infer: bool = True,
+        retries: int = 1,
+    ) -> dict[str, Any]:
+        return self.add(
+            [{"role": "user", "content": text}],
+            user_id=user_id,
+            metadata=metadata,
+            infer=infer,
+            retries=retries,
+        )
+
+    def search(
+        self,
+        query: str,
+        user_id: str | None = None,
+        limit: int = 5,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.searches.append(
+            {
+                "query": str(query or ""),
+                "user_id": str(user_id or self.user_id),
+                "limit": int(limit),
+                "metadata": metadata or {},
+            }
+        )
+        kinds = metadata.get("kind") if isinstance(metadata, dict) else None
+        allowed_kinds = {str(item) for item in kinds} if isinstance(kinds, list) else None
+        out: list[dict[str, Any]] = []
+        for entry in reversed(self.entries):
+            kind = str(entry.get("metadata", {}).get("kind", "") or "")
+            if allowed_kinds is not None and kind not in allowed_kinds:
+                continue
+            out.append(entry)
+            if len(out) >= int(limit):
+                break
+        return out
 
 
 async def _live_time(customer_id: str) -> dict[str, str]:
@@ -389,3 +466,130 @@ def test_live_telegram_interactive_chat_can_use_owner_update_while_searching(
             item for item in internal_calls if item.get("path") == "/internal/web_search"
         ],
     )
+
+
+@pytest.mark.live_llm
+def test_live_telegram_interactive_chat_remembers_and_honors_style_preference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = get_settings()
+    if not str(settings.openai_compatible_api_key or "").strip():
+        pytest.skip("OPENAI_COMPATIBLE_API_KEY (or OPENROUTER_API_KEY) required for live LLM e2e")
+
+    memory = _RecordingMemory()
+    harness = build_harness(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        scenario_name="interactive_style_memory",
+        memory_service=memory,
+    )
+    owner_user_id = 777
+    owner_chat_id = 1777
+
+    def owner_messages_since(start_index: int) -> list[dict[str, Any]]:
+        return [
+            item
+            for item in harness.telegram_client.sent_messages[start_index:]
+            if int(item.get("chat_id", 0)) == owner_chat_id
+            and not str(item.get("business_connection_id", "") or "").strip()
+        ]
+
+    try:
+        fresh_status = harness.post_telegram(
+            body=_telegram_message(
+                chat_id=owner_chat_id,
+                user_id=owner_user_id,
+                username="owner777",
+                text="/fresh",
+            )
+        )
+        assert fresh_status == 200
+        assert _wait_until(
+            lambda: any(
+                int(item.get("chat_id", 0)) == owner_chat_id
+                for item in harness.telegram_client.sent_messages
+            ),
+            timeout_seconds=30.0,
+        )
+
+        internal_start = harness.count_internal_api_calls()
+        style_start = len(harness.telegram_client.sent_messages)
+        style_status = harness.post_telegram(
+            body=_telegram_message(
+                chat_id=owner_chat_id,
+                user_id=owner_user_id,
+                username="owner777",
+                text=(
+                    "Remember this as my normal Telegram chat writing style: write naturally. "
+                    "Do not make answers look like Markdown documents. No headings, no horizontal "
+                    "rules, no bold or italic marker style. Lists are okay when they fit naturally. "
+                    "Reply with one short sentence after you save it."
+                ),
+            )
+        )
+        assert style_status == 200
+        assert _wait_until(
+            lambda: bool(owner_messages_since(style_start)) and bool(memory.entries),
+            timeout_seconds=180.0,
+        ), {
+            "owner_messages": owner_messages_since(style_start),
+            "memory_entries": memory.entries,
+            "internal_calls": harness.internal_api_calls_since(internal_start),
+        }
+
+        stored_text = "\n".join(str(item.get("text", "") or "") for item in memory.entries)
+        assert "Markdown" in stored_text or "markdown" in stored_text
+        assert "natur" in stored_text.lower() or "естествен" in stored_text.lower()
+        assert any(
+            item.get("path") == "/internal/memory/add"
+            for item in harness.internal_api_calls_since(internal_start)
+        )
+
+        second_internal_start = harness.count_internal_api_calls()
+        second_start = len(harness.telegram_client.sent_messages)
+        second_status = harness.post_telegram(
+            body=_telegram_message(
+                chat_id=owner_chat_id,
+                user_id=owner_user_id,
+                username="owner777",
+                text=(
+                    "Назови три идеи TikTok роликов для dark feminine personal brand. "
+                    "Ответь по-русски, коротко, без объяснения моих стилевых правил."
+                ),
+            )
+        )
+        assert second_status == 200
+        assert _wait_until(
+            lambda: bool(owner_messages_since(second_start)),
+            timeout_seconds=180.0,
+        ), {
+            "owner_messages": owner_messages_since(second_start),
+            "memory_entries": memory.entries,
+            "memory_searches": memory.searches,
+        }
+
+        reply_text = str(owner_messages_since(second_start)[-1].get("text", "") or "").strip()
+        second_internal_calls = harness.internal_api_calls_since(second_internal_start)
+        assert reply_text
+        assert any(item.get("path") == "/internal/memory/search" for item in second_internal_calls)
+        assert memory.searches
+        assert not re.search(r"(?m)^\s*#{1,6}\s+", reply_text)
+        assert not re.search(r"(?m)^\s*[-*_]{3,}\s*$", reply_text)
+        assert "**" not in reply_text
+        assert "__" not in reply_text
+
+        harness.recorder.add(
+            "live_interactive_style_memory_e2e",
+            owner_chat_id=owner_chat_id,
+            stored_memories=memory.entries,
+            memory_searches=memory.searches,
+            reply_text=reply_text,
+            internal_memory_calls=[
+                item
+                for item in harness.internal_api_calls_since(internal_start)
+                if item.get("path") in {"/internal/memory/add", "/internal/memory/search"}
+            ],
+        )
+    finally:
+        close_harness(harness)

--- a/tests/test_core_tools.py
+++ b/tests/test_core_tools.py
@@ -107,6 +107,15 @@ async def test_memory_search_passes_customer_scope() -> None:
     assert kwargs["json_body"]["user_id"] == "telegram_123"
 
 
+def test_memory_add_documents_interactive_style_preferences() -> None:
+    tools = register_runtime_tools(DummyRuntime([]))
+    description = str(tools["memory_add"].description)
+
+    assert "stable preferences" in description
+    assert "style instructions" in description
+    assert "normal interactive chat" in description
+
+
 @pytest.mark.asyncio
 async def test_server_time_returns_expected_keys() -> None:
     runtime = DummyRuntime([])

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -479,6 +479,48 @@ class _FakeTelegramClient:
         }
 
 
+class _SplitResultTelegramClient:
+    def __init__(self) -> None:
+        self.sent_messages: list[dict[str, Any]] = []
+
+    async def send_message(
+        self,
+        *,
+        chat_id: int | str,
+        text: str,
+        parse_mode: str | None = "HTML",
+        reply_markup: dict[str, Any] | None = None,
+        business_connection_id: str | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> dict[str, Any]:
+        del parse_mode, reply_markup, reply_to_message_id
+        chunks = ["First chunk", "Second chunk"]
+        results: list[dict[str, Any]] = []
+        for idx, chunk in enumerate(chunks, start=1):
+            self.sent_messages.append(
+                {
+                    "chat_id": str(chat_id),
+                    "text": chunk,
+                    "business_connection_id": business_connection_id,
+                    "message_id": 2_000 + idx,
+                }
+            )
+            results.append(
+                {
+                    "ok": True,
+                    "result": {
+                        "message_id": 2_000 + idx,
+                        "date": int(datetime.now(UTC).timestamp()) + idx,
+                        "chat": {"id": chat_id, "type": "private"},
+                        "text": chunk,
+                        "business_connection_id": business_connection_id,
+                        "sender_business_bot": {"id": "fake-bot"},
+                    },
+                }
+            )
+        return {"ok": True, "result": results[0]["result"], "results": results}
+
+
 def _mk_service(
     tmp_path: Path,
     *,
@@ -1238,6 +1280,44 @@ async def test_telegram_business_workflow_uses_bound_files_and_replies_via_busin
     assert sent["chat_id"] == "555"
     assert sent["business_connection_id"] == "bc_123"
     assert sent["reply_to_message_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_telegram_business_reply_persists_each_split_message(
+    tmp_path: Path,
+) -> None:
+    service, _, _, telegram_business, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=_FakeComposio({}, {}),
+    )
+    telegram_business.client = _SplitResultTelegramClient()
+    workflow = {
+        "customer_id": "telegram_123",
+        "source_config": {"business_connection_id": "bc_123"},
+    }
+    conversation_summary = {
+        "conversation_id": "555",
+        "latest_inbound_message_id": "10",
+    }
+
+    error = await service._send_telegram_business_reply(
+        workflow=workflow,
+        conversation_summary=conversation_summary,
+        reply_text="First chunk\n\nSecond chunk",
+    )
+
+    assert error is None
+    conversation = telegram_business.get_conversation(
+        customer_id="telegram_123",
+        business_connection_id="bc_123",
+        conversation_id="555",
+    )
+    assert conversation["ok"] is True
+    messages = conversation["conversation"]["messages"]
+    assert [item["message_id"] for item in messages] == ["2001", "2002"]
+    assert [item["text"] for item in messages] == ["First chunk", "Second chunk"]
+    assert all(item["sender_role"] == "assistant" for item in messages)
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_policy_hardening.py
+++ b/tests/test_prompt_policy_hardening.py
@@ -151,6 +151,10 @@ def test_turn_mode_policy_messages_are_mode_specific() -> None:
     assert "live user-guided turn" in interactive
     assert "attach one concise visible progress sentence" in interactive
     assert "call send_owner_update as the first tool call" in interactive
+    assert "Apply retrieved user preferences, directive facts, and style facts" in interactive
+    assert "store a concise preference with tool_group_exec" in interactive
+    assert "stop making Telegram answers look like Markdown documents" in interactive
+    assert "Lists are fine when they fit the answer naturally." in interactive
     assert "collaborating on an intake workflow draft" in workflow_setup
     assert "attach one concise visible progress sentence" in workflow_setup
     assert "call send_owner_update as the first tool call" in workflow_setup

--- a/tests/test_telegram_client_resilience.py
+++ b/tests/test_telegram_client_resilience.py
@@ -52,6 +52,18 @@ class _NotModifiedEditClient:
         )
 
 
+class _RecordingSendClient:
+    payloads: list[dict]
+
+    def __init__(self):
+        self.payloads = []
+
+    async def post(self, _url, *, json, timeout):
+        del timeout
+        self.payloads.append(dict(json))
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": len(self.payloads)}})
+
+
 @pytest.mark.asyncio
 async def test_post_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(telegram_client_module.httpx, "AsyncClient", _AlwaysTimeoutClient)
@@ -78,3 +90,27 @@ async def test_post_treats_not_modified_edit_as_success(monkeypatch: pytest.Monk
     result = await tg._post("editMessageText", {"chat_id": 1, "message_id": 10, "text": "..."})
     assert isinstance(result, dict)
     assert result.get("ok") is True
+
+
+@pytest.mark.asyncio
+async def test_send_message_splits_long_markdown_into_formatted_messages() -> None:
+    recorder = _RecordingSendClient()
+    tg = TelegramClient("dummy")
+    tg._client = recorder
+    text = (
+        "## ВОПРОС 1\n\n"
+        "**1. «I retired my nice girl era» — Before/After**\n"
+        "- Хук: резкий переход в чёрное платье\n"
+        '- Титр: *"I retired my nice girl era"*\n'
+        "- Почему вирусный: трансформация хорошо репостится\n\n"
+    ) * 80
+
+    result = await tg.send_message(chat_id=1, text=text, parse_mode="HTML")
+
+    assert isinstance(result, dict)
+    assert len(recorder.payloads) > 1
+    assert all(payload.get("parse_mode") == "HTML" for payload in recorder.payloads)
+    assert all(len(str(payload.get("text", ""))) <= 3800 for payload in recorder.payloads)
+    assert all("## " not in str(payload.get("text", "")) for payload in recorder.payloads)
+    assert all("**" not in str(payload.get("text", "")) for payload in recorder.payloads)
+    assert all("[Truncated to fit Telegram.]" not in str(payload.get("text", "")) for payload in recorder.payloads)

--- a/tests/test_telegram_client_resilience.py
+++ b/tests/test_telegram_client_resilience.py
@@ -122,6 +122,8 @@ async def test_send_message_splits_long_markdown_into_formatted_messages() -> No
     result = await tg.send_message(chat_id=1, text=text, parse_mode="HTML")
 
     assert isinstance(result, dict)
+    assert isinstance(result.get("results"), list)
+    assert len(result["results"]) == len(recorder.payloads)
     assert len(recorder.payloads) > 1
     assert all(payload.get("parse_mode") == "HTML" for payload in recorder.payloads)
     assert all(len(str(payload.get("text", ""))) <= 3800 for payload in recorder.payloads)

--- a/tests/test_telegram_client_resilience.py
+++ b/tests/test_telegram_client_resilience.py
@@ -64,6 +64,20 @@ class _RecordingSendClient:
         return httpx.Response(200, json={"ok": True, "result": {"message_id": len(self.payloads)}})
 
 
+class _FailSecondSendClient:
+    payloads: list[dict]
+
+    def __init__(self):
+        self.payloads = []
+
+    async def post(self, _url, *, json, timeout):
+        del timeout
+        self.payloads.append(dict(json))
+        if len(self.payloads) >= 2:
+            raise httpx.ReadTimeout("timeout")
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": len(self.payloads)}})
+
+
 @pytest.mark.asyncio
 async def test_post_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(telegram_client_module.httpx, "AsyncClient", _AlwaysTimeoutClient)
@@ -114,3 +128,16 @@ async def test_send_message_splits_long_markdown_into_formatted_messages() -> No
     assert all("## " not in str(payload.get("text", "")) for payload in recorder.payloads)
     assert all("**" not in str(payload.get("text", "")) for payload in recorder.payloads)
     assert all("[Truncated to fit Telegram.]" not in str(payload.get("text", "")) for payload in recorder.payloads)
+
+
+@pytest.mark.asyncio
+async def test_send_message_reports_failure_when_later_split_chunk_fails() -> None:
+    recorder = _FailSecondSendClient()
+    tg = TelegramClient("dummy")
+    tg._client = recorder
+    text = "## Heading\n\n**Important**\n- item\n\n" * 500
+
+    result = await tg.send_message(chat_id=1, text=text, parse_mode="HTML")
+
+    assert result is None
+    assert len(recorder.payloads) >= 2

--- a/tests/test_telegram_formatter.py
+++ b/tests/test_telegram_formatter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from opentulpa.interfaces.telegram.formatter import (
     TELEGRAM_TEXT_CHAR_LIMIT,
     prepare_text_and_mode,
+    prepare_text_chunks_and_mode,
 )
 
 
@@ -14,3 +15,24 @@ def test_prepare_text_and_mode_truncates_oversized_html_message() -> None:
     assert mode == "HTML"
     assert len(formatted) <= TELEGRAM_TEXT_CHAR_LIMIT
     assert "truncated" in formatted.lower()
+
+
+def test_prepare_text_chunks_and_mode_splits_markdown_without_raw_fallback() -> None:
+    section = (
+        "## ВОПРОС 1\n\n"
+        "**1. «I retired my nice girl era» — Before/After**\n"
+        "- Хук: резкий переход в чёрное платье\n"
+        '- Титр: *"I retired my nice girl era"*\n'
+        "- Почему вирусный: трансформация хорошо репостится\n\n"
+    )
+    text = section * 80
+
+    chunks, mode = prepare_text_chunks_and_mode(text, "HTML")
+
+    assert mode == "HTML"
+    assert len(chunks) > 1
+    assert all(len(chunk) <= TELEGRAM_TEXT_CHAR_LIMIT for chunk in chunks)
+    assert all("[Truncated to fit Telegram.]" not in chunk for chunk in chunks)
+    assert all("## " not in chunk for chunk in chunks)
+    assert all("**" not in chunk for chunk in chunks)
+    assert all("<b>" in chunk or "• " in chunk for chunk in chunks)

--- a/tests/test_telegram_formatter.py
+++ b/tests/test_telegram_formatter.py
@@ -20,6 +20,7 @@ def test_prepare_text_and_mode_truncates_oversized_html_message() -> None:
 def test_prepare_text_chunks_and_mode_splits_markdown_without_raw_fallback() -> None:
     section = (
         "## ВОПРОС 1\n\n"
+        "---\n\n"
         "**1. «I retired my nice girl era» — Before/After**\n"
         "- Хук: резкий переход в чёрное платье\n"
         '- Титр: *"I retired my nice girl era"*\n'
@@ -35,4 +36,6 @@ def test_prepare_text_chunks_and_mode_splits_markdown_without_raw_fallback() -> 
     assert all("[Truncated to fit Telegram.]" not in chunk for chunk in chunks)
     assert all("## " not in chunk for chunk in chunks)
     assert all("**" not in chunk for chunk in chunks)
+    assert all("────────" not in chunk for chunk in chunks)
+    assert all("\n---\n" not in chunk for chunk in chunks)
     assert all("<b>" in chunk or "• " in chunk for chunk in chunks)


### PR DESCRIPTION
## Summary

- Teach normal interactive chat turns to apply retrieved preference, directive, and style facts.
- Instruct the agent to save durable normal-chat style preferences through `memory_add` when the user asks OpenTulpa to remember a writing style.
- Add a live Telegram interactive e2e that proves the agent stores the style preference and honors it on a later Telegram turn.

## Why

The issue was in normal Telegram interactive chat, not intake workflow setup. A long-running chat could follow a style correction in context, but it was not reliably prompted to store that correction as durable memory for future turns.

## Validation

- `uv run pytest tests/e2e/scenarios/test_telegram_interactive_owner_update.py::test_live_telegram_interactive_chat_remembers_and_honors_style_preference --run-e2e --run-live-llm -q` -> `1 passed in 32.07s`
- `uv run pytest tests/test_prompt_policy_hardening.py::test_turn_mode_policy_messages_are_mode_specific tests/test_core_tools.py::test_memory_add_documents_interactive_style_preferences -q` -> `2 passed`
- `uv run ruff check tests/e2e/harness/runner.py tests/e2e/scenarios/test_telegram_interactive_owner_update.py src/opentulpa/agent/turn_policy.py src/opentulpa/agent/tools/memory_tools.py tests/test_core_tools.py tests/test_prompt_policy_hardening.py` -> passed