### PR TITLE
Fix natural web chat streaming

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -1310,32 +1310,41 @@ def build_runtime_graph(runtime: Any):
         )
         model_with_tools = runtime.model_with_tools_for_turn_mode(turn_mode)
         assert model_with_tools is not None
+        call_context = {
+            "call_site": "graph_agent",
+            "trace_id": state.get("agent_trace_id"),
+            "thread_id": thread_id,
+            "customer_id": customer_id,
+            "turn_mode": turn_mode,
+            "prompt_mode": prompt_mode,
+            "_langfuse_graph_callback_covers_call": bool(
+                state.get("langfuse_graph_callback_attached")
+            ),
+            "prompt_sections": prompt_section_names,
+            "stable_prefix_count": stable_prefix_count,
+            "stable_prefix_tokens": stable_prefix_tokens,
+            "frozen_late_tokens": frozen_late_tokens,
+            "dynamic_late_tokens": dynamic_late_tokens,
+            "older_history_tokens": older_history_tokens,
+            "latest_turn_tokens": latest_turn_tokens,
+            "prompt_overhead_tokens": prompt_overhead_tokens,
+            "history_message_count": len(actual_history_messages),
+            "raw_chat_history_count": raw_chat_history_count,
+            "raw_tool_history_count": raw_tool_history_count,
+            "protected_history_count": protected_history_count,
+            "optional_context_messages": optional_context_messages,
+        }
+        stream_model_calls = bool(state.get("stream_model_calls"))
+        astream_fn = getattr(runtime, "astream_model", None)
         ainvoke_fn = getattr(runtime, "ainvoke_model", None)
