### PR TITLE
Let active turns drain during deploy shutdown

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,6 +54,10 @@ The system is split so that transports and storage are replaceable, while the ag
 6. Tool-call preambles and interactive progress updates can be surfaced before the final reply when the runtime emits them
 7. Telegram webhook handling returns quickly while the tracked turn continues in the background when needed
 
+### Graceful deploy shutdown
+
+OpenTulpa tracks active web turns and accepted Telegram webhook work, including owner chat and Telegram Business intake, in a process-local shutdown drain. During shutdown the app marks itself draining, `/healthz` returns `503`, new web chat and Telegram webhook turns are rejected by that old process, and in-flight work is allowed to finish until `OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS` expires. Railway uses overlapping deploys plus `drainingSeconds`, so idle deployments switch quickly while active agent loops get a bounded window to send their final reply.
+
 ### External DM intake flow
 
 This is the flow behind persistent lead handling such as Telegram Business inboxes.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -195,11 +195,16 @@ Telegram is optional in server mode. For web/API-only deployments, leave Telegra
 ### Recommended settings
 
 - `COMPOSIO_API_KEY` for connector integrations such as Google Sheets and Instagram
+- `OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS=300` to let active web or Telegram turns finish during Railway deploy shutdown
 - Model defaults live in `opentulpa.config.yaml` (`LLM_MODEL=z-ai/glm-5.1`, `LLM_REASONING_EFFORT=medium`, `WAKE_EXECUTION_MODEL=z-ai/glm-5.1`, Gemini Flash for memory/media, Gemini Flash Lite for the business knowledge oracle)
 
 Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set.
 
 If `OPENAI_COMPATIBLE_BASE_URL` is not OpenRouter, review `opentulpa.config.yaml` before startup. The provider must have valid model IDs for `llm_model`, `wake_execution_model`, `workflow_setup_input_classifier_model`, `memory_llm_model`, `multimodal_llm`, `business_knowledge_oracle_model`, `openai_compatible_embedding_model`, and optional `browser_use_model`. File, image, browser, memory, workflow setup, and source-grounded knowledge features will not work correctly if those roles point at unavailable or incompatible models. When an API key is present, `start.sh` calls the provider's OpenAI-compatible `/models` endpoint and warns if configured model IDs are missing from the catalog; it still cannot infer capabilities such as multimodal support from providers that do not expose those flags.
+
+### Graceful deploys
+
+`railway.toml` enables overlapping deploys and a 300 second drain window. On shutdown, OpenTulpa marks the old process as draining, makes `/healthz` fail so new traffic shifts away, rejects new web chat and Telegram webhook turns on the old process, and waits for active web turns or accepted Telegram webhook work, including Telegram Business intake, to finish. If no turn is active, shutdown completes immediately.
 
 ### Optional settings
 

--- a/railway.toml
+++ b/railway.toml
@@ -7,3 +7,5 @@ healthcheckPath = "/healthz"
 healthcheckTimeout = 600
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
+overlapSeconds = 120
+drainingSeconds = 300

--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -201,6 +201,20 @@ def _telegram_support_user_ids(settings: Any) -> list[int]:
     return out
 
 
+def _shutdown_grace_seconds() -> int:
+    raw = str(os.environ.get("OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", "") or "").strip()
+    if not raw:
+        return 300
+    try:
+        return max(0, int(float(raw)))
+    except ValueError:
+        print(
+            f"Invalid OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS={raw!r}; using 300",
+            file=sys.stderr,
+        )
+        return 300
+
+
 def _auto_configure_telegram_webhook(settings: Any) -> None:
     bot_token = str(settings.telegram_bot_token or "").strip()
     if not bot_token:
@@ -429,7 +443,14 @@ def main() -> None:
     # OpenTulpa exposes HTTP/SSE routes only. Disabling Uvicorn's websocket
     # backend avoids noisy websockets deprecation warnings on local startup.
     try:
-        uvicorn.run(app, host=settings.host, port=settings.port, log_level="info", ws="none")
+        uvicorn.run(
+            app,
+            host=settings.host,
+            port=settings.port,
+            log_level="info",
+            ws="none",
+            timeout_graceful_shutdown=_shutdown_grace_seconds(),
+        )
     finally:
         if langfuse_tracer is not None:
             langfuse_tracer.shutdown()

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import logging
+import os
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -48,6 +49,7 @@ from opentulpa.context.link_aliases import LinkAliasService
 from opentulpa.context.service import EventContextService
 from opentulpa.context.user_context import UserContextService
 from opentulpa.core.config import get_openai_compatible_api_key_from_env, get_settings
