### PR TITLE
Stream web chat with provider cadence

### DIFF
--- a/src/opentulpa/agent/context_engineer.py
+++ b/src/opentulpa/agent/context_engineer.py
@@ -71,8 +71,12 @@ class ContextEngineer:
             return mode == "execution"
         if normalized_kind == "task_directive":
             return mode != "literal_chat"
-        if normalized_kind in {"thread_rollup", "skill_discovery", "invoked_skills", "link_aliases"}:
+        if normalized_kind == "skill_discovery":
+            return mode != "literal_chat"
+        if normalized_kind in {"thread_rollup", "invoked_skills", "link_aliases"}:
             return mode != "literal_chat" and bool(should_retrieve)
+        if normalized_kind == "memory_grounding":
+            return mode != "literal_chat"
         return False
 
     @staticmethod

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -356,24 +356,26 @@ def _build_relevant_skill_discovery_context(
     available_skills: Any,
     selected_names: list[str] | None,
 ) -> str:
-    if not isinstance(available_skills, list) or not selected_names:
+    if not isinstance(available_skills, list):
         return ""
-    wanted = {str(name).strip() for name in selected_names if str(name).strip()}
-    if not wanted:
-        return ""
+    wanted = {str(name).strip() for name in selected_names or [] if str(name).strip()}
+    include_all = not wanted
     lines = [
-        "Skills relevant to this task:",
-        "These are discovery hints only. Use skill_get(name) before relying on a skill's actual instructions.",
+        "Available skills registry:",
+        "This is a compact glossary only. If a skill is needed, call skill_get(name) before relying on its instructions.",
     ]
     seen: set[str] = set()
     for item in available_skills:
         if not isinstance(item, dict):
             continue
         name = str(item.get("name", "")).strip()
-        if not name or name not in wanted or name in seen:
+        if not name or name in seen:
+            continue
+        if not include_all and name not in wanted:
             continue
         seen.add(name)
-        description = " ".join(str(item.get("description", "")).split()).strip()
+        description_words = " ".join(str(item.get("description", "")).split()).strip().split()
+        description = " ".join(description_words[:20]).strip()
         scope = str(item.get("scope", "")).strip() or "user"
         if description:
             lines.append(f"- {name} ({scope}): {description[:220]}")
@@ -834,7 +836,7 @@ def build_runtime_graph(runtime: Any):
                 skill_candidates=available_skills,
                 thread_rollup_sections=rollup_sections,
             )
-            if should_retrieve and latest_user and latest_user != cached_query:
+            if latest_user and latest_user != cached_query:
                 if not available_skills:
                     list_skills = getattr(runtime, "_list_available_skills", None)
                     if callable(list_skills):
@@ -842,18 +844,7 @@ def build_runtime_graph(runtime: Any):
                             available_skills = await list_skills(customer_id)
                         except Exception:
                             available_skills = []
-                selected = await runtime._select_relevant_skills(
-                    customer_id=customer_id,
-                    query=latest_user,
-                    candidates=available_skills,
-                    prompt_mode=prompt_mode,
-                    max_skills=3,
-                )
-                skill_names = [
-                    str(item.get("name", "")).strip()
-                    for item in selected
-                    if isinstance(item, dict) and str(item.get("name", "")).strip()
-                ]
+                skill_names = []
                 skill_query = latest_user
             skill_discovery_context = _build_relevant_skill_discovery_context(
                 available_skills=available_skills,
@@ -868,11 +859,19 @@ def build_runtime_graph(runtime: Any):
                 )
                 else None
             )