-        if callable(ainvoke_fn):
-            call_context = {
-                "call_site": "graph_agent",
-                "trace_id": state.get("agent_trace_id"),
-                "thread_id": thread_id,
-                "customer_id": customer_id,
-                "turn_mode": turn_mode,
-                "prompt_mode": prompt_mode,
-                "_langfuse_graph_callback_covers_call": bool(
-                    state.get("langfuse_graph_callback_attached")
-                ),
-                "prompt_sections": prompt_section_names,
-                "stable_prefix_count": stable_prefix_count,
-                "stable_prefix_tokens": stable_prefix_tokens,
-                "frozen_late_tokens": frozen_late_tokens,
-                "dynamic_late_tokens": dynamic_late_tokens,
-                "older_history_tokens": older_history_tokens,
-                "latest_turn_tokens": latest_turn_tokens,
-                "prompt_overhead_tokens": prompt_overhead_tokens,
-                "history_message_count": len(actual_history_messages),
-                "raw_chat_history_count": raw_chat_history_count,
-                "raw_tool_history_count": raw_tool_history_count,
-                "protected_history_count": protected_history_count,
-                "optional_context_messages": optional_context_messages,
-            }
+        if stream_model_calls and callable(astream_fn):
+            response = await astream_fn(
+                model_with_tools,
+                model_messages,
+                stable_prefix_count=stable_prefix_count,
+                call_context=call_context,
+            )
+        elif callable(ainvoke_fn):
             response = await ainvoke_fn(
                 model_with_tools,
                 model_messages,

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -12,7 +12,7 @@ from langchain.chat_models import init_chat_model
 from langchain_openrouter import ChatOpenRouter
 from pydantic import BaseModel
 
-from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage
 from opentulpa.agent.utils import content_to_text as _content_to_text
 
 logger = logging.getLogger(__name__)
@@ -373,6 +373,37 @@ def supports_ainvoke_kwargs(target: Any, kwargs: dict[str, Any]) -> bool:
     return all(key in sig.parameters for key in kwargs)
 
 
+def supports_astream_kwargs(target: Any, kwargs: dict[str, Any]) -> bool:
+    if not kwargs:
+        return False
+    astream = getattr(target, "astream", None)
+    if not callable(astream):
+        return False
+    try:
+        sig = inspect.signature(astream)
+    except (TypeError, ValueError):
+        return False
+    params = sig.parameters.values()
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params):
+        return True
+    return all(key in sig.parameters for key in kwargs)
+
+
+def _ai_message_from_stream_chunk(chunk: Any) -> AIMessage:
+    if isinstance(chunk, AIMessage):
+        return chunk
+    content = getattr(chunk, "content", "")
+    return AIMessage(
+        content=content,
+        additional_kwargs=dict(getattr(chunk, "additional_kwargs", {}) or {}),
+        response_metadata=dict(getattr(chunk, "response_metadata", {}) or {}),
+        id=getattr(chunk, "id", None),
+        tool_calls=list(getattr(chunk, "tool_calls", []) or []),
+        invalid_tool_calls=list(getattr(chunk, "invalid_tool_calls", []) or []),
+        usage_metadata=getattr(chunk, "usage_metadata", None),
+    )
+
+
 async def ainvoke_model(
     runtime: Any,
     model: Any,
@@ -445,6 +476,97 @@ async def ainvoke_model(
     if last_exc is not None:
         raise last_exc
     raise RuntimeError("Model invocation failed without attempts.")
+
+
+async def astream_model(
+    runtime: Any,
+    model: Any,
+    messages: list[Any],
+    *,
+    model_name: str | None = None,
+    stable_prefix_count: int = 0,
+    call_context: dict[str, Any] | None = None,
+) -> Any:
+    resolved_model_name = runtime._resolve_model_name_for_runtime_call(
+        model, explicit_name=model_name
+    )
+    prepared_messages = runtime.prepare_messages_for_prompt_cache(
+        list(messages),
+        model_name=resolved_model_name,
+        stable_prefix_count=stable_prefix_count,
+    )
+    base_invoke_extras = runtime.model_invoke_extras(model_name=resolved_model_name)
+    attempts = runtime._model_request_attempts(model_name=resolved_model_name)
+    last_exc: Exception | None = None
+    for attempt_index, attempt in enumerate(attempts):
+        invoke_extras = deep_merge_dicts(
+            dict(base_invoke_extras),
+            dict(attempt.get("invoke_extras") or {}),
+        )
+        attempt_context = dict(call_context or {})
+        attempt_context.update(dict(attempt.get("call_context") or {}))
+        attempt_context["provider_attempt_name"] = (
+            str(attempt.get("name") or "").strip() or "default"
+        )
+        attempt_context["provider_attempt_index"] = attempt_index + 1
+        attempt_context["provider_attempt_count"] = len(attempts)
+        callback_target = runtime._model_with_callbacks(model, call_context=attempt_context)
+        astream = getattr(callback_target, "astream", None)
+        if not callable(astream):
+            return await ainvoke_model(
+                runtime,
+                model,
+                messages,
+                model_name=resolved_model_name,
+                stable_prefix_count=stable_prefix_count,
+                call_context=call_context,
+            )
+        response: Any | None = None
+        error_text: str | None = None
+        try:
+            accumulated: Any | None = None
+            if supports_astream_kwargs(callback_target, invoke_extras):
+                stream = astream(prepared_messages, **invoke_extras)
+            else:
+                stream = astream(prepared_messages)
+            async for chunk in stream:
+                accumulated = chunk if accumulated is None else accumulated + chunk
+            if accumulated is None:
+                response = AIMessage(content="")
+            else:
+                response = _ai_message_from_stream_chunk(accumulated)
+            return response
+        except Exception as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            last_exc = exc
+            if attempt_index + 1 >= len(attempts):
+                raise
+            logger.warning(
+                "Streaming model invocation via %s failed for %s; retrying with next provider route: %s",
+                attempt_context["provider_attempt_name"],
+                resolved_model_name,
+                error_text,
+            )
+            runtime.log_behavior_event(
+                event="llm.provider_fallback",
+                model_name=resolved_model_name,
+                failed_provider_attempt=attempt_context["provider_attempt_name"],
+                next_provider_attempt=str(attempts[attempt_index + 1].get("name") or "").strip()
+                or "default",
+                error=error_text,
+            )
+        finally:
+            runtime._record_llm_call_trace(
+                model_name=resolved_model_name,
+                prepared_messages=prepared_messages,
+                stable_prefix_count=stable_prefix_count,
+                response=response,
+                error=error_text,
+                call_context=attempt_context,
+            )
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Streaming model invocation failed without attempts.")
 
 
 async def invoke_structured_model[StructuredModelT: BaseModel](

--- a/src/opentulpa/agent/models.py
+++ b/src/opentulpa/agent/models.py
@@ -45,5 +45,6 @@ class AgentState(TypedDict, total=False):
     workflow_setup_repair_instruction: str
     frozen_prompt_context: dict[str, Any] | None
     frozen_history_projection: dict[str, Any] | None
+    stream_model_calls: bool
     remaining_steps: RemainingSteps
     loop_limit_status_update_sent: bool

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1572,6 +1572,24 @@ class OpenTulpaLangGraphRuntime:
             call_context=call_context,
         )
 
+    async def astream_model(
+        self,
+        model: Any,
+        messages: list[Any],
+        *,
+        model_name: str | None = None,
+        stable_prefix_count: int = 0,
+        call_context: dict[str, Any] | None = None,
+    ) -> Any:
+        return await _model_pool.astream_model(
+            self,
+            model,
+            messages,
+            model_name=model_name,
+            stable_prefix_count=stable_prefix_count,
+            call_context=call_context,
+        )
+
     @staticmethod
     def _looks_like_provisional_reply(text: str) -> bool:
         candidate = " ".join(str(text or "").split()).strip()
@@ -2934,6 +2952,7 @@ class OpenTulpaLangGraphRuntime:
             "workflow_setup_repair_instruction": "",
             "frozen_prompt_context": None,
             "frozen_history_projection": None,
+            "stream_model_calls": False,
             **skill_state,
         }
 
@@ -3353,6 +3372,8 @@ class OpenTulpaLangGraphRuntime:
         include_pending_context: bool = True,
         forced_skill_names: list[str] | None = None,
         prompt_mode_override: str | None = None,
+        stream_precommit_seconds: float | None = None,
+        stream_incremental_deltas: bool = False,
     ) -> AsyncIterator[str]:
         await self.start()
         assert self._graph is not None
@@ -3438,6 +3459,7 @@ class OpenTulpaLangGraphRuntime:
                 prompt_mode_override=prompt_mode_override,
             )
             config = prepared.config
+            prepared.graph_input["stream_model_calls"] = True
             segment_accumulated = ""
             stream_key = ""
             yielded_any = False
@@ -3448,7 +3470,11 @@ class OpenTulpaLangGraphRuntime:
                 str(os.environ.get("AGENT_STREAM_NO_VISIBLE_PROGRESS_SECONDS", "210")).strip()
                 or "210"
             )
-            stream_precommit_seconds = STREAM_PRECOMMIT_SECONDS
+            effective_stream_precommit_seconds = (
+                STREAM_PRECOMMIT_SECONDS
+                if stream_precommit_seconds is None
+                else max(0.0, float(stream_precommit_seconds))
+            )
             stream_total_chunks = 0
             stream_agent_chunks = 0
             stream_tool_chunks = 0
@@ -3460,6 +3486,7 @@ class OpenTulpaLangGraphRuntime:
             buffered_visible = ""
             buffered_visible_truncated = False
             buffered_visible_source_chars = 0
+            emitted_visible_text = ""
             pending_progress_text = "Working on it…"
             self.log_behavior_event(
                 event="turn_stream_loop_start",
@@ -3467,14 +3494,14 @@ class OpenTulpaLangGraphRuntime:
                 thread_id=thread_id,
                 customer_id=customer_id,
                 stream_no_visible_timeout_s=stream_no_visible_timeout_s,
-                stream_precommit_seconds=stream_precommit_seconds,
+                stream_precommit_seconds=effective_stream_precommit_seconds,
                 turn_mode=normalized_turn_mode,
             )
 
             def _precommit_active() -> bool:
-                if stream_precommit_seconds <= 0 or yielded_any:
+                if effective_stream_precommit_seconds <= 0 or yielded_any:
                     return False
-                return (time.monotonic() - stream_started_at) < stream_precommit_seconds
+                return (time.monotonic() - stream_started_at) < effective_stream_precommit_seconds
 
             def _finalize_segment(*, register_links: bool = True) -> None:
                 nonlocal segment_accumulated
@@ -3617,7 +3644,16 @@ class OpenTulpaLangGraphRuntime:
                                 first_visible_yield_ms=first_visible_yield_ms,
                                 turn_mode=normalized_turn_mode,
                             )