+from opentulpa.core.shutdown_drain import ShutdownDrain
 from opentulpa.intake import (
     IntakeWorkflowService,
     WorkflowSetupService,
@@ -193,6 +195,17 @@ def _business_knowledge_oracle(
     )
 
 
+def _shutdown_drain_timeout_seconds() -> float:
+    raw = str(os.environ.get("OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", "") or "").strip()
+    if not raw:
+        return 300.0
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning("Invalid OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS=%r; using 300", raw)
+        return 300.0
+
+
 def create_app(
     memory: MemoryService | None = None,
     scheduler: SchedulerService | None = None,
@@ -213,6 +226,7 @@ def create_app(
     task_runner = task_service
     runtime = agent_runtime
     settings = get_settings()
+    shutdown_drain = ShutdownDrain(timeout_seconds=_shutdown_drain_timeout_seconds())
     context_events_service = context_events or EventContextService(
         db_path=PROJECT_ROOT / ".opentulpa" / "context_events.db"
     )
@@ -355,6 +369,9 @@ def create_app(
 
     def get_agent_runtime() -> Any:
         return runtime
+
+    def get_shutdown_drain() -> ShutdownDrain:
+        return shutdown_drain
 
     intake_service = intake_workflow_service or IntakeWorkflowService(
         db_path=PROJECT_ROOT / ".opentulpa" / "intake_workflows.db",
@@ -507,6 +524,12 @@ def create_app(
         if intake_service and hasattr(intake_service, "start"):
             await intake_service.start()
         yield
+        drained = await shutdown_drain.drain()
+        if not drained:
+            logger.warning(
+                "Shutdown drain timed out with active_turns=%s",
+                shutdown_drain.status().active_turns,
+            )
         if intake_service and hasattr(intake_service, "shutdown"):
             await intake_service.shutdown()
         if scheduler_service:
@@ -534,6 +557,7 @@ def create_app(
     app.state.knowledge_service = knowledge
     app.state.user_context_service = user_context_service
     app.state.telegram_business = telegram_business
+    app.state.shutdown_drain = shutdown_drain
 
     @app.middleware("http")
     async def enforce_public_route_boundary(
@@ -574,7 +598,11 @@ def create_app(
     )
     tulpa_loader.reload()
 
-    register_health_routes(app, get_agent_runtime=get_agent_runtime)
+    register_health_routes(
+        app,
+        get_agent_runtime=get_agent_runtime,
+        get_shutdown_drain=get_shutdown_drain,
+    )
     register_debug_log_routes(app)
     register_chat_routes(
         app,
@@ -588,6 +616,7 @@ def create_app(
         get_file_vault=get_file_vault,
         get_workflow_setup_service=get_workflow_setup_service,
         resolve_customer_id=profile_service.resolve_customer_id,
+        get_shutdown_drain=get_shutdown_drain,
     )
     register_memory_routes(
         app,
@@ -681,6 +710,7 @@ def create_app(
         get_intake_workflows=get_intake_workflows,
         get_telegram_chat=get_telegram_chat,
         get_agent_runtime=get_agent_runtime,
+        get_shutdown_drain=get_shutdown_drain,
     )
 
     refresh_tulpa_mounts()

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -22,6 +22,7 @@ from opentulpa.context.uploaded_files import (
     build_uploaded_files_context,
     should_skip_auto_summary_for_upload,
 )
+from opentulpa.core.shutdown_drain import ShutdownDrainingError
 from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
 from opentulpa.web.events import append_web_event
 
@@ -86,6 +87,7 @@ def register_generic_chat_routes(
     get_file_vault: Callable[[], Any],
     get_workflow_setup_service: Callable[[], Any],
     resolve_customer_id: Callable[[str], str] | None = None,
+    get_shutdown_drain: Callable[[], Any] | None = None,
 ) -> None:
     """Register authenticated generic chat endpoints."""
 
@@ -110,10 +112,14 @@ def register_generic_chat_routes(
         runtime = get_agent_runtime()
         if runtime is None or not (hasattr(runtime, "ainvoke_text") or hasattr(runtime, "astream_text")):
             return JSONResponse(status_code=503, content={"detail": "agent runtime unavailable"})
+        drain = get_shutdown_drain() if get_shutdown_drain is not None else None
+        if drain is not None and bool(getattr(drain, "draining", False)):
+            return JSONResponse(status_code=503, content={"detail": "instance draining"})
 
         return StreamingResponse(
             _stream_turn(
                 runtime=runtime,
+                shutdown_drain=drain,
                 workflow_setup_service=get_workflow_setup_service(),
                 file_vault=get_file_vault(),
                 customer_id=_resolve_customer_id(payload.customer_id),
@@ -259,6 +265,7 @@ async def _stream_turn(
     text: str,
     file_ids: list[str],
     include_pending_context: bool,
+    shutdown_drain: Any | None = None,
 ) -> AsyncIterator[str]:
     assert customer_id.strip()
     assert thread_id.strip()
@@ -286,6 +293,17 @@ async def _stream_turn(
         return {"ok": True, "sent": True}
 
     async def _run_turn() -> None:
+        turn_context = shutdown_drain.active_turn() if shutdown_drain is not None else None
+        turn_context_entered = False
+        try:
+            if turn_context is not None:
+                await turn_context.__aenter__()
+                turn_context_entered = True
+        except ShutdownDrainingError:
+            await queue.put(("error", {"message": "instance draining", "type": "ShutdownDrainingError"}))
+            await queue.put(("done", {}))
+            return
+
         append_web_event(
             customer_id=customer_id,
             thread_id=thread_id,
@@ -380,6 +398,8 @@ async def _stream_turn(
                         thread_id=thread_id,
                         sender=_send_file,
                     )
+            if turn_context_entered:
+                await turn_context.__aexit__(None, None, None)
             await queue.put(("done", {}))
 
     yield _sse("status", {"message": "Starting..."})

--- a/src/opentulpa/api/routes/health.py
+++ b/src/opentulpa/api/routes/health.py
@@ -6,17 +6,29 @@ from collections.abc import Callable
 from typing import Any
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 
 def register_health_routes(
     app: FastAPI,
     *,
     get_agent_runtime: Callable[[], Any],
+    get_shutdown_drain: Callable[[], Any] | None = None,
 ) -> None:
     """Register liveness and runtime-health endpoints."""
 
-    @app.get("/healthz")
-    async def health() -> dict[str, str]:
+    @app.get("/healthz", response_model=None)
+    async def health() -> Any:
+        drain = get_shutdown_drain() if get_shutdown_drain is not None else None
+        status = drain.status() if drain is not None and hasattr(drain, "status") else None
+        if status is not None and bool(getattr(status, "draining", False)):
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "status": "draining",
+                    "active_turns": int(getattr(status, "active_turns", 0)),
+                },
+            )
         return {"status": "ok"}
 
     @app.get("/agent/healthz")

--- a/src/opentulpa/api/routes/telegram_webhook.py
+++ b/src/opentulpa/api/routes/telegram_webhook.py
@@ -15,6 +15,7 @@ from typing import Any
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 
+from opentulpa.core.shutdown_drain import ShutdownDrainingError
 from opentulpa.interfaces.telegram.client import (
     parse_telegram_callback_query,
     parse_telegram_update,
@@ -87,11 +88,15 @@ def register_telegram_webhook_routes(
     get_intake_workflows: Callable[[], Any],
     get_telegram_chat: Callable[[], Any],
     get_agent_runtime: Callable[[], Any],
+    get_shutdown_drain: Callable[[], Any] | None = None,
 ) -> None:
     """Register Telegram webhook routes."""
 
     @app.post("/webhook/telegram")
     async def telegram_webhook(request: Request) -> Response:
+        drain = get_shutdown_drain() if get_shutdown_drain is not None else None
+        if drain is not None and bool(getattr(drain, "draining", False)):
+            return JSONResponse(status_code=503, content={"detail": "instance draining"})
         if not settings.telegram_bot_token:
             return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
         expected_secret = str(settings.telegram_webhook_secret or "").strip()
@@ -115,6 +120,13 @@ def register_telegram_webhook_routes(
             return JSONResponse(status_code=403, content={"detail": "invalid telegram secret"})
         body = await request.json()
         update_keys = _top_level_update_keys(body) if isinstance(body, dict) else []
+        turn_context = None
+        if drain is not None and hasattr(drain, "active_turn"):
+            turn_context = drain.active_turn()
+            try:
+                await turn_context.__aenter__()
+            except ShutdownDrainingError:
+                return JSONResponse(status_code=503, content={"detail": "instance draining"})
         _write_telegram_webhook_event(
             "accepted",
             update_id=body.get("update_id") if isinstance(body, dict) else None,
@@ -125,10 +137,25 @@ def register_telegram_webhook_routes(
         )
 
         # Return 200 before long-running agent work so Telegram does not retry the same update.
-        _track_background_task(app, asyncio.create_task(_telegram_background_handler(body=body)))
+        _track_background_task(
+            app,
+            asyncio.create_task(
+                _telegram_background_handler(body=body, turn_context=turn_context)
+            ),
+        )
         return Response(status_code=200)
 
-    async def _telegram_background_handler(body: dict[str, Any]) -> None:
+    async def _telegram_background_handler(
+        body: dict[str, Any],
+        turn_context: Any | None = None,
+    ) -> None:
+        try:
+            await _run_telegram_background_handler(body)
+        finally:
+            if turn_context is not None:
+                await turn_context.__aexit__(None, None, None)
+
+    async def _run_telegram_background_handler(body: dict[str, Any]) -> None:
         business_result = get_telegram_business().ingest_update(body)
         if bool(business_result.get("handled")):
             _write_telegram_webhook_event(

--- a/src/opentulpa/core/shutdown_drain.py
+++ b/src/opentulpa/core/shutdown_drain.py
@@ -1,0 +1,74 @@
+"""Graceful shutdown drain coordination for active conversation turns."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+
+class ShutdownDrainingError(RuntimeError):
+    """Raised when new work is rejected because the instance is draining."""
+
+
+@dataclass(frozen=True)
+class DrainStatus:
+    draining: bool
+    active_turns: int
+
+
+class ShutdownDrain:
+    """Tracks active turns so shutdown can wait without delaying idle deploys."""
+
+    def __init__(self, *, timeout_seconds: float = 300.0) -> None:
+        assert timeout_seconds >= 0
+        self._timeout_seconds = float(timeout_seconds)
+        self._active_turns = 0
+        self._draining = False
+        self._condition = asyncio.Condition()
+
+    @property
+    def timeout_seconds(self) -> float:
+        return self._timeout_seconds
+
+    @property
+    def draining(self) -> bool:
+        return self._draining
+
+    def status(self) -> DrainStatus:
+        assert self._active_turns >= 0
+        return DrainStatus(draining=self._draining, active_turns=self._active_turns)
+
+    def start_draining(self) -> None:
+        self._draining = True
+
+    @asynccontextmanager
+    async def active_turn(self) -> Any:
+        async with self._condition:
+            if self._draining:
+                raise ShutdownDrainingError("instance is draining")
+            self._active_turns += 1
+            assert self._active_turns > 0
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._active_turns -= 1
+                assert self._active_turns >= 0
+                if self._active_turns == 0:
+                    self._condition.notify_all()
+
+    async def drain(self) -> bool:
+        self.start_draining()
+        async with self._condition:
+            if self._active_turns == 0:
+                return True
+            try:
+                await asyncio.wait_for(
+                    self._condition.wait_for(lambda: self._active_turns == 0),
+                    timeout=self._timeout_seconds,
+                )
+            except TimeoutError:
+                return False
+        return True

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import re
 from collections.abc import Callable
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from typing import Any
 
@@ -17,6 +17,7 @@ from opentulpa.core.debug_logs import (
     build_debug_logs_archive_bytes,
 )
 from opentulpa.core.ids import new_short_id
+from opentulpa.core.shutdown_drain import ShutdownDrainingError
 from opentulpa.interfaces.telegram.attachments import (
     build_uploaded_files_context,
     extract_attachments,
@@ -321,6 +322,15 @@ def _inject_telegram_reply_context(text: str, reply_context: str) -> str:
     if not clean_context or not clean_text:
         return clean_text
     return f"{clean_context}\n\nCurrent user message:\n{clean_text}"
+
+
+@asynccontextmanager
+async def _active_turn_context(shutdown_drain: Any | None):
+    if shutdown_drain is None or not hasattr(shutdown_drain, "active_turn"):
+        yield
+        return
+    async with shutdown_drain.active_turn():
+        yield
 
 
 def support_bot_commands() -> list[dict[str, str]]:
@@ -1049,6 +1059,7 @@ async def _run_interactive_session(
     agent_runtime: Any,
     workflow_setup_status: Callable[..., dict[str, Any]] | None = None,
     workflow_setup_after_reply: Callable[..., dict[str, Any]] | None = None,
+    shutdown_drain: Any | None = None,
 ) -> None:
     while True:
         ready = await session.wait_for_ready_head()
@@ -1126,26 +1137,53 @@ async def _run_interactive_session(
                 )
                 STATE_STORE.touch_assistant_message(session.chat_id)
 
-            final, suppressed = await stream_langgraph_reply_to_telegram(
-                agent_runtime=agent_runtime,
-                thread_id=session.thread_id,
-                customer_id=session.customer_id,
-                text=effective_text,
+            async with _active_turn_context(shutdown_drain):
+                final, suppressed = await stream_langgraph_reply_to_telegram(
+                    agent_runtime=agent_runtime,
+                    thread_id=session.thread_id,
+                    customer_id=session.customer_id,
+                    text=effective_text,
+                    bot_token=bot_token,
+                    chat_id=session.chat_id,
+                    turn_mode=turn_mode,
+                    interactive_session=session,
+                    final_reply_callback=(
+                        _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
+                    ),
+                )
+                if turn_mode == "workflow_setup" and final and not suppressed:
+                    _apply_workflow_setup_after_reply(
+                        workflow_setup_after_reply=workflow_setup_after_reply,
+                        customer_id=session.customer_id,
+                        thread_id=session.thread_id,
+                        reply_text=final,
+                    )
+                if final and not suppressed:
+                    STATE_STORE.touch_assistant_message(session.chat_id)
+                elif not suppressed:
+                    debug_log(
+                        hypothesis_id="telegram_chat",
+                        location="interfaces/telegram/chat_service.py:_run_interactive_session",
+                        message="fallback_no_final_reply",
+                        data={"chat_id": session.chat_id, "thread_id": session.thread_id},
+                    )
+                    sent = await _send_direct_telegram_reply(
+                        bot_token=bot_token,
+                        chat_id=session.chat_id,
+                        text=(
+                            "I received your message but no final reply was available yet. "
+                            "Ask again or use /status."
+                        ),
+                    )
+                    if sent:
+                        STATE_STORE.touch_assistant_message(session.chat_id)
+        except ShutdownDrainingError:
+            await _send_direct_telegram_reply(
                 bot_token=bot_token,
                 chat_id=session.chat_id,
-                turn_mode=turn_mode,
-                interactive_session=session,
-                final_reply_callback=(
-                    _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
-                ),
+                text="OpenTulpa is finishing a deploy. Please retry in a moment.",
             )
-            if turn_mode == "workflow_setup" and final and not suppressed:
-                _apply_workflow_setup_after_reply(
-                    workflow_setup_after_reply=workflow_setup_after_reply,
-                    customer_id=session.customer_id,
-                    thread_id=session.thread_id,
-                    reply_text=final,
-                )
+            return
         except Exception as exc:
             logger.exception(
                 "Telegram interactive runner failed (chat_id=%s, thread_id=%s): %s",
@@ -1171,22 +1209,6 @@ async def _run_interactive_session(
                     thread_id=session.thread_id,
                     session=session,
                 )
-        if final and not suppressed:
-            STATE_STORE.touch_assistant_message(session.chat_id)
-        elif not suppressed:
-            debug_log(
-                hypothesis_id="telegram_chat",
-                location="interfaces/telegram/chat_service.py:_run_interactive_session",
-                message="fallback_no_final_reply",
-                data={"chat_id": session.chat_id, "thread_id": session.thread_id},
-            )
-            sent = await _send_direct_telegram_reply(
-                bot_token=bot_token,
-                chat_id=session.chat_id,
-                text="I received your message but no final reply was available yet. Ask again or use /status.",
-            )
-            if sent:
-                STATE_STORE.touch_assistant_message(session.chat_id)
         if await session.finish_runner_if_idle():
             return
 
@@ -1210,6 +1232,7 @@ async def handle_telegram_text(
     resolve_telegram_customer_id: Callable[[int], str] | None = None,
     owner_customer_id: str | None = None,
     bind_telegram_customer_id: Callable[..., Any] | None = None,
+    shutdown_drain: Any | None = None,
 ) -> str | None:
     parsed = parse_telegram_update(body)
     if not parsed:
@@ -1475,6 +1498,7 @@ async def handle_telegram_text(
                 agent_runtime=agent_runtime,
                 workflow_setup_status=workflow_setup_status,
                 workflow_setup_after_reply=workflow_setup_after_reply,
+                shutdown_drain=shutdown_drain,
             )
         finally:
             await interactive_inbox.prune_if_idle(session)
@@ -1525,20 +1549,40 @@ async def handle_telegram_text(
                 )
                 STATE_STORE.touch_assistant_message(ctx.chat_id)
 
-            final, suppressed = await stream_langgraph_reply_to_telegram(
-                agent_runtime=agent_runtime,
-                thread_id=thread_id,
-                customer_id=customer_id,
-                text=effective_text,
-                bot_token=bot_token,
-                chat_id=ctx.chat_id,
-                turn_mode=turn_mode,
-                final_reply_callback=(
-                    _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
-                ),
-            )
-            if suppressed:
-                return None
+            async with _active_turn_context(shutdown_drain):
+                final, suppressed = await stream_langgraph_reply_to_telegram(
+                    agent_runtime=agent_runtime,
+                    thread_id=thread_id,
+                    customer_id=customer_id,
+                    text=effective_text,
+                    bot_token=bot_token,
+                    chat_id=ctx.chat_id,
+                    turn_mode=turn_mode,
+                    final_reply_callback=(
+                        _workflow_setup_late_reply if turn_mode == "workflow_setup" else None
+                    ),
+                )
+                if suppressed:
+                    return None
+                if final:
+                    if turn_mode == "workflow_setup":
+                        _apply_workflow_setup_after_reply(
+                            workflow_setup_after_reply=workflow_setup_after_reply,
+                            customer_id=customer_id,
+                            thread_id=thread_id,
+                            reply_text=final,
+                        )
+                    STATE_STORE.touch_assistant_message(ctx.chat_id)
+                    return None
+                debug_log(
+                    hypothesis_id="telegram_chat",
+                    location="interfaces/telegram/chat_service.py:handle_telegram_text",
+                    message="fallback_no_final_reply",
+                    data={"chat_id": ctx.chat_id, "thread_id": thread_id},
+                )
+                return "I received your message but no final reply was available yet. Ask again or use /status."
+        except ShutdownDrainingError:
+            return "OpenTulpa is finishing a deploy. Please retry in a moment."
         except Exception as exc:
             logger.exception(
                 "Telegram streaming reply failed (chat_id=%s, thread_id=%s): %s",
@@ -1547,39 +1591,25 @@ async def handle_telegram_text(
                 exc,
             )
             return _format_agent_error_for_user(exc)
-        if final:
+
+    try:
+        async with _active_turn_context(shutdown_drain):
+            response = await agent_runtime.ainvoke_text(
+                thread_id=thread_id,
+                customer_id=customer_id,
+                text=effective_text,
+                turn_mode=turn_mode,
+            )
             if turn_mode == "workflow_setup":
                 _apply_workflow_setup_after_reply(
                     workflow_setup_after_reply=workflow_setup_after_reply,
                     customer_id=customer_id,
                     thread_id=thread_id,
-                    reply_text=final,
+                    reply_text=str(response or ""),
                 )
-            STATE_STORE.touch_assistant_message(ctx.chat_id)
-            return None
-        debug_log(
-            hypothesis_id="telegram_chat",
-            location="interfaces/telegram/chat_service.py:handle_telegram_text",
-            message="fallback_no_final_reply",
-            data={"chat_id": ctx.chat_id, "thread_id": thread_id},
-        )
-        return "I received your message but no final reply was available yet. Ask again or use /status."
-
-    try:
-        response = await agent_runtime.ainvoke_text(
-            thread_id=thread_id,
-            customer_id=customer_id,
-            text=effective_text,
-            turn_mode=turn_mode,
-        )
-        if turn_mode == "workflow_setup":
-            _apply_workflow_setup_after_reply(
-                workflow_setup_after_reply=workflow_setup_after_reply,
-                customer_id=customer_id,
-                thread_id=thread_id,
-                reply_text=str(response or ""),
-            )
-        return str(response) if response is not None else None
+            return str(response) if response is not None else None
+    except ShutdownDrainingError:
+        return "OpenTulpa is finishing a deploy. Please retry in a moment."
     except Exception as exc:
         logger.exception(
             "Telegram non-streaming reply failed (chat_id=%s, thread_id=%s): %s",
@@ -1692,6 +1722,7 @@ class TelegramChatService:
         support_user_ids_csv: str | None = None,
         support_usernames_csv: str | None = None,
         agent_runtime: Any | None = None,
+        shutdown_drain: Any | None = None,
     ) -> str | None:
         return await handle_telegram_text(
             body=body,
@@ -1711,4 +1742,5 @@ class TelegramChatService:
             resolve_telegram_customer_id=self.resolve_telegram_customer_id,
             owner_customer_id=self.owner_customer_id,
             bind_telegram_customer_id=self.bind_telegram_customer_id,
+            shutdown_drain=shutdown_drain,
         )

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -47,6 +47,20 @@ def test_internal_routes_blocked_from_public_clients(
     get_settings.cache_clear()
 
 
+def test_healthz_reports_draining_during_shutdown(tmp_path: Path) -> None:
+    get_settings.cache_clear()
+    with _mk_client(tmp_path, client_host="8.8.8.8") as client:
+        healthz = client.get("/healthz")
+        assert healthz.status_code == 200
+
+        client.app.state.shutdown_drain.start_draining()
+        draining = client.get("/healthz")
+
+    assert draining.status_code == 503
+    assert draining.json() == {"status": "draining", "active_turns": 0}
+    get_settings.cache_clear()
+
+
 def test_webhook_route_public_with_telegram_auth(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/test_main_bootstrap.py
+++ b/tests/test_main_bootstrap.py
@@ -107,6 +107,14 @@ def test_ensure_telegram_webhook_secret_generates_when_missing(monkeypatch) -> N
     assert os.environ.get("TELEGRAM_WEBHOOK_SECRET") == generated
 
 
+def test_shutdown_grace_seconds_defaults_and_parses(monkeypatch) -> None:
+    monkeypatch.delenv("OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", raising=False)
+    assert entry._shutdown_grace_seconds() == 300
+
+    monkeypatch.setenv("OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", "45.5")
+    assert entry._shutdown_grace_seconds() == 45
+
+
 def test_auto_configure_telegram_webhook_posts_secret_and_business_updates(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 

--- a/tests/test_shutdown_drain.py
+++ b/tests/test_shutdown_drain.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opentulpa.core.shutdown_drain import ShutdownDrain, ShutdownDrainingError
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_idle_returns_immediately() -> None:
+    drain = ShutdownDrain(timeout_seconds=1)
+
+    assert await drain.drain() is True
+    assert drain.status().draining is True
+    assert drain.status().active_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_waits_for_active_turn() -> None:
+    drain = ShutdownDrain(timeout_seconds=1)
+
+    async with drain.active_turn():
+        task = asyncio.create_task(drain.drain())
+        await asyncio.sleep(0)
+
+        assert not task.done()
+
+    assert await asyncio.wait_for(task, timeout=1) is True
+    assert drain.status().active_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drain_rejects_new_turn_after_draining() -> None:
+    drain = ShutdownDrain(timeout_seconds=1)
+    drain.start_draining()
+
+    with pytest.raises(ShutdownDrainingError):
+        async with drain.active_turn():
+            raise AssertionError("turn should not start")

--- a/tests/test_telegram_business_webhook.py
+++ b/tests/test_telegram_business_webhook.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -75,6 +77,44 @@ class _FakeIntakeWorkflows:
             }
         )
         return {"ok": False, "summary": "send failed"}
+
+
+class _SlowFakeIntakeWorkflows(_FakeIntakeWorkflows):
+    def __init__(self, *, started: threading.Event, release: threading.Event) -> None:
+        super().__init__()
+        self.started = started
+        self.release = release
+
+    async def run_workflow(self, *, customer_id: str, workflow_id: str, event_type: str = "manual"):  # type: ignore[no-untyped-def]
+        self.started.set()
+        await asyncio.to_thread(self.release.wait)
+        return await super().run_workflow(
+            customer_id=customer_id,
+            workflow_id=workflow_id,
+            event_type=event_type,
+        )
+
+
+class _RecordingDrain:
+    def __init__(self) -> None:
+        self.draining = False
+        self.entered = threading.Event()
+        self.exited = threading.Event()
+
+    def active_turn(self):  # type: ignore[no-untyped-def]
+        drain = self
+
+        class _Context:
+            async def __aenter__(self):  # type: ignore[no-untyped-def]
+                drain.entered.set()
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
+                _ = exc_type, exc, tb
+                drain.exited.set()
+                return False
+
+        return _Context()
 
 
 def test_telegram_business_owner_customer_id_uses_first_allowed_username(
@@ -188,6 +228,72 @@ def test_business_message_webhook_triggers_matching_workflow_and_notifies_owner(
     ]
     assert telegram_client.messages[0]["chat_id"] == "777"
     assert "Telegram Business workflow issue: send failed" in str(telegram_client.messages[0]["text"])
+
+
+def test_business_message_webhook_holds_shutdown_drain_until_workflow_finishes(
+    tmp_path: Path,
+) -> None:
+    app = FastAPI()
+    telegram_client = _RecordingTelegramClient()
+    telegram_business = TelegramBusinessService(db_path=tmp_path / "telegram_business.db")
+    telegram_business.upsert_connection(
+        {
+            "id": "bc_123",
+            "user_chat_id": 777,
+            "is_enabled": True,
+            "user": {"id": 123, "is_bot": False, "first_name": "Kim"},
+            "rights": {"can_reply": True},
+        }
+    )
+    started = threading.Event()
+    release = threading.Event()
+    intake = _SlowFakeIntakeWorkflows(started=started, release=release)
+    drain = _RecordingDrain()
+    settings = SimpleNamespace(
+        telegram_bot_token="bot-token",
+        telegram_webhook_secret="secret-token",
+        telegram_allowed_user_ids=None,
+        telegram_allowed_usernames=None,
+    )
+
+    register_telegram_webhook_routes(
+        app,
+        settings=settings,
+        get_telegram_client=lambda: telegram_client,
+        get_telegram_business=lambda: telegram_business,
+        get_intake_workflows=lambda: intake,
+        get_telegram_chat=lambda: _FakeTelegramChat(),
+        get_agent_runtime=lambda: object(),
+        get_shutdown_drain=lambda: drain,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/webhook/telegram",
+            json={
+                "update_id": 1,
+                "business_message": {
+                    "business_connection_id": "bc_123",
+                    "message_id": 10,
+                    "date": 1_775_552_400,
+                    "chat": {"id": 555, "type": "private", "username": "alice"},
+                    "from": {"id": 999, "is_bot": False, "username": "alice"},
+                    "text": "Can I book 3pm?",
+                },
+            },
+            headers={"x-telegram-bot-api-secret-token": "secret-token"},
+        )
+
+        assert response.status_code == 200
+        assert drain.entered.wait(timeout=1)
+        assert started.wait(timeout=1)
+        assert not drain.exited.is_set()
+
+        release.set()
+        _wait_for_webhook_tasks(app)
+
+    assert drain.exited.is_set()
+    assert intake.run_calls
 
 
 def test_telegram_webhook_writes_debug_log_events_for_secret_and_business_updates(

--- a/tests/test_telegram_media_typing.py
+++ b/tests/test_telegram_media_typing.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from opentulpa.core.shutdown_drain import ShutdownDrain
 from opentulpa.interfaces.telegram import chat_service as chat_module
 
 
@@ -67,3 +68,53 @@ async def test_media_ingestion_emits_typing_indicator(monkeypatch: pytest.Monkey
     assert reply is None
     assert _FakeTelegramClient.calls
     assert all(action == "typing" for _, action in _FakeTelegramClient.calls)
+
+
+@pytest.mark.asyncio
+async def test_telegram_stream_turn_blocks_shutdown_drain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_store = _FakeStateStore({"admin_user_id": 100, "pending_key_by_chat": {}, "sessions": {}})
+    monkeypatch.setattr(chat_module, "STATE_STORE", fake_store)
+    monkeypatch.setattr(chat_module, "get_openai_compatible_api_key_from_env", lambda: "key")
+    monkeypatch.setattr(chat_module, "is_user_allowed", lambda **kwargs: True)
+    monkeypatch.setattr(chat_module, "extract_attachments", lambda _message: [])
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _fake_stream_langgraph_reply_to_telegram(**kwargs: Any) -> tuple[str | None, bool]:
+        _ = kwargs
+        started.set()
+        await release.wait()
+        return "done", False
+
+    monkeypatch.setattr(chat_module, "stream_langgraph_reply_to_telegram", _fake_stream_langgraph_reply_to_telegram)
+    drain = ShutdownDrain(timeout_seconds=1)
+    touch_active_turns: list[int] = []
+
+    def _touch_assistant_message(_chat_id: int) -> None:
+        touch_active_turns.append(drain.status().active_turns)
+
+    fake_store.touch_assistant_message = _touch_assistant_message  # type: ignore[method-assign]
+
+    turn_task = asyncio.create_task(
+        chat_module.handle_telegram_text(
+            body={"message": {"chat": {"id": 1}, "from": {"id": 100}, "text": "hi"}},
+            bot_token="123:abc",
+            agent_runtime=object(),
+            shutdown_drain=drain,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    drain_task = asyncio.create_task(drain.drain())
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+
+    release.set()
+
+    assert await asyncio.wait_for(turn_task, timeout=1) is None
+    assert await asyncio.wait_for(drain_task, timeout=1) is True
+    assert drain.status().active_turns == 0
+    assert touch_active_turns == [1]


### PR DESCRIPTION
## Summary
- Add a process-local shutdown drain that tracks active web and Telegram owner turns.
- Reject new web chat / Telegram webhook turns once the old process is draining, and make `/healthz` return 503 during drain.
- Align Railway overlap/draining config and Uvicorn graceful shutdown timeout with `OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS`.
- Document the graceful deploy behavior in architecture and deployment docs.

## Why
Railway redeploys could interrupt an in-flight Telegram agent loop before the final message was sent. This gives active turns a bounded completion window while idle deploys still switch immediately.

## Linear
OPE-95

## Tests
- `uv run ruff check src/opentulpa/core/shutdown_drain.py src/opentulpa/api/app.py src/opentulpa/api/routes/health.py src/opentulpa/api/routes/telegram_webhook.py src/opentulpa/api/routes/generic_chat.py src/opentulpa/interfaces/telegram/chat_service.py src/opentulpa/__main__.py tests/test_shutdown_drain.py tests/test_telegram_media_typing.py tests/test_internal_api_auth.py tests/test_main_bootstrap.py`
- `uv run pytest tests/test_shutdown_drain.py tests/test_telegram_media_typing.py tests/test_internal_api_auth.py tests/test_main_bootstrap.py -q`
- `uv run pytest tests/test_generic_chat_routes.py tests/test_web_events.py tests/test_telegram_interactive_mailbox.py tests/test_telegram_workflow_setup_mode.py tests/test_telegram_support_bindings.py tests/test_telegram_fresh_command.py -q`
- `git diff --check`