### PR TITLE
Limit routine Telegram notifications to direct owner chats

### DIFF
--- a/src/opentulpa/application/wake_orchestrator.py
+++ b/src/opentulpa/application/wake_orchestrator.py
@@ -114,6 +114,18 @@ class WakeOrchestrator:
             return text
         return text[:1197].rstrip() + "..."
 
+    @staticmethod
+    def _direct_owner_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        direct_slots: list[dict[str, Any]] = []
+        for slot in slots:
+            if str(slot.get("role", "")).strip() == "support":
+                continue
+            with suppress(Exception):
+                chat_id = int(slot["chat_id"])
+                if chat_id > 0:
+                    direct_slots.append(slot)
+        return direct_slots
+
     async def handle_event(self, body: dict[str, Any]) -> None:
         wake_type = str(body.get("type", "")).strip()
         if wake_type not in {"task_event", "routine_event"}:
@@ -286,8 +298,7 @@ class WakeOrchestrator:
             delivery_slots: list[dict[str, Any]] = []
             with suppress(Exception):
                 delivery_slots = self._get_telegram_chat().find_session_slots(customer_id)
-            owner_slots = [slot for slot in delivery_slots if str(slot.get("role", "")).strip() != "support"]
-            delivery_slots = owner_slots or delivery_slots[:1]
+            delivery_slots = self._direct_owner_slots(delivery_slots)
             if not delivery_slots:
                 self._record_routine_execution(
                     customer_id=customer_id,
@@ -394,6 +405,7 @@ class WakeOrchestrator:
         routine_slots: list[dict[str, Any]] = []
         with suppress(Exception):
             routine_slots = self._get_telegram_chat().find_session_slots(customer_id)
+        routine_slots = self._direct_owner_slots(routine_slots)
         if not routine_slots:
             self._record_routine_execution(
                 customer_id=customer_id,

--- a/tests/test_wake_orchestrator.py
+++ b/tests/test_wake_orchestrator.py
@@ -157,6 +157,48 @@ async def test_routine_event_notifies_and_records_execution() -> None:
 
 
 @pytest.mark.asyncio
+async def test_routine_event_notifies_direct_owner_chats_only() -> None:
+    settings = SimpleNamespace(telegram_bot_token="test-token")
+    context_events = _FakeContextEvents()
+    chat = _FakeTelegramChat()
+    chat.slots = [
+        {"chat_id": 166, "role": "owner"},
+        {"chat_id": -1003941778604, "role": "owner"},
+        {"chat_id": 9900, "role": "support"},
+    ]
+    client = _FakeTelegramClient()
+    runtime = _FakeRuntime(result="routine done")
+
+    orchestrator = WakeOrchestrator(
+        settings=settings,
+        get_context_events=lambda: context_events,
+        get_telegram_chat=lambda: chat,
+        get_telegram_client=lambda: client,
+        get_agent_runtime=lambda: runtime,
+    )
+
+    await orchestrator.handle_event(
+        {
+            "type": "routine_event",
+            "event_type": "scheduled",
+            "customer_id": "telegram_166",
+            "routine_id": "rtn_123",
+            "routine_name": "Test Routine",
+            "notify_user": True,
+            "payload": {
+                "customer_id": "telegram_166",
+                "notify_user": True,
+                "instruction": "Check for AI news and summarize it.",
+            },
+        }
+    )
+
+    assert [item["chat_id"] for item in client.sent] == [166]
+    payload = context_events.events[-1]["payload"]
+    assert payload["notified_chat_ids"] == [166]
+
+
+@pytest.mark.asyncio
 async def test_routine_event_silent_mode_still_executes_and_backlogs() -> None:
     settings = SimpleNamespace(telegram_bot_token="test-token")
     context_events = _FakeContextEvents()


### PR DESCRIPTION
## Summary

Fixes OPE-110 and protects OPE-111's web-delivery intent.

Scheduled routine notifications now filter Telegram delivery slots to direct owner chats only:

- skips support slots
- skips Telegram group/supergroup chats ()
- keeps routine execution recording and web event delivery unchanged

## Root Cause

Generic routine delivery sent the execution summary to every Telegram session slot for the same customer. Group chats can share that customer id, so personal routine output could broadcast into groups.

## Validation

- ......                                                                   [100%]
6 passed in 0.62s -> 6 passed
- All checks passed! -> passed