-                        yield expanded
+                        visible_output = expanded
+                        if stream_incremental_deltas:
+                            visible_output = (
+                                expanded[len(emitted_visible_text) :]
+                                if emitted_visible_text and expanded.startswith(emitted_visible_text)
+                                else expanded
+                            )
+                            emitted_visible_text = expanded
+                        if visible_output:
+                            yield visible_output
                         if truncated:
                             self.log_behavior_event(
                                 event="turn_stream_reply_truncated",
@@ -3690,7 +3726,17 @@ class OpenTulpaLangGraphRuntime:
                         elapsed_ms=int((time.monotonic() - stream_started_at) * 1000),
                         turn_mode=normalized_turn_mode,
                     )
-                    yield buffered_visible
+                    visible_output = buffered_visible
+                    if stream_incremental_deltas:
+                        visible_output = (
+                            buffered_visible[len(emitted_visible_text) :]
+                            if emitted_visible_text
+                            and buffered_visible.startswith(emitted_visible_text)
+                            else buffered_visible
+                        )
+                        emitted_visible_text = buffered_visible
+                    if visible_output:
+                        yield visible_output
                     if buffered_visible_truncated:
                         self.log_behavior_event(
                             event="turn_stream_reply_truncated",

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -353,16 +353,18 @@ async def _stream_turn(
                     text=effective_text,
                     turn_mode=turn_mode,
                     include_pending_context=include_pending_context,
+                    stream_precommit_seconds=0.0,
+                    stream_incremental_deltas=True,
                 ):
-                    current = str(chunk or "").strip()
-                    if not current:
+                    current = str(chunk or "")
+                    if not current.strip():
                         continue
-                    progress = _progress_message(current)
+                    progress = _progress_message(current.strip())
                     if progress:
                         await queue.put(("status", {"message": progress}))
                         continue
-                    final_text = current
-                    await queue.put(("delta", {"text": current}))
+                    final_text = f"{final_text}{current}"
+                    await queue.put(("delta", {"text": current, "append": True}))
             final_text = str(final_text or "").strip()
             if (
                 turn_mode == "workflow_setup"

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -357,7 +357,7 @@ async def _stream_turn(
                     stream_incremental_deltas=True,
                 ):
                     current = str(chunk or "")
-                    if not current.strip():
+                    if not current:
                         continue
                     progress = _progress_message(current.strip())
                     if progress:

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -46,8 +47,27 @@ class _StreamingRuntime:
         file_result = self.file_sender({"id": "file_123", "original_filename": "demo.pdf"})
         if hasattr(file_result, "__await__"):
             await file_result
+        if kwargs.get("stream_incremental_deltas"):
+            yield "Hello"
+            yield " from web."
+            return
         yield "Hello"
         yield "Hello from web."
+
+
+def _sse_payloads(text: str, event_name: str) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for block in text.split("\n\n"):
+        if f"event: {event_name}" not in block:
+            continue
+        data_lines = [
+            line.removeprefix("data:").strip()
+            for line in block.splitlines()
+            if line.startswith("data:")
+        ]
+        assert data_lines
+        payloads.append(json.loads("\n".join(data_lines)))
+    return payloads
 
 
 def _client(monkeypatch: Any, tmp_path: Any) -> tuple[TestClient, _StreamingRuntime]:
@@ -104,10 +124,16 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert "event: file" in text
     assert "/web/files/file_123/content" in text
     assert "event: delta" in text
+    assert _sse_payloads(text, "delta") == [
+        {"text": "Hello", "append": True},
+        {"text": " from web.", "append": True},
+    ]
     assert "Hello from web." in text
     assert "event: final" in text
     assert runtime.calls[0]["customer_id"] == "telegram_1"
     assert runtime.calls[0]["thread_id"] == "dashboard-owner-1"
+    assert runtime.calls[0]["stream_precommit_seconds"] == 0.0
+    assert runtime.calls[0]["stream_incremental_deltas"] is True
 
 
 def test_web_chat_resolves_bound_telegram_alias(monkeypatch: Any, tmp_path: Any) -> None:

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -12,10 +12,11 @@ from opentulpa.core.config import get_settings
 
 
 class _StreamingRuntime:
-    def __init__(self) -> None:
+    def __init__(self, *, incremental_chunks: list[str] | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
         self.update_sender: Any | None = None
         self.file_sender: Any | None = None
+        self.incremental_chunks = incremental_chunks or ["Hello", " from web."]
 
     async def register_interactive_update_sender(self, *, thread_id: str, sender: Any) -> None:
         assert thread_id
@@ -48,8 +49,8 @@ class _StreamingRuntime:
         if hasattr(file_result, "__await__"):
             await file_result
         if kwargs.get("stream_incremental_deltas"):
-            yield "Hello"
-            yield " from web."
+            for chunk in self.incremental_chunks:
+                yield chunk
             return
         yield "Hello"
         yield "Hello from web."
@@ -77,6 +78,17 @@ def _client(monkeypatch: Any, tmp_path: Any) -> tuple[TestClient, _StreamingRunt
     vault = FileVaultService(root_dir=tmp_path / "vault", db_path=tmp_path / "vault.db")
     app = create_app(agent_runtime=runtime, file_vault_service=vault)
     return TestClient(app), runtime
+
+
+def _client_with_runtime(
+    monkeypatch: Any,
+    tmp_path: Any,
+    runtime: _StreamingRuntime,
+) -> TestClient:
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    get_settings.cache_clear()
+    vault = FileVaultService(root_dir=tmp_path / "vault", db_path=tmp_path / "vault.db")
+    return TestClient(create_app(agent_runtime=runtime, file_vault_service=vault))
 
 
 def test_web_chat_rejects_missing_bearer(monkeypatch: Any, tmp_path: Any) -> None:
@@ -134,6 +146,36 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert runtime.calls[0]["thread_id"] == "dashboard-owner-1"
     assert runtime.calls[0]["stream_precommit_seconds"] == 0.0
     assert runtime.calls[0]["stream_incremental_deltas"] is True
+
+
+def test_web_chat_preserves_whitespace_only_incremental_deltas(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    runtime = _StreamingRuntime(incremental_chunks=["Hello", " ", "world", "\n\n", "Again"])
+    client = _client_with_runtime(monkeypatch, tmp_path, runtime)
+
+    with client.stream(
+        "POST",
+        "/web/chat/turns",
+        headers={"authorization": "Bearer web-secret"},
+        json={
+            "customer_id": "telegram_1",
+            "thread_id": "dashboard-owner-1",
+            "text": "hi",
+        },
+    ) as response:
+        text = response.read().decode("utf-8")
+
+    assert response.status_code == 200
+    assert _sse_payloads(text, "delta") == [
+        {"text": "Hello", "append": True},
+        {"text": " ", "append": True},
+        {"text": "world", "append": True},
+        {"text": "\n\n", "append": True},
+        {"text": "Again", "append": True},
+    ]
+    assert _sse_payloads(text, "final") == [{"text": "Hello world\n\nAgain"}]
 
 
 def test_web_chat_resolves_bound_telegram_alias(monkeypatch: Any, tmp_path: Any) -> None:

--- a/tests/test_runtime_model_streaming.py
+++ b/tests/test_runtime_model_streaming.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Annotated, Any, TypedDict
+
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessageChunk
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage
+from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
+
+
+class _State(TypedDict):
+    messages: Annotated[list[Any], add_messages]
+
+
+@pytest.mark.asyncio
+async def test_astream_model_surfaces_provider_chunks_to_langgraph(tmp_path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="z-ai/glm-5.1",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+    model = FakeListChatModel(responses=["abc"])
+
+    async def agent_node(state: _State) -> dict[str, list[Any]]:
+        response = await runtime.astream_model(
+            model,
+            list(state["messages"]),
+            model_name="z-ai/glm-5.1",
+            call_context={"call_site": "graph_agent"},
+        )
+        return {"messages": [response]}
+
+    builder = StateGraph(_State)
+    builder.add_node("agent", agent_node)
+    builder.add_edge(START, "agent")
+    builder.add_edge("agent", END)
+    graph = builder.compile()
+
+    chunks: list[str] = []
+    async for message_chunk, metadata in graph.astream(
+        {"messages": [HumanMessage(content="hi")]},
+        stream_mode="messages",
+    ):
+        assert metadata.get("langgraph_node") == "agent"
+        chunks.append(str(getattr(message_chunk, "content", "")))
+
+    assert chunks == ["a", "b", "c"]
+
+
+class _StreamingToolCallModel:
+    async def astream(self, _messages: list[Any]):
+        yield AIMessageChunk(
+            content="",
+            tool_call_chunks=[
+                {"name": "fake_tool", "args": "{", "id": "call_1", "index": 0}
+            ],
+        )
+        yield AIMessageChunk(
+            content="",
+            tool_call_chunks=[
+                {"name": None, "args": '"step":1}', "id": None, "index": 0}
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_astream_model_preserves_streamed_tool_calls(tmp_path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="z-ai/glm-5.1",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+
+    response = await runtime.astream_model(
+        _StreamingToolCallModel(),
+        [HumanMessage(content="use a tool")],
+        model_name="z-ai/glm-5.1",
+        call_context={"call_site": "graph_agent"},
+    )
+
+    assert isinstance(response, AIMessage)
+    assert response.tool_calls == [
+        {"name": "fake_tool", "args": {"step": 1}, "id": "call_1", "type": "tool_call"}
+    ]

--- a/tests/test_runtime_reply_limits.py
+++ b/tests/test_runtime_reply_limits.py
@@ -34,6 +34,24 @@ class _OversizedStreamGraph:
         return {"messages": [AIMessage(content="unused")]}
 
 
+class _MultiChunkStreamGraph:
+    async def astream(
+        self,
+        _state: dict[str, Any],
+        *,
+        config: dict[str, Any],
+        stream_mode: str,
+    ) -> AsyncIterator[tuple[AIMessage, dict[str, str]]]:
+        del config, stream_mode
+        yield AIMessage(content="Hello"), {"langgraph_node": "agent"}
+        yield AIMessage(content=" from"), {"langgraph_node": "agent"}
+        yield AIMessage(content=" web."), {"langgraph_node": "agent"}
+
+    async def ainvoke(self, _state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        del config
+        return {"messages": [AIMessage(content="unused")]}
+
+
 def _build_runtime(tmp_path, graph: Any) -> OpenTulpaLangGraphRuntime:
     runtime = object.__new__(OpenTulpaLangGraphRuntime)
     runtime._graph = graph
@@ -102,3 +120,21 @@ async def test_astream_text_truncates_oversized_stream_reply(tmp_path) -> None:
     lines = runtime._behavior_log_path.read_text(encoding="utf-8").strip().splitlines()
     events = [json.loads(line)["event"] for line in lines if line.strip()]
     assert "turn_stream_reply_truncated" in events
+
+
+@pytest.mark.asyncio
+async def test_astream_text_can_emit_incremental_visible_deltas(tmp_path) -> None:
+    runtime = _build_runtime(tmp_path, _MultiChunkStreamGraph())
+
+    chunks: list[str] = []
+    async for chunk in runtime.astream_text(
+        thread_id="chat-stream-deltas",
+        customer_id="telegram_limit",
+        text="draft the post",
+        stream_precommit_seconds=0.0,
+        stream_incremental_deltas=True,
+    ):
+        chunks.append(chunk)
+
+    assert chunks == ["Hello", " from", " web."]
+    assert "".join(chunks) == "Hello from web."


### PR DESCRIPTION
## Summary
- stream provider chunks through LangGraph model calls instead of waiting for full model replies
- add web-only incremental visible delta mode so dashboard SSE receives append deltas instead of accumulated snapshots
- preserve Telegram stream behavior while covering streamed tool-call assembly and web SSE behavior with tests

## Verification
- uv run pytest -q tests/test_generic_chat_routes.py tests/test_runtime_reply_limits.py tests/test_runtime_model_streaming.py tests/test_runtime_stream_fallback.py tests/test_telegram_stream_segments.py tests/test_telegram_stream_timeout.py
- uv run ruff check src/opentulpa/agent/graph_builder.py src/opentulpa/agent/model_pool.py src/opentulpa/agent/models.py src/opentulpa/agent/runtime.py src/opentulpa/api/routes/generic_chat.py tests/test_generic_chat_routes.py tests/test_runtime_reply_limits.py tests/test_runtime_model_streaming.py