-            memory_grounding = await runtime._load_memory_grounding_context(
-                customer_id=customer_id,
-                user_text=latest_user,
-                turn_mode=turn_mode,
-                token_budget=500,
+            memory_grounding = (
+                await runtime._load_memory_grounding_context(
+                    customer_id=customer_id,
+                    user_text=latest_user,
+                    turn_mode=turn_mode,
+                    token_budget=500,
+                )
+                if context_engineer.should_include_optional_context(
+                    kind="memory_grounding",
+                    prompt_mode=prompt_mode,
+                    should_retrieve=should_retrieve,
+                )
+                else ""
             )
             thread_rollup = (
                 "\n\n".join(

--- a/src/opentulpa/agent/prompt_classifier.py
+++ b/src/opentulpa/agent/prompt_classifier.py
@@ -34,7 +34,6 @@ _EXECUTION_HINTS = (
     "browse ",
 )
 
-
 def classify_prompt_mode(user_text: str, *, turn_mode: str) -> PromptMode:
     normalized_turn_mode = str(turn_mode or "").strip().lower()
     if normalized_turn_mode == "workflow_setup":

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -2491,64 +2491,8 @@ class OpenTulpaLangGraphRuntime:
         available = (
             candidates if isinstance(candidates, list) else await self._list_available_skills(cid)
         )
-        if not available:
-            return {"skill_names": [], "context": ""}
-        selected = await self._select_relevant_skills(
-            customer_id=cid,
-            query=query,
-            candidates=available,
-            prompt_mode=prompt_mode,
-            max_skills=1,
-        )
-        if not selected:
-            return {"skill_names": [], "context": ""}
-
-        sections: list[str] = []
-        skill_names: list[str] = []
-        total_chars = 0
-        max_total_chars = 9000
-        for item in selected:
-            name = str(item.get("name", "")).strip()
-            if not name:
-                continue
-            try:
-                r = await self._request_with_backoff(
-                    "POST",
-                    "/internal/skills/get",
-                    json_body={
-                        "customer_id": cid,
-                        "name": name,
-                        "include_files": False,
-                        "include_global": True,
-                    },
-                    timeout=8.0,
-                    retries=1,
-                )
-                if r.status_code != 200:
-                    continue
-                payload = r.json()
-                skill = payload.get("skill", {})
-                if not isinstance(skill, dict):
-                    continue
-                skill_md = str(skill.get("skill_markdown", "")).strip()
-                if not skill_md:
-                    continue
-                snippet = (
-                    f"Skill name: {name}\n"
-                    f"Scope: {skill.get('scope', '')}\n"
-                    f"Description: {skill.get('description', '')}\n"
-                    f"Selection reason: {item.get('reason', '')}\n\n"
-                    f"SKILL.md:\n{skill_md[:3500]}"
-                )
-                if total_chars + len(snippet) > max_total_chars:
-                    break
-                sections.append(snippet)
-                skill_names.append(name)
-                total_chars += len(snippet)
-            except Exception:
-                continue
-        context = "\n\n---\n\n".join(sections).strip()
-        return {"skill_names": skill_names, "context": context}
+        del available
+        return {"skill_names": [], "context": ""}
 
     async def _load_skill_context_by_names(
         self,
@@ -2848,22 +2792,10 @@ class OpenTulpaLangGraphRuntime:
                 "active_invoked_skill_names": [],
                 "active_skill_context": "",
             }
-        selected = await self._select_relevant_skills(
-            customer_id=customer_id,
-            query=query,
-            candidates=available_skills,
-            prompt_mode=prompt_mode,
-            max_skills=3,
-        )
-        names = [
-            str(item.get("name", "")).strip()
-            for item in selected
-            if str(item.get("name", "")).strip()
-        ]
         return {
             "prompt_mode": prompt_mode,
             "active_skill_query": query,
-            "active_skill_names": names,
+            "active_skill_names": [],
             "active_available_skills": available_skills,
             "active_skill_discovery_context": "",
             "active_invoked_skill_context": "",

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import mimetypes
+import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from hmac import compare_digest
@@ -347,6 +348,7 @@ async def _stream_turn(
                 )
             else:
                 final_text = ""
+                delta_seq = 0
                 async for chunk in runtime.astream_text(
                     thread_id=thread_id,
                     customer_id=customer_id,
@@ -364,7 +366,18 @@ async def _stream_turn(
                         await queue.put(("status", {"message": progress}))
                         continue
                     final_text = f"{final_text}{current}"
-                    await queue.put(("delta", {"text": current, "append": True}))
+                    delta_seq += 1
+                    await queue.put(
+                        (
+                            "delta",
+                            {
+                                "text": current,
+                                "append": True,
+                                "seq": delta_seq,
+                                "server_received_at_ms": int(time.time() * 1000),
+                            },
+                        )
+                    )
             final_text = str(final_text or "").strip()
             if (
                 turn_mode == "workflow_setup"

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -136,10 +136,11 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert "event: file" in text
     assert "/web/files/file_123/content" in text
     assert "event: delta" in text
-    assert _sse_payloads(text, "delta") == [
-        {"text": "Hello", "append": True},
-        {"text": " from web.", "append": True},
-    ]
+    deltas = _sse_payloads(text, "delta")
+    assert [delta["text"] for delta in deltas] == ["Hello", " from web."]
+    assert [delta["append"] for delta in deltas] == [True, True]
+    assert [delta["seq"] for delta in deltas] == [1, 2]
+    assert all(isinstance(delta["server_received_at_ms"], int) for delta in deltas)
     assert "Hello from web." in text
     assert "event: final" in text
     assert runtime.calls[0]["customer_id"] == "telegram_1"
@@ -168,13 +169,11 @@ def test_web_chat_preserves_whitespace_only_incremental_deltas(
         text = response.read().decode("utf-8")
 
     assert response.status_code == 200
-    assert _sse_payloads(text, "delta") == [
-        {"text": "Hello", "append": True},
-        {"text": " ", "append": True},
-        {"text": "world", "append": True},
-        {"text": "\n\n", "append": True},
-        {"text": "Again", "append": True},
-    ]
+    deltas = _sse_payloads(text, "delta")
+    assert [delta["text"] for delta in deltas] == ["Hello", " ", "world", "\n\n", "Again"]
+    assert [delta["append"] for delta in deltas] == [True, True, True, True, True]
+    assert [delta["seq"] for delta in deltas] == [1, 2, 3, 4, 5]
+    assert all(isinstance(delta["server_received_at_ms"], int) for delta in deltas)
     assert _sse_payloads(text, "final") == [{"text": "Hello world\n\nAgain"}]
 
 

--- a/tests/test_prompt_policy_hardening.py
+++ b/tests/test_prompt_policy_hardening.py
@@ -110,10 +110,28 @@ def test_build_relevant_skill_discovery_context_is_discovery_only() -> None:
         ],
         selected_names=["browser-use-operator"],
     )
-    assert "Skills relevant to this task:" in text
-    assert "Use skill_get(name) before relying on a skill's actual instructions." in text
+    assert "Available skills registry:" in text
+    assert "call skill_get(name)" in text
     assert "browser-use-operator" in text
     assert "routine-schedule-composer" not in text
+
+
+def test_build_relevant_skill_discovery_context_lists_registry_without_selector() -> None:
+    text = _build_relevant_skill_discovery_context(
+        available_skills=[
+            {
+                "name": "browser-use-operator",
+                "description": "Use browser steps for dynamic websites with authenticated pages, JavaScript rendering, screenshots, forms, navigation, session reuse, retries, and extra words that should be trimmed down hard.",
+                "scope": "global",
+            },
+            {"name": "routine-schedule-composer", "description": "Compose robust routine instructions", "scope": "global"},
+        ],
+        selected_names=[],
+    )
+    assert "Available skills registry:" in text
+    assert "browser-use-operator" in text
+    assert "routine-schedule-composer" in text
+    assert "extra words that should be trimmed down hard" not in text
 
 
 def test_tool_validation_helpers_live_in_dedicated_module() -> None:

--- a/tests/test_runtime_pending_context_input.py
+++ b/tests/test_runtime_pending_context_input.py
@@ -992,6 +992,41 @@ async def test_agent_reuses_turn_scoped_available_skills_without_relisting() -> 
 
 
 @pytest.mark.asyncio
+async def test_pre_resolve_skill_state_does_not_call_llm_selector() -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    selector_calls = 0
+
+    async def _list_available_skills(customer_id: str) -> list[dict[str, Any]]:
+        assert customer_id == "telegram_test"
+        return [
+            {
+                "name": "browser-use-operator",
+                "description": "Use browser steps for dynamic websites.",
+                "scope": "global",
+            }
+        ]
+
+    async def _selector(**kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal selector_calls
+        selector_calls += 1
+        del kwargs
+        return []
+
+    runtime._list_available_skills = _list_available_skills  # type: ignore[method-assign]
+    runtime._select_relevant_skills = _selector  # type: ignore[method-assign]
+
+    state = await runtime._pre_resolve_skill_state(
+        customer_id="telegram_test",
+        user_text="use browser if needed",
+        prompt_mode="task_chat",
+    )
+
+    assert selector_calls == 0
+    assert state["active_skill_names"] == []
+    assert state["active_available_skills"][0]["name"] == "browser-use-operator"
+
+
+@pytest.mark.asyncio
 async def test_interactive_prompt_keeps_core_policy_as_stable_prefix() -> None:
     runtime = object.__new__(OpenTulpaLangGraphRuntime)
     captured: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- Preserve whitespace-only web chat stream deltas.
- Add per-delta sequence and receive timestamp metadata to web chat SSE.
- Send a compact available-skills registry instead of running a pre-chat skill selector.
- Avoid memory grounding for literal chat prompts.

## Validation
- `uv run ruff check src/opentulpa/agent/context_engineer.py src/opentulpa/agent/graph_builder.py src/opentulpa/agent/prompt_classifier.py src/opentulpa/agent/runtime.py src/opentulpa/api/routes/generic_chat.py tests/test_generic_chat_routes.py tests/test_prompt_policy_hardening.py tests/test_runtime_pending_context_input.py`
- `uv run pytest -q tests/test_generic_chat_routes.py tests/test_runtime_pending_context_input.py tests/test_prompt_policy_hardening.py tests/test_prompt_cache_split.py tests/test_llm_call_tracing.py tests/test_runtime_model_streaming.py`
