### PR TITLE
Add intake draft approval workflow

### DIFF
--- a/src/opentulpa/agent/tools/intake_workflow_tools.py
+++ b/src/opentulpa/agent/tools/intake_workflow_tools.py
@@ -68,6 +68,26 @@ def _validate_intake_sink_request(*, sink_type: str, sink_config: dict[str, Any]
     return None
 
 
+def _active_thread_id(runtime: Any, explicit_thread_id: str | None) -> str:
+    safe_thread = str(explicit_thread_id or "").strip()
+    if safe_thread:
+        return safe_thread
+    getter = getattr(runtime, "get_active_thread_id", None)
+    if callable(getter):
+        safe_thread = str(getter() or "").strip()
+    if safe_thread:
+        return safe_thread
+    return str(getattr(runtime, "_active_thread_id", "") or "").strip()
+
+
+def _default_reply_mode_for_origin(*, channel: str, thread_id: str) -> str:
+    safe_channel = str(channel or "").strip().lower()
+    if safe_channel == "telegram_business_dm":
+        return "auto"
+    safe_thread = str(thread_id or "").strip().lower()
+    if safe_thread.startswith("dashboard-owner-"):
+        return "draft"
+    return "auto"
 
 
 def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
@@ -88,6 +108,7 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         knowledge_file_ids: list[str] | None = None,
         notify_user: bool = True,
         enabled: bool = True,
+        reply_mode: str = "",
         workflow_id: str | None = "",
         thread_id: str = "",
         execution_origin: str | None = None,
@@ -132,6 +153,11 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         - If a sink needs human-readable or localized column names, put those labels in
           sink_config.field_mapping; do not change required_fields ids.
         - source_config is optional.
+        - reply_mode controls lead-facing replies:
+          - auto sends replies immediately.
+          - draft stores replies for owner approval in the web dashboard before sending.
+          - If omitted, dashboard/web-created Instagram intake workflows default to draft.
+          - Telegram-created workflows and Telegram Business workflows use auto; Telegram does not support intake draft approval.
         - If source_config.conversation_id is omitted, the workflow scans recent conversations
           for the configured source instead of pinning one specific thread.
         - By default, do not filter inbound messages by intent before the workflow can reply.
@@ -172,13 +198,21 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         - For generic_composio_write, prefer:
           sink_config={"toolkit": "...", "operation_hint": "...", "field_mapping": {...}, "static_arguments": {...}}
         """
-        _ = thread_id, execution_origin, preapproved, guard_context
+        _ = execution_origin, preapproved, guard_context
         safe_customer = require_customer_id(runtime)
         safe_name = str(name or "").strip()
         safe_intent = str(intent_description or "").strip()
         safe_channel = str(channel or "").strip() or "instagram_dm"
         safe_provider = str(provider or "").strip() or "composio"
         safe_schedule = "" if safe_channel == "telegram_business_dm" else (str(schedule or "").strip() or "*/5 * * * *")
+        safe_thread_id = _active_thread_id(runtime, thread_id)
+        requested_reply_mode = str(reply_mode or "").strip().lower()
+        safe_reply_mode = requested_reply_mode or _default_reply_mode_for_origin(
+            channel=safe_channel,
+            thread_id=safe_thread_id,
+        )
+        if safe_channel == "telegram_business_dm":
+            safe_reply_mode = "auto"
         safe_sink_type = str(sink_type or "").strip()
         safe_workflow_id = _normalize_optional_id(workflow_id)
         safe_required_fields = _unique_string_list(required_fields)
@@ -206,6 +240,8 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
             return {"error": "intake_workflow_upsert failed: sink_type is required"}
         if not safe_sink_config:
             return {"error": "intake_workflow_upsert failed: sink_config is required"}
+        if safe_reply_mode not in {"auto", "draft"}:
+            return {"error": "intake_workflow_upsert failed: reply_mode must be auto|draft"}
         sink_error = _validate_intake_sink_request(
             sink_type=safe_sink_type,
             sink_config=safe_sink_config,
@@ -234,6 +270,7 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
                 "schedule": safe_schedule,
                 "notify_user": bool(notify_user),
                 "enabled": bool(enabled),
+                "reply_mode": safe_reply_mode,
             },
             timeout=20.0,
         )

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -575,6 +575,7 @@ def create_app(
             and not path.startswith("/webhook/")
             and path != "/web/events"
             and not path.startswith("/web/chat/")
+            and not path.startswith("/web/intake/drafts/")
             and not path.startswith("/web/files/")
             and not path.startswith("/web/local-files/")
             and path not in public_health_paths
@@ -660,6 +661,7 @@ def create_app(
         get_intake_workflows=get_intake_workflows,
         get_workflow_setup_service=get_workflow_setup_service,
         resolve_customer_id=profile_service.resolve_customer_id,
+        web_token=settings.opentulpa_web_token,
     )
     register_telegram_business_routes(
         app,

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -158,10 +158,13 @@ def register_intake_workflow_routes(
     async def internal_intake_drafts_discard(request: Request) -> Any:
         service = get_intake_workflows()
         body = await request.json()
-        draft = service.discard_draft(
-            customer_id=resolve_body_customer_id(body, resolve_customer_id),
-            draft_id=str(body.get("draft_id", "")).strip(),
-        )
+        try:
+            draft = service.discard_draft(
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
+                draft_id=str(body.get("draft_id", "")).strip(),
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
         if draft is None:
             return JSONResponse(status_code=404, content={"detail": "draft not found"})
         return {"ok": True, "draft": draft}

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from collections.abc import Callable
 from typing import Any
 
@@ -17,8 +18,17 @@ def register_intake_workflow_routes(
     get_intake_workflows: Callable[[], Any],
     get_workflow_setup_service: Callable[[], Any],
     resolve_customer_id: Callable[[str], str] | None = None,
+    web_token: str | None = None,
 ) -> None:
     """Register internal intake workflow endpoints."""
+
+    def _authorized_web_request(request: Request) -> bool:
+        expected = str(web_token or "").strip()
+        if not expected:
+            return False
+        header = str(request.headers.get("authorization", "") or "").strip()
+        scheme, _, token = header.partition(" ")
+        return scheme.lower() == "bearer" and hmac.compare_digest(token.strip(), expected)
 
     @app.post("/internal/intake/workflows/upsert")
     async def internal_intake_workflows_upsert(request: Request) -> Any:
@@ -44,6 +54,7 @@ def register_intake_workflow_routes(
                 schedule=str(body.get("schedule", "*/5 * * * *")).strip() or "*/5 * * * *",
                 notify_user=bool(body.get("notify_user", True)),
                 enabled=bool(body.get("enabled", True)),
+                reply_mode=str(body.get("reply_mode", "auto")).strip() or "auto",
             )
         except Exception as exc:
             return JSONResponse(status_code=400, content={"detail": str(exc)})
@@ -102,6 +113,96 @@ def register_intake_workflow_routes(
         )
         status_code = 200 if bool(result.get("ok", False)) else 400
         return JSONResponse(status_code=status_code, content=result)
+
+    @app.post("/internal/intake/drafts/list")
+    async def internal_intake_drafts_list(request: Request) -> Any:
+        service = get_intake_workflows()
+        body = await request.json()
+        drafts = service.list_drafts(
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
+            workflow_id=str(body.get("workflow_id", "")).strip() or None,
+            status=str(body.get("status", "pending")).strip().lower(),
+            limit=int(body.get("limit", 50) or 50),
+        )
+        return {"ok": True, "drafts": drafts}
+
+    @app.post("/internal/intake/drafts/get")
+    async def internal_intake_drafts_get(request: Request) -> Any:
+        service = get_intake_workflows()
+        body = await request.json()
+        draft = service.get_draft(
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
+            draft_id=str(body.get("draft_id", "")).strip(),
+        )
+        if draft is None:
+            return JSONResponse(status_code=404, content={"detail": "draft not found"})
+        return {"ok": True, "draft": draft}
+
+    @app.post("/internal/intake/drafts/edit")
+    async def internal_intake_drafts_edit(request: Request) -> Any:
+        service = get_intake_workflows()
+        body = await request.json()
+        try:
+            draft = service.edit_draft(
+                customer_id=resolve_body_customer_id(body, resolve_customer_id),
+                draft_id=str(body.get("draft_id", "")).strip(),
+                reply_text=str(body.get("reply_text", "") or ""),
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        if draft is None:
+            return JSONResponse(status_code=404, content={"detail": "draft not found"})
+        return {"ok": True, "draft": draft}
+
+    @app.post("/internal/intake/drafts/discard")
+    async def internal_intake_drafts_discard(request: Request) -> Any:
+        service = get_intake_workflows()
+        body = await request.json()
+        draft = service.discard_draft(
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
+            draft_id=str(body.get("draft_id", "")).strip(),
+        )
+        if draft is None:
+            return JSONResponse(status_code=404, content={"detail": "draft not found"})
+        return {"ok": True, "draft": draft}
+
+    @app.post("/internal/intake/drafts/approve")
+    async def internal_intake_drafts_approve(request: Request) -> Any:
+        service = get_intake_workflows()
+        body = await request.json()
+        draft, error = await service.approve_draft(
+            customer_id=resolve_body_customer_id(body, resolve_customer_id),
+            draft_id=str(body.get("draft_id", "")).strip(),
+        )
+        if draft is None:
+            return JSONResponse(status_code=404, content={"detail": "draft not found"})
+        if error is not None:
+            return JSONResponse(status_code=400, content={"detail": error, "draft": draft})
+        return {"ok": True, "draft": draft}
+
+    @app.post("/web/intake/drafts/list")
+    async def web_intake_drafts_list(request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        return await internal_intake_drafts_list(request)
+
+    @app.post("/web/intake/drafts/edit")
+    async def web_intake_drafts_edit(request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        return await internal_intake_drafts_edit(request)
+
+    @app.post("/web/intake/drafts/discard")
+    async def web_intake_drafts_discard(request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        return await internal_intake_drafts_discard(request)
+
+    @app.post("/web/intake/drafts/approve")
+    async def web_intake_drafts_approve(request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        return await internal_intake_drafts_approve(request)
 
     @app.post("/internal/intake/setup/begin")
     async def internal_intake_setup_begin(request: Request) -> Any:

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -20,10 +20,13 @@ from opentulpa.intake.workflow_skill import build_intake_workflow_skill, workflo
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
 from opentulpa.persistence.sqlite import connect_sqlite
 from opentulpa.scheduler.models import Routine
+from opentulpa.web.events import append_web_event
 
 _ALLOWED_CHANNELS = {"instagram_dm", "telegram_business_dm"}
 _ALLOWED_PROVIDERS = {"composio", "telegram_bot_api"}
 _ALLOWED_SINK_TYPES = {"google_sheets_composio", "local_csv", "generic_composio_write"}
+_ALLOWED_REPLY_MODES = {"auto", "draft"}
+_DRAFT_SENDABLE_STATUSES = {"pending", "edited"}
 _DEFAULT_SCHEDULE = "*/5 * * * *"
 _DEFAULT_EDIT_WINDOW = timedelta(hours=2)
 _MAX_LATEST_INBOUND_AGE = timedelta(minutes=1)
@@ -1075,6 +1078,7 @@ class IntakeWorkflowService:
                     notify_user INTEGER NOT NULL,
                     enabled INTEGER NOT NULL,
                     routine_id TEXT NOT NULL,
+                    reply_mode TEXT NOT NULL DEFAULT 'auto',
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
@@ -1130,6 +1134,23 @@ class IntakeWorkflowService:
                 );
                 CREATE INDEX IF NOT EXISTS idx_intake_pending_runs_due
                     ON intake_pending_runs(status, due_at);
+
+                CREATE TABLE IF NOT EXISTS intake_drafts (
+                    draft_id TEXT PRIMARY KEY,
+                    customer_id TEXT NOT NULL,
+                    workflow_id TEXT NOT NULL,
+                    conversation_id TEXT NOT NULL,
+                    recipient_id TEXT NOT NULL,
+                    platform TEXT NOT NULL,
+                    reply_text TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    sent_at TEXT,
+                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                );
+                CREATE INDEX IF NOT EXISTS idx_intake_drafts_scope
+                    ON intake_drafts(customer_id, workflow_id, status, updated_at DESC);
                 """
             )
             self._ensure_cursor_columns(conn)
@@ -1161,6 +1182,7 @@ class IntakeWorkflowService:
             "assistant_instructions": "TEXT NOT NULL DEFAULT ''",
             "business_facts_json": "TEXT NOT NULL DEFAULT '{}'",
             "knowledge_file_ids_json": "TEXT NOT NULL DEFAULT '[]'",
+            "reply_mode": "TEXT NOT NULL DEFAULT 'auto'",
         }
         for column, column_type in required_columns.items():
             if column in existing:
@@ -1212,6 +1234,7 @@ class IntakeWorkflowService:
         schedule: str,
         notify_user: bool,
         enabled: bool,
+        reply_mode: str,
         existing: dict[str, Any] | None,
     ) -> dict[str, Any]:
         safe_customer = str(customer_id or "").strip()
@@ -1226,6 +1249,7 @@ class IntakeWorkflowService:
         safe_assistant_instructions = str(assistant_instructions or "").strip()
         safe_business_facts = _normalize_business_facts(business_facts)
         safe_knowledge_file_ids = _unique_string_list(knowledge_file_ids)
+        safe_reply_mode = str(reply_mode or "auto").strip().lower() or "auto"
         if not safe_customer:
             raise ValueError("customer_id is required")
         if not safe_name:
@@ -1234,11 +1258,14 @@ class IntakeWorkflowService:
             raise ValueError("channel must be instagram_dm|telegram_business_dm")
         if safe_provider not in _ALLOWED_PROVIDERS:
             raise ValueError("provider must be composio|telegram_bot_api")
+        if safe_reply_mode not in _ALLOWED_REPLY_MODES:
+            raise ValueError("reply_mode must be auto|draft")
         if safe_channel == "instagram_dm" and safe_provider != "composio":
             raise ValueError("instagram_dm workflows require provider=composio")
         if safe_channel == "telegram_business_dm" and safe_provider != "telegram_bot_api":
             raise ValueError("telegram_business_dm workflows require provider=telegram_bot_api")
         if safe_channel == "telegram_business_dm":
+            safe_reply_mode = "auto"
             safe_source_config = self._resolve_telegram_business_source_config(
                 customer_id=safe_customer,
                 source_config=safe_source_config,
@@ -1295,6 +1322,7 @@ class IntakeWorkflowService:
             "notify_user": bool(notify_user),
             "enabled": bool(enabled),
             "routine_id": safe_routine_id,
+            "reply_mode": safe_reply_mode,
         }
 
     def _resolve_telegram_business_source_config(
@@ -1503,6 +1531,7 @@ class IntakeWorkflowService:
             "notify_user": bool(row["notify_user"]),
             "enabled": bool(row["enabled"]),
             "routine_id": str(row["routine_id"]),
+            "reply_mode": str(row["reply_mode"] or "auto"),
             "created_at": str(row["created_at"]),
             "updated_at": str(row["updated_at"]),
         }
@@ -1525,6 +1554,111 @@ class IntakeWorkflowService:
             "created_at": str(row["created_at"] or ""),
             "updated_at": str(row["updated_at"] or ""),
         }
+
+    def _hydrate_draft_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        with suppress(json.JSONDecodeError):
+            loaded = json.loads(str(row["metadata_json"] or "{}"))
+            if isinstance(loaded, dict):
+                metadata = loaded
+        return {
+            "draft_id": str(row["draft_id"]),
+            "customer_id": str(row["customer_id"]),
+            "workflow_id": str(row["workflow_id"]),
+            "conversation_id": str(row["conversation_id"]),
+            "recipient_id": str(row["recipient_id"]),
+            "platform": str(row["platform"]),
+            "reply_text": str(row["reply_text"]),
+            "status": str(row["status"]),
+            "created_at": str(row["created_at"] or ""),
+            "updated_at": str(row["updated_at"] or ""),
+            "sent_at": str(row["sent_at"] or ""),
+            "metadata": metadata,
+        }
+
+    def _draft_metadata(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+        conversation: dict[str, Any] | None = None,
+        decision: dict[str, Any] | None = None,
+        active_booking: dict[str, Any] | None = None,
+        recent_completed_booking: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        summary = self._enrich_conversation_summary(
+            workflow=workflow,
+            conversation_summary=conversation_summary,
+        )
+        return {
+            "workflow": {
+                "workflow_id": str(workflow.get("workflow_id", "") or ""),
+                "customer_id": str(workflow.get("customer_id", "") or ""),
+                "channel": str(workflow.get("channel", "") or ""),
+                "provider": str(workflow.get("provider", "") or ""),
+                "source_config": _safe_dict(workflow.get("source_config")),
+            },
+            "workflow_name": str(workflow.get("name", "") or ""),
+            "workflow_id": str(workflow.get("workflow_id", "") or ""),
+            "conversation_id": str(summary.get("conversation_id", "") or ""),
+            "recipient_id": str(summary.get("recipient_id", "") or ""),
+            "platform": self._source_platform(workflow),
+            "reply_mode": "draft",
+            "latest_inbound_message_id": str(
+                summary.get("latest_inbound_message_id", "") or ""
+            ).strip(),
+            "latest_inbound_text": str(
+                summary.get("latest_inbound_message_text_preview", "") or ""
+            ).strip(),
+            "latest_inbound_sender_username": str(
+                summary.get("latest_inbound_sender_username", "") or ""
+            ).strip(),
+            "conversation_summary": summary,
+            "conversation": _safe_dict(conversation),
+            "decision": _safe_dict(decision),
+            "active_booking": _safe_dict(active_booking),
+            "recent_completed_booking": _safe_dict(recent_completed_booking),
+        }
+
+    def _append_draft_web_event(self, draft: dict[str, Any]) -> None:
+        metadata = {
+            **_safe_dict(draft.get("metadata")),
+            "draft_id": str(draft.get("draft_id", "") or ""),
+            "workflow_id": str(draft.get("workflow_id", "") or ""),
+            "conversation_id": str(draft.get("conversation_id", "") or ""),
+            "recipient_id": str(draft.get("recipient_id", "") or ""),
+            "platform": str(draft.get("platform", "") or ""),
+            "status": str(draft.get("status", "") or ""),
+            "reply_mode": "draft",
+        }
+        append_web_event(
+            customer_id=str(draft.get("customer_id", "") or ""),
+            thread_id=f"intake_{draft.get('workflow_id', '')}_{draft.get('conversation_id', '')}",
+            source=str(draft.get("platform", "") or "intake"),
+            kind="draft_reply",
+            text=str(draft.get("reply_text", "") or ""),
+            metadata_json=_json_dumps(metadata),
+        )
+
+    def _append_sent_web_event(self, draft: dict[str, Any]) -> None:
+        metadata = {
+            **_safe_dict(draft.get("metadata")),
+            "draft_id": str(draft.get("draft_id", "") or ""),
+            "workflow_id": str(draft.get("workflow_id", "") or ""),
+            "conversation_id": str(draft.get("conversation_id", "") or ""),
+            "recipient_id": str(draft.get("recipient_id", "") or ""),
+            "platform": str(draft.get("platform", "") or ""),
+            "status": "sent",
+            "reply_mode": "draft",
+        }
+        append_web_event(
+            customer_id=str(draft.get("customer_id", "") or ""),
+            thread_id=f"intake_{draft.get('workflow_id', '')}_{draft.get('conversation_id', '')}",
+            source=str(draft.get("platform", "") or "intake"),
+            kind="assistant_message",
+            text=str(draft.get("reply_text", "") or ""),
+            metadata_json=_json_dumps(metadata),
+        )
 
     @staticmethod
     def _workflow_to_upsert_draft(workflow: dict[str, Any]) -> dict[str, Any]:
@@ -1552,6 +1686,7 @@ class IntakeWorkflowService:
             "schedule": str(workflow.get("schedule", _DEFAULT_SCHEDULE) or _DEFAULT_SCHEDULE),
             "notify_user": bool(workflow.get("notify_user", True)),
             "enabled": bool(workflow.get("enabled", True)),
+            "reply_mode": str(workflow.get("reply_mode", "auto") or "auto"),
         }
 
     def preflight_workflow_payload(
@@ -1574,6 +1709,7 @@ class IntakeWorkflowService:
         schedule: str = _DEFAULT_SCHEDULE,
         notify_user: bool = True,
         enabled: bool = True,
+        reply_mode: str = "auto",
     ) -> dict[str, Any]:
         try:
             normalized = self._normalize_workflow_payload(
@@ -1594,6 +1730,7 @@ class IntakeWorkflowService:
                 schedule=schedule,
                 notify_user=notify_user,
                 enabled=enabled,
+                reply_mode=reply_mode,
                 existing=None,
             )
         except Exception as exc:
@@ -1802,6 +1939,7 @@ class IntakeWorkflowService:
         schedule: str = _DEFAULT_SCHEDULE,
         notify_user: bool = True,
         enabled: bool = True,
+        reply_mode: str = "auto",
     ) -> dict[str, Any]:
         existing = None
         safe_workflow_id = _normalize_optional_id(workflow_id)
@@ -1844,6 +1982,7 @@ class IntakeWorkflowService:
             schedule=schedule,
             notify_user=notify_user,
             enabled=enabled,
+            reply_mode=reply_mode,
             existing=existing,
         )
         now = _utc_now_iso()
@@ -1858,8 +1997,8 @@ class IntakeWorkflowService:
                     intent_description, required_fields_json, field_guidance_json,
                     assistant_instructions, business_facts_json, knowledge_file_ids_json, sink_type,
                     sink_config_json, schedule, notify_user, enabled, routine_id,
-                    created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    reply_mode, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(workflow_id) DO UPDATE SET
                     customer_id=excluded.customer_id,
                     name=excluded.name,
@@ -1878,6 +2017,7 @@ class IntakeWorkflowService:
                     notify_user=excluded.notify_user,
                     enabled=excluded.enabled,
                     routine_id=excluded.routine_id,
+                    reply_mode=excluded.reply_mode,
                     updated_at=excluded.updated_at
                 """,
                 (
@@ -1899,6 +2039,7 @@ class IntakeWorkflowService:
                     1 if workflow["notify_user"] else 0,
                     1 if workflow["enabled"] else 0,
                     workflow["routine_id"],
+                    workflow["reply_mode"],
                     created_at,
                     now,
                 ),
@@ -2002,6 +2143,7 @@ class IntakeWorkflowService:
                 "DELETE FROM intake_pending_runs WHERE workflow_id = ?",
                 (workflow["workflow_id"],),
             )
+            conn.execute("DELETE FROM intake_drafts WHERE workflow_id = ?", (workflow["workflow_id"],))
             conn.commit()
         if self._scheduler is not None:
             with suppress(Exception):
@@ -2749,6 +2891,359 @@ class IntakeWorkflowService:
             )
         return f"unsupported reply source {channel}/{provider}"
 
+    async def _send_or_request_approval(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+        reply_text: str,
+        conversation: dict[str, Any] | None = None,
+        decision: dict[str, Any] | None = None,
+        active_booking: dict[str, Any] | None = None,
+        recent_completed_booking: dict[str, Any] | None = None,
+        approved_draft_id: str = "",
+    ) -> tuple[str | None, dict[str, Any] | None]:
+        if self._reply_requires_approval(workflow) and not approved_draft_id:
+            draft = self.create_draft_reply(
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                reply_text=reply_text,
+                conversation=conversation,
+                decision=decision,
+                active_booking=active_booking,
+                recent_completed_booking=recent_completed_booking,
+            )
+            self._emit_observability(
+                event="intake.reply.approval_pending",
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                draft_id=str(draft.get("draft_id", "") or ""),
+            )
+            return None, draft
+        return await self._send_source_reply(
+            workflow=workflow,
+            conversation_summary=conversation_summary,
+            reply_text=reply_text,
+        ), None
+
+    @staticmethod
+    def _reply_requires_approval(workflow: dict[str, Any]) -> bool:
+        channel = str(workflow.get("channel", "") or "").strip().lower()
+        if channel == "telegram_business_dm":
+            return False
+        return str(workflow.get("reply_mode", "auto") or "auto").strip().lower() == "draft"
+
+    def create_draft_reply(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+        reply_text: str,
+        conversation: dict[str, Any] | None = None,
+        decision: dict[str, Any] | None = None,
+        active_booking: dict[str, Any] | None = None,
+        recent_completed_booking: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        safe_reply = str(reply_text or "").strip()
+        conversation_id = str(conversation_summary.get("conversation_id", "") or "").strip()
+        recipient_id = str(conversation_summary.get("recipient_id", "") or "").strip()
+        if not safe_reply:
+            raise ValueError("draft reply requires non-empty reply_text")
+        if not conversation_id or not recipient_id:
+            raise ValueError("draft reply requires conversation_id and recipient_id")
+        now = _utc_now_iso()
+        draft = {
+            "draft_id": new_short_id("dft"),
+            "customer_id": str(workflow["customer_id"]),
+            "workflow_id": str(workflow["workflow_id"]),
+            "conversation_id": conversation_id,
+            "recipient_id": recipient_id,
+            "platform": self._source_platform(workflow),
+            "reply_text": safe_reply,
+            "status": "pending",
+            "created_at": now,
+            "updated_at": now,
+            "sent_at": "",
+            "metadata": self._draft_metadata(
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                conversation=conversation,
+                decision=decision,
+                active_booking=active_booking,
+                recent_completed_booking=recent_completed_booking,
+            ),
+        }
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO intake_drafts (
+                    draft_id, customer_id, workflow_id, conversation_id, recipient_id, platform,
+                    reply_text, status, created_at, updated_at, sent_at, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    draft["draft_id"],
+                    draft["customer_id"],
+                    draft["workflow_id"],
+                    draft["conversation_id"],
+                    draft["recipient_id"],
+                    draft["platform"],
+                    draft["reply_text"],
+                    draft["status"],
+                    draft["created_at"],
+                    draft["updated_at"],
+                    draft["sent_at"],
+                    _json_dumps(draft["metadata"]),
+                ),
+            )
+            conn.commit()
+        self._append_draft_web_event(draft)
+        return draft
+
+    def list_drafts(
+        self,
+        *,
+        customer_id: str,
+        workflow_id: str | None = None,
+        status: str = "pending",
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        safe_customer = str(customer_id or "").strip()
+        if not safe_customer:
+            return []
+        safe_limit = max(1, min(int(limit), 200))
+        query = "SELECT * FROM intake_drafts WHERE customer_id = ?"
+        params: list[Any] = [safe_customer]
+        if workflow_id:
+            query += " AND workflow_id = ?"
+            params.append(str(workflow_id).strip())
+        if status:
+            query += " AND status = ?"
+            params.append(str(status).strip().lower())
+        query += " ORDER BY updated_at DESC LIMIT ?"
+        params.append(safe_limit)
+        with self._conn() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [self._hydrate_draft_row(row) for row in rows]
+
+    def get_draft(self, *, customer_id: str, draft_id: str) -> dict[str, Any] | None:
+        safe_customer = str(customer_id or "").strip()
+        safe_draft = str(draft_id or "").strip()
+        if not safe_customer or not safe_draft:
+            return None
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM intake_drafts WHERE customer_id = ? AND draft_id = ?",
+                (safe_customer, safe_draft),
+            ).fetchone()
+        return self._hydrate_draft_row(row) if row is not None else None
+
+    def edit_draft(self, *, customer_id: str, draft_id: str, reply_text: str) -> dict[str, Any] | None:
+        draft = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if draft is None:
+            return None
+        if str(draft.get("status", "") or "") not in _DRAFT_SENDABLE_STATUSES:
+            raise ValueError("only pending drafts can be edited")
+        safe_reply = str(reply_text or "").strip()
+        if not safe_reply:
+            raise ValueError("reply_text is required")
+        now = _utc_now_iso()
+        with self._conn() as conn:
+            conn.execute(
+                """
+                UPDATE intake_drafts
+                SET reply_text = ?, status = 'edited', updated_at = ?
+                WHERE customer_id = ? AND draft_id = ?
+                """,
+                (safe_reply, now, customer_id, draft_id),
+            )
+            conn.commit()
+        updated = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if updated is None:
+            raise RuntimeError("draft disappeared after edit")
+        return updated
+
+    def discard_draft(self, *, customer_id: str, draft_id: str) -> dict[str, Any] | None:
+        draft = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if draft is None:
+            return None
+        now = _utc_now_iso()
+        with self._conn() as conn:
+            conn.execute(
+                """
+                UPDATE intake_drafts
+                SET status = 'discarded', updated_at = ?
+                WHERE customer_id = ? AND draft_id = ?
+                """,
+                (now, customer_id, draft_id),
+            )
+            conn.commit()
+        return self.get_draft(customer_id=customer_id, draft_id=draft_id)
+
+    async def approve_draft(self, *, customer_id: str, draft_id: str) -> tuple[dict[str, Any] | None, str | None]:
+        draft = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if draft is None:
+            return None, None
+        original_status = str(draft.get("status", "") or "")
+        if original_status not in _DRAFT_SENDABLE_STATUSES:
+            return draft, "only pending drafts can be approved"
+        now = _utc_now_iso()
+        with self._conn() as conn:
+            claimed = conn.execute(
+                """
+                UPDATE intake_drafts
+                SET status = 'approved', updated_at = ?
+                WHERE customer_id = ? AND draft_id = ? AND status IN ('pending', 'edited')
+                """,
+                (now, customer_id, draft_id),
+            ).rowcount
+            conn.commit()
+        if claimed != 1:
+            current = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+            return current or draft, "draft is already being processed"
+        error: str | None = None
+        sent_reply_text = str(draft.get("reply_text", "") or "")
+        workflow = self.get_workflow(
+            customer_id=customer_id,
+            workflow_id=str(draft.get("workflow_id", "") or ""),
+        )
+        metadata = _safe_dict(draft.get("metadata"))
+        workflow_snapshot = _safe_dict(metadata.get("workflow"))
+        if workflow_snapshot:
+            workflow = {**(workflow or {}), **workflow_snapshot}
+        if workflow is None:
+            error = "draft workflow was not found"
+        else:
+            error, sent_reply_text = await self._resume_approved_draft_send(
+                draft=draft,
+                workflow=workflow,
+                metadata=metadata,
+            )
+        if error is not None:
+            with self._conn() as conn:
+                conn.execute(
+                    """
+                    UPDATE intake_drafts
+                    SET status = ?, updated_at = ?
+                    WHERE customer_id = ? AND draft_id = ? AND status = 'approved'
+                    """,
+                    (original_status, _utc_now_iso(), customer_id, draft_id),
+                )
+                conn.commit()
+            return draft, error
+        now = _utc_now_iso()
+        with self._conn() as conn:
+            conn.execute(
+                """
+                UPDATE intake_drafts
+                SET reply_text = ?, status = 'sent', updated_at = ?, sent_at = ?
+                WHERE customer_id = ? AND draft_id = ?
+                """,
+                (sent_reply_text, now, now, customer_id, draft_id),
+            )
+            conn.commit()
+        sent = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if sent is None:
+            raise RuntimeError("draft disappeared after approval")
+        self._append_sent_web_event(sent)
+        return sent, None
+
+    async def _resume_approved_draft_send(
+        self,
+        *,
+        draft: dict[str, Any],
+        workflow: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> tuple[str | None, str]:
+        draft_id = str(draft.get("draft_id", "") or "").strip()
+        reply_text = str(draft.get("reply_text", "") or "").strip()
+        conversation_id = str(draft.get("conversation_id", "") or "").strip()
+        conversation_summary = {
+            **_safe_dict(metadata.get("conversation_summary")),
+            "conversation_id": conversation_id,
+            "recipient_id": str(draft.get("recipient_id", "") or ""),
+        }
+        conversation = _safe_dict(metadata.get("conversation"))
+        if not conversation:
+            loaded_summary, loaded_conversation, load_error = self._load_source_conversation(
+                workflow=workflow,
+                conversation_id=conversation_id,
+            )
+            if load_error is not None:
+                return load_error, reply_text
+            conversation_summary = {**loaded_summary, **conversation_summary}
+            conversation = loaded_conversation
+        decision = {
+            **_safe_dict(metadata.get("decision")),
+            "reply_action": "send_reply",
+            "reply_text": reply_text,
+        }
+        decision.setdefault("booking_action", "ignore")
+        decision.setdefault("ready_to_save", False)
+        direct_error = await self._send_source_reply(
+            workflow=workflow,
+            conversation_summary=conversation_summary,
+            reply_text=reply_text,
+        )
+        if direct_error is None:
+            return None, reply_text
+        recovery_feedback = [
+            self._build_recovery_feedback(
+                phase="reply_execution",
+                error=direct_error,
+                decision=decision,
+            )
+        ]
+        active_booking = self._get_active_booking(
+            customer_id=str(workflow["customer_id"]),
+            workflow_id=str(workflow["workflow_id"]),
+            conversation_id=conversation_id,
+        )
+        recent_completed_booking = self._get_recent_completed_booking(
+            customer_id=str(workflow["customer_id"]),
+            workflow_id=str(workflow["workflow_id"]),
+            conversation_id=conversation_id,
+        )
+        apply_error = direct_error
+        for _attempt in range(_MAX_DECISION_RECOVERY_ATTEMPTS):
+            next_decision, decide_error = await self._decide_workflow_action(
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                conversation=conversation,
+                active_booking=active_booking,
+                recent_completed_booking=recent_completed_booking,
+                execution_feedback=recovery_feedback,
+            )
+            if decide_error:
+                return decide_error, reply_text
+            applied, apply_error, feedback = await self._apply_decision(
+                workflow=workflow,
+                conversation_summary=conversation_summary,
+                conversation=conversation,
+                active_booking=active_booking,
+                recent_completed_booking=recent_completed_booking,
+                decision=next_decision,
+                approved_draft_id=draft_id,
+            )
+            if apply_error is None:
+                if bool(applied.get("replied", False)):
+                    return None, str(next_decision.get("reply_text", "") or reply_text)
+                return "approved draft recovery completed without sending a reply", reply_text
+            if feedback is None:
+                break
+            recovery_feedback.append(feedback)
+            active_booking = self._get_active_booking(
+                customer_id=str(workflow["customer_id"]),
+                workflow_id=str(workflow["workflow_id"]),
+                conversation_id=conversation_id,
+            )
+            recent_completed_booking = self._get_recent_completed_booking(
+                customer_id=str(workflow["customer_id"]),
+                workflow_id=str(workflow["workflow_id"]),
+                conversation_id=conversation_id,
+            )
+        return apply_error, reply_text
+
     async def run_workflow(
         self,
         *,
@@ -2998,10 +3493,17 @@ class IntakeWorkflowService:
                             booking_id="",
                             reply_text=reply_text,
                         )
-                        reply_error = await self._send_source_reply(
+                        reply_error, draft = await self._send_or_request_approval(
                             workflow=workflow,
                             conversation_summary=cursor_summary,
                             reply_text=reply_text,
+                            conversation=conversation,
+                            decision={
+                                "booking_action": "ignore",
+                                "reply_action": "send_reply",
+                                "reply_text": reply_text,
+                                "ready_to_save": False,
+                            },
                         )
                         if reply_error is not None:
                             errors.append(f"{conversation_id}: {reply_error}")
@@ -3018,6 +3520,45 @@ class IntakeWorkflowService:
                                 conversation_summary=cursor_summary,
                                 phase="reply_execution",
                                 error=reply_error,
+                            )
+                            continue
+                        if draft is not None:
+                            self._emit_observability(
+                                event="intake.apply.ok",
+                                workflow=workflow,
+                                conversation_summary=cursor_summary,
+                                status="approval_pending",
+                                booking_action="ignore",
+                                reply_action=reply_action,
+                                ready_to_save=False,
+                                draft_id=str(draft.get("draft_id", "") or ""),
+                            )
+                            self._set_cursor(
+                                workflow_id=str(workflow["workflow_id"]),
+                                conversation_id=conversation_id,
+                                latest_inbound_message_id=latest_inbound_id,
+                                latest_inbound_message_time=latest_inbound_time,
+                                conversation_updated_time=conversation_updated_time,
+                                latest_outbound_message_id=latest_outbound_id,
+                                agent_action_at=_utc_now_iso(),
+                            )
+                            result_items.append(
+                                {
+                                    "conversation_id": conversation_id,
+                                    "matched": False,
+                                    "status": "approval_pending",
+                                    "draft_id": str(draft.get("draft_id", "") or ""),
+                                    "replied": False,
+                                }
+                            )
+                            self._emit_observability(
+                                event="intake.conversation.complete",
+                                workflow=workflow,
+                                conversation_summary=cursor_summary,
+                                matched=False,
+                                status="approval_pending",
+                                replied=False,
+                                draft_id=str(draft.get("draft_id", "") or ""),
                             )
                             continue
                         self._emit_observability(
@@ -3397,6 +3938,7 @@ class IntakeWorkflowService:
         recent_completed_booking: dict[str, Any] | None,
         decision: dict[str, Any],
         stale_guard: bool = False,
+        approved_draft_id: str = "",
     ) -> tuple[dict[str, Any], str | None, dict[str, Any] | None]:
         booking_action = str(decision.get("booking_action", "ignore") or "ignore").strip().lower()
         ready_to_save = bool(decision.get("ready_to_save"))
@@ -3482,10 +4024,15 @@ class IntakeWorkflowService:
                     booking_id="",
                     reply_text=reply_text,
                 )
-                reply_error = await self._send_source_reply(
+                reply_error, draft = await self._send_or_request_approval(
                     workflow=workflow,
                     conversation_summary=conversation_summary,
                     reply_text=reply_text,
+                    conversation=conversation,
+                    decision=decision,
+                    active_booking=active_booking,
+                    recent_completed_booking=recent_completed_booking,
+                    approved_draft_id=approved_draft_id,
                 )
                 if reply_error is not None:
                     self._emit_observability(
@@ -3508,6 +4055,25 @@ class IntakeWorkflowService:
                         error=reply_error,
                         decision=decision,
                     )
+                if draft is not None:
+                    draft_id = str(draft.get("draft_id", "") or "")
+                    self._emit_observability(
+                        event="intake.apply.ok",
+                        workflow=workflow,
+                        conversation_summary=conversation_summary,
+                        status="approval_pending",
+                        booking_action=booking_action,
+                        reply_action=reply_action,
+                        ready_to_save=ready_to_save,
+                        draft_id=draft_id,
+                    )
+                    return {
+                        "conversation_id": str(conversation_summary.get("conversation_id", "") or ""),
+                        "matched": True,
+                        "status": "approval_pending",
+                        "draft_id": draft_id,
+                        "replied": False,
+                    }, None, None
                 self._emit_observability(
                     event="intake.reply.ok",
                     workflow=workflow,
@@ -3872,10 +4438,15 @@ class IntakeWorkflowService:
                 booking_id=str(target_booking.get("booking_id", "") or "").strip(),
                 reply_text=reply_text,
             )
-            reply_error = await self._send_source_reply(
+            reply_error, draft = await self._send_or_request_approval(
                 workflow=workflow,
                 conversation_summary=conversation_summary,
                 reply_text=reply_text,
+                conversation=conversation,
+                decision=decision,
+                active_booking=active_booking,
+                recent_completed_booking=recent_completed_booking,
+                approved_draft_id=approved_draft_id,
             )
             if reply_error is not None:
                 self._emit_observability(
@@ -3898,6 +4469,30 @@ class IntakeWorkflowService:
                     error=reply_error,
                     decision=decision,
                 )
+            if draft is not None:
+                draft_id = str(draft.get("draft_id", "") or "")
+                self._emit_observability(
+                    event="intake.apply.ok",
+                    workflow=workflow,
+                    conversation_summary=conversation_summary,
+                    status="approval_pending",
+                    booking_id=str(target_booking.get("booking_id", "") or "").strip(),
+                    sink_write_status=str(target_booking.get("sink_write_status", "") or "").strip(),
+                    booking_action=booking_action,
+                    reply_action=reply_action,
+                    ready_to_save=ready_to_save,
+                    saved_summary=saved_summary,
+                    draft_id=draft_id,
+                )
+                return {
+                    "conversation_id": str(conversation_summary.get("conversation_id", "") or ""),
+                    "matched": True,
+                    "status": "approval_pending",
+                    "booking_id": str(target_booking.get("booking_id", "") or ""),
+                    "saved_summary": saved_summary,
+                    "draft_id": draft_id,
+                    "replied": False,
+                }, None, None
             self._emit_observability(
                 event="intake.reply.ok",
                 workflow=workflow,
@@ -3917,13 +4512,16 @@ class IntakeWorkflowService:
             ready_to_save=ready_to_save,
             saved_summary=saved_summary,
         )
-        return {
+        applied_result = {
             "conversation_id": str(conversation_summary.get("conversation_id", "") or ""),
             "matched": True,
             "status": str(target_booking.get("status", "") or "active"),
             "booking_id": str(target_booking.get("booking_id", "") or ""),
             "saved_summary": saved_summary,
-        }, None, None
+        }
+        if reply_action == "send_reply":
+            applied_result["replied"] = True
+        return applied_result, None, None
 
     def _build_recovery_feedback(
         self,

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -592,6 +592,26 @@ class IntakeWorkflowService:
         latest_time = _parse_datetime(latest_summary.get("latest_inbound_message_created_time"))
         return bool(decided_time and latest_time and latest_time > decided_time)
 
+    @classmethod
+    def _draft_stale_error(
+        cls,
+        *,
+        draft_summary: dict[str, Any],
+        latest_summary: dict[str, Any],
+    ) -> str | None:
+        if not cls._latest_inbound_changed(
+            decided_summary=draft_summary,
+            latest_summary=latest_summary,
+        ):
+            return None
+        latest_id = str(latest_summary.get("latest_inbound_message_id", "") or "").strip()
+        if latest_id:
+            return (
+                "draft is stale because a newer inbound message arrived "
+                f"before approval: {latest_id}"
+            )
+        return "draft is stale because a newer inbound message arrived before approval"
+
     def _recover_interrupted_pending_runs(self) -> None:
         with self._conn() as conn:
             conn.execute(
@@ -2904,15 +2924,18 @@ class IntakeWorkflowService:
         approved_draft_id: str = "",
     ) -> tuple[str | None, dict[str, Any] | None]:
         if self._reply_requires_approval(workflow) and not approved_draft_id:
-            draft = self.create_draft_reply(
-                workflow=workflow,
-                conversation_summary=conversation_summary,
-                reply_text=reply_text,
-                conversation=conversation,
-                decision=decision,
-                active_booking=active_booking,
-                recent_completed_booking=recent_completed_booking,
-            )
+            try:
+                draft = self.create_draft_reply(
+                    workflow=workflow,
+                    conversation_summary=conversation_summary,
+                    reply_text=reply_text,
+                    conversation=conversation,
+                    decision=decision,
+                    active_booking=active_booking,
+                    recent_completed_booking=recent_completed_booking,
+                )
+            except ValueError as exc:
+                return str(exc), None
             self._emit_observability(
                 event="intake.reply.approval_pending",
                 workflow=workflow,
@@ -3168,16 +3191,20 @@ class IntakeWorkflowService:
             "conversation_id": conversation_id,
             "recipient_id": str(draft.get("recipient_id", "") or ""),
         }
-        conversation = _safe_dict(metadata.get("conversation"))
-        if not conversation:
-            loaded_summary, loaded_conversation, load_error = self._load_source_conversation(
-                workflow=workflow,
-                conversation_id=conversation_id,
-            )
-            if load_error is not None:
-                return load_error, reply_text
-            conversation_summary = {**loaded_summary, **conversation_summary}
-            conversation = loaded_conversation
+        loaded_summary, loaded_conversation, load_error = self._load_source_conversation(
+            workflow=workflow,
+            conversation_id=conversation_id,
+        )
+        if load_error is not None:
+            return load_error, reply_text
+        stale_error = self._draft_stale_error(
+            draft_summary=conversation_summary,
+            latest_summary=loaded_summary,
+        )
+        if stale_error is not None:
+            return stale_error, reply_text
+        conversation_summary = {**loaded_summary, **conversation_summary}
+        conversation = loaded_conversation or _safe_dict(metadata.get("conversation"))
         decision = {
             **_safe_dict(metadata.get("decision")),
             "reply_action": "send_reply",

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -3042,25 +3042,25 @@ class IntakeWorkflowService:
         draft = self.get_draft(customer_id=customer_id, draft_id=draft_id)
         if draft is None:
             return None
-        if str(draft.get("status", "") or "") not in _DRAFT_SENDABLE_STATUSES:
-            raise ValueError("only pending drafts can be edited")
         safe_reply = str(reply_text or "").strip()
         if not safe_reply:
             raise ValueError("reply_text is required")
         now = _utc_now_iso()
         with self._conn() as conn:
-            conn.execute(
+            changed = conn.execute(
                 """
                 UPDATE intake_drafts
                 SET reply_text = ?, status = 'edited', updated_at = ?
-                WHERE customer_id = ? AND draft_id = ?
+                WHERE customer_id = ? AND draft_id = ? AND status IN ('pending', 'edited')
                 """,
                 (safe_reply, now, customer_id, draft_id),
-            )
+            ).rowcount
             conn.commit()
         updated = self.get_draft(customer_id=customer_id, draft_id=draft_id)
         if updated is None:
             raise RuntimeError("draft disappeared after edit")
+        if changed != 1:
+            raise ValueError("only pending drafts can be edited")
         return updated
 
     def discard_draft(self, *, customer_id: str, draft_id: str) -> dict[str, Any] | None:
@@ -3069,16 +3069,21 @@ class IntakeWorkflowService:
             return None
         now = _utc_now_iso()
         with self._conn() as conn:
-            conn.execute(
+            changed = conn.execute(
                 """
                 UPDATE intake_drafts
                 SET status = 'discarded', updated_at = ?
-                WHERE customer_id = ? AND draft_id = ?
+                WHERE customer_id = ? AND draft_id = ? AND status IN ('pending', 'edited')
                 """,
                 (now, customer_id, draft_id),
-            )
+            ).rowcount
             conn.commit()
-        return self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        updated = self.get_draft(customer_id=customer_id, draft_id=draft_id)
+        if updated is None:
+            raise RuntimeError("draft disappeared after discard")
+        if changed != 1:
+            raise ValueError("only pending drafts can be discarded")
+        return updated
 
     async def approve_draft(self, *, customer_id: str, draft_id: str) -> tuple[dict[str, Any] | None, str | None]:
         draft = self.get_draft(customer_id=customer_id, draft_id=draft_id)

--- a/src/opentulpa/intake/workflow_setup_service.py
+++ b/src/opentulpa/intake/workflow_setup_service.py
@@ -112,6 +112,31 @@ def _normalize_schedule_for_channel(draft: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _default_reply_mode_for_setup_origin(*, channel: str, thread_id: str) -> str:
+    safe_channel = str(channel or "").strip().lower()
+    if safe_channel == "telegram_business_dm":
+        return "auto"
+    safe_thread = str(thread_id or "").strip().lower()
+    if safe_thread.startswith("dashboard-owner-"):
+        return "draft"
+    return "auto"
+
+
+def _normalize_reply_mode_for_origin(draft: dict[str, Any], *, thread_id: str) -> dict[str, Any]:
+    normalized = dict(draft)
+    channel = str(normalized.get("channel", "") or "").strip().lower()
+    if channel == "telegram_business_dm":
+        normalized["reply_mode"] = "auto"
+        return normalized
+    reply_mode = str(normalized.get("reply_mode", "") or "").strip().lower()
+    if reply_mode not in {"auto", "draft"}:
+        normalized["reply_mode"] = _default_reply_mode_for_setup_origin(
+            channel=channel,
+            thread_id=thread_id,
+        )
+    return normalized
+
+
 def _compact_preflight_for_scratchpad(preflight: dict[str, Any]) -> dict[str, Any]:
     sink_preflight = _safe_dict(preflight.get("sink_preflight"))
     dry_run = _safe_dict(sink_preflight.get("dry_run"))
@@ -171,6 +196,7 @@ class WorkflowSetupService:
                     "schedule": "*/5 * * * *",
                     "notify_user": True,
                     "enabled": True,
+                    "reply_mode": "",
                 }
             )
         )
@@ -330,9 +356,11 @@ class WorkflowSetupService:
                     ),
                     "notify_user": bool(workflow_snapshot.get("notify_user", True)),
                     "enabled": bool(workflow_snapshot.get("enabled", True)),
+                    "reply_mode": str(workflow_snapshot.get("reply_mode", "auto") or "auto"),
                 }
             )
             draft = _normalize_schedule_for_channel(draft)
+        draft = _normalize_reply_mode_for_origin(draft, thread_id=thread_id)
         return self._store.create_session(
             customer_id=customer_id,
             thread_id=thread_id,
@@ -364,6 +392,7 @@ class WorkflowSetupService:
         updated_draft = _normalize_local_csv_draft_sink_config(
             _normalize_schedule_for_channel(updated_draft)
         )
+        updated_draft = _normalize_reply_mode_for_origin(updated_draft, thread_id=thread_id)
         updated_scratchpad = _deep_merge(
             _safe_dict(session.get("scratchpad")), _safe_dict(scratchpad_patch)
         )
@@ -382,7 +411,10 @@ class WorkflowSetupService:
         )
         if session is None:
             raise ValueError("active workflow setup session not found")
-        draft = _safe_dict(session.get("draft_upsert"))
+        draft = _normalize_reply_mode_for_origin(
+            _safe_dict(session.get("draft_upsert")),
+            thread_id=thread_id,
+        )
         session_id = str(session.get("session_id", "") or "").strip()
         draft_hash = self._draft_hash(draft)
         cached_preflight = self._cached_ready_preflight(session, draft_hash=draft_hash)
@@ -434,6 +466,7 @@ class WorkflowSetupService:
                 schedule=str(draft.get("schedule", "*/5 * * * *") or "*/5 * * * *"),
                 notify_user=bool(draft.get("notify_user", True)),
                 enabled=bool(draft.get("enabled", True)),
+                reply_mode=str(draft.get("reply_mode", "auto") or "auto"),
             )
             knowledge_preflight = self._preflight_knowledge_scope(
                 customer_id=customer_id,
@@ -661,7 +694,10 @@ class WorkflowSetupService:
         )
         if session is None:
             raise ValueError("active workflow setup session not found")
-        draft = _safe_dict(session.get("draft_upsert"))
+        draft = _normalize_reply_mode_for_origin(
+            _safe_dict(session.get("draft_upsert")),
+            thread_id=thread_id,
+        )
         current_hash = self._draft_hash(draft)
         confirmed_hash = str(session.get("confirmed_draft_hash", "") or "").strip()
         if not confirmed_hash or current_hash != confirmed_hash:

--- a/tests/e2e/scenarios/test_instagram_intake_drafts.py
+++ b/tests/e2e/scenarios/test_instagram_intake_drafts.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from harness.runner import build_harness, close_harness
+from mocks.composio_instagram import build_instagram_conversation
+
+from opentulpa.api.app import create_app
+from opentulpa.integrations.composio import ComposioService
+from opentulpa.scheduler.service import SchedulerService
+
+pytestmark = [pytest.mark.e2e, pytest.mark.ingress]
+
+
+class _DeterministicDraftRuntime:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.behavior_events: list[dict[str, Any]] = []
+        self._link_alias_service = None
+        self._decisions = [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 1.0,
+                "conversation_summary": "Customer wants a same-day booking.",
+                "extracted_fields": {},
+                "missing_fields": ["vehicle"],
+                "reply_action": "send_reply",
+                "reply_text": "BROKEN_PAYLOAD",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "First draft deliberately exercises invalid Composio payload recovery.",
+            },
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 1.0,
+                "conversation_summary": "Retry after Composio rejected the approved draft payload.",
+                "extracted_fields": {},
+                "missing_fields": ["vehicle"],
+                "reply_action": "send_reply",
+                "reply_text": "Yes, we can do 17:00 today. What vehicle should we book?",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Repair the rejected outbound payload with a valid customer-facing reply.",
+            },
+        ]
+
+    async def decide_intake_workflow(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if not self._decisions:
+            raise AssertionError("unexpected intake decision call")
+        return self._decisions.pop(0)
+
+    def record_observability_event(
+        self,
+        *,
+        event: str,
+        customer_id: str | None = None,
+        **fields: Any,
+    ) -> None:
+        if customer_id:
+            fields["customer_id"] = customer_id
+        self.behavior_events.append({"event": event, **fields})
+
+
+class _ComposioInstagramDraftE2E(ComposioService):
+    __slots__ = ("conversation", "sdk_calls", "_reject_broken_payload_once", "_reject_next_send")
+
+    def __init__(self, *, conversation: dict[str, Any], reject_next_send: bool = False) -> None:
+        super().__init__(api_key="e2e-composio-key")
+        self.conversation = conversation
+        self.sdk_calls: list[dict[str, Any]] = []
+        self._reject_broken_payload_once = True
+        self._reject_next_send = bool(reject_next_send)
+
+    def _sdk_execute_tool(  # type: ignore[override]
+        self,
+        *,
+        slug: str,
+        arguments: dict[str, Any],
+        connected_account_id: str | None,
+        user_id: str,
+        text: str | None = None,
+    ) -> dict[str, Any]:
+        call = {
+            "slug": slug,
+            "arguments": dict(arguments),
+            "connected_account_id": connected_account_id,
+            "user_id": user_id,
+            "text": text,
+        }
+        self.sdk_calls.append(call)
+        if slug == "INSTAGRAM_GET_CONVERSATION":
+            assert arguments["conversation_id"] == "conv_draft_e2e_1"
+            assert user_id == "cust_e2e_drafts"
+            return {"successful": True, "error": None, "data": self.conversation}
+        if slug == "INSTAGRAM_LIST_ALL_CONVERSATIONS":
+            return {
+                "successful": True,
+                "error": None,
+                "data": {"data": [{"id": "conv_draft_e2e_1"}]},
+            }
+        if slug == "INSTAGRAM_SEND_TEXT_MESSAGE":
+            assert arguments["recipient_id"] == "178900099"
+            assert arguments["text"]
+            if self._reject_next_send or (
+                arguments["text"] == "BROKEN_PAYLOAD" and self._reject_broken_payload_once
+            ):
+                self._reject_next_send = False
+                self._reject_broken_payload_once = False
+                return {
+                    "successful": False,
+                    "error": "Invalid request data provided: field 'text' is not valid for Instagram send.",
+                    "data": {"status_code": 400},
+                }
+            return {
+                "successful": True,
+                "error": None,
+                "data": {"id": "mid_sent_repaired", "echo_text": arguments["text"]},
+            }
+        raise AssertionError(f"unexpected Composio tool slug: {slug}")
+
+
+def _post_json(client: TestClient, path: str, body: dict[str, Any]) -> dict[str, Any]:
+    response = client.post(path, json=body)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload.get("ok") is True
+    return payload
+
+
+def test_instagram_intake_draft_approval_resumes_and_repairs_composio_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opentulpa.api import app as app_module
+    from opentulpa.tasks import sandbox as sandbox_module
+
+    project_root = tmp_path / "project_root"
+    project_root.mkdir()
+    monkeypatch.setattr(app_module, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(sandbox_module, "PROJECT_ROOT", project_root)
+
+    conversation_item = build_instagram_conversation(
+        conversation_id="conv_draft_e2e_1",
+        recipient_id="178900099",
+        inbound_text="Can I book a wash today around 5?",
+    )
+    conversation_item["conversation"]["participants"] = {
+        "data": [
+            {"id": "page_draft_e2e", "username": "autospa"},
+            {"id": "178900099", "username": "lead_draft_e2e"},
+        ]
+    }
+    runtime = _DeterministicDraftRuntime()
+    composio = _ComposioInstagramDraftE2E(conversation=conversation_item["conversation"])
+    app = create_app(
+        agent_runtime=runtime,
+        scheduler=SchedulerService(db_path=tmp_path / "scheduler.sqlite"),
+        composio_service=composio,
+    )
+
+    with TestClient(app) as client:
+        workflow_payload = _post_json(
+            client,
+            "/internal/intake/workflows/upsert",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "name": "E2E Instagram Draft Approval",
+                "channel": "instagram_dm",
+                "provider": "composio",
+                "source_config": {
+                    "connected_account_id": "acct_e2e_drafts",
+                    "conversation_id": "conv_draft_e2e_1",
+                },
+                "intent_description": "Reply to Instagram DMs asking to book a car wash.",
+                "required_fields": ["vehicle", "time"],
+                "sink_type": "local_csv",
+                "sink_config": {"file_path": "tulpa_stuff/e2e/drafts.csv"},
+                "reply_mode": "draft",
+                "notify_user": False,
+                "enabled": True,
+            },
+        )
+        workflow = workflow_payload["workflow"]
+        assert workflow["reply_mode"] == "draft"
+
+        run_payload = _post_json(
+            client,
+            "/internal/intake/workflows/run",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "workflow_id": workflow["workflow_id"],
+                "force": True,
+                "event_type": "manual_e2e",
+            },
+        )
+        assert run_payload["results"][0]["status"] == "approval_pending"
+        assert not [
+            call for call in composio.sdk_calls if call["slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"
+        ]
+
+        drafts_payload = _post_json(
+            client,
+            "/internal/intake/drafts/list",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "workflow_id": workflow["workflow_id"],
+            },
+        )
+        drafts = drafts_payload["drafts"]
+        assert len(drafts) == 1
+        assert drafts[0]["reply_text"] == "BROKEN_PAYLOAD"
+        assert drafts[0]["metadata"]["decision"]["reply_text"] == "BROKEN_PAYLOAD"
+        assert drafts[0]["metadata"]["conversation"]["id"] == "conv_draft_e2e_1"
+
+        approved_payload = _post_json(
+            client,
+            "/internal/intake/drafts/approve",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "draft_id": drafts[0]["draft_id"],
+            },
+        )
+
+    approved = approved_payload["draft"]
+    send_calls = [call for call in composio.sdk_calls if call["slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"]
+    assert approved["status"] == "sent"
+    assert approved["reply_text"] == "Yes, we can do 17:00 today. What vehicle should we book?"
+    assert len(send_calls) == 2
+    assert send_calls[0]["arguments"]["text"] == "BROKEN_PAYLOAD"
+    assert send_calls[1]["arguments"]["text"] == approved["reply_text"]
+    assert "conversation_id" not in send_calls[0]["arguments"]
+    assert len(runtime.calls) == 2
+    assert runtime.calls[1]["execution_feedback"][0]["phase"] == "reply_execution"
+    assert "field 'text' is not valid" in runtime.calls[1]["execution_feedback"][0]["error"]
+    assert any(
+        event["event"] == "intake.reply.approval_pending"
+        for event in runtime.behavior_events
+    )
+
+
+@pytest.mark.live_llm
+def test_live_llm_instagram_intake_draft_approval_repairs_composio_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conversation_item = build_instagram_conversation(
+        conversation_id="conv_draft_e2e_1",
+        recipient_id="178900099",
+        inbound_text="Can I book a car wash today around 5pm?",
+    )
+    conversation_item["conversation"]["participants"] = {
+        "data": [
+            {"id": "page_draft_e2e", "username": "autospa"},
+            {"id": "178900099", "username": "lead_draft_e2e"},
+        ]
+    }
+    composio = _ComposioInstagramDraftE2E(
+        conversation=conversation_item["conversation"],
+        reject_next_send=True,
+    )
+    harness = build_harness(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        scenario_name="instagram_intake_drafts_live_llm",
+        composio_service=composio,
+    )
+    try:
+        workflow_payload = _post_json(
+            harness.client,
+            "/internal/intake/workflows/upsert",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "name": "Live LLM E2E Instagram Draft Approval",
+                "channel": "instagram_dm",
+                "provider": "composio",
+                "source_config": {
+                    "connected_account_id": "acct_e2e_drafts",
+                    "conversation_id": "conv_draft_e2e_1",
+                },
+                "intent_description": (
+                    "Reply to Instagram DMs asking to book a car wash. If the lead asks "
+                    "for an appointment and the vehicle is missing, ask one concise "
+                    "follow-up question for the vehicle before saving."
+                ),
+                "required_fields": ["vehicle", "time"],
+                "field_guidance": {
+                    "vehicle": "The customer's car model or vehicle type.",
+                    "time": "Requested appointment time.",
+                },
+                "assistant_instructions": (
+                    "Live E2E contract: when this Instagram lead asks for a booking, "
+                    "reply with a concise customer-facing question asking what vehicle "
+                    "they want to book. Do not save a booking yet. If execution_feedback "
+                    "says the Instagram send failed, retry with a valid concise reply."
+                ),
+                "sink_type": "local_csv",
+                "sink_config": {"file_path": "tulpa_stuff/e2e/live_llm_drafts.csv"},
+                "reply_mode": "draft",
+                "notify_user": False,
+                "enabled": True,
+            },
+        )
+        workflow = workflow_payload["workflow"]
+
+        run_payload = _post_json(
+            harness.client,
+            "/internal/intake/workflows/run",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "workflow_id": workflow["workflow_id"],
+                "force": True,
+                "event_type": "manual_live_llm_e2e",
+            },
+        )
+        assert run_payload["results"], run_payload
+        assert run_payload["results"][0]["status"] == "approval_pending"
+        assert not [
+            call for call in composio.sdk_calls if call["slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"
+        ]
+
+        drafts_payload = _post_json(
+            harness.client,
+            "/internal/intake/drafts/list",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "workflow_id": workflow["workflow_id"],
+            },
+        )
+        drafts = drafts_payload["drafts"]
+        assert len(drafts) == 1
+        assert str(drafts[0]["reply_text"]).strip()
+
+        approved = _post_json(
+            harness.client,
+            "/internal/intake/drafts/approve",
+            {
+                "customer_id": "cust_e2e_drafts",
+                "draft_id": drafts[0]["draft_id"],
+            },
+        )["draft"]
+
+        send_calls = [call for call in composio.sdk_calls if call["slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"]
+        assert approved["status"] == "sent"
+        assert str(approved["reply_text"]).strip()
+        assert len(send_calls) >= 2
+        assert send_calls[0]["arguments"]["text"] == drafts[0]["reply_text"]
+        assert send_calls[-1]["arguments"]["text"] == approved["reply_text"]
+        assert "conversation_id" not in send_calls[-1]["arguments"]
+    finally:
+        close_harness(harness)

--- a/tests/test_intake_tools.py
+++ b/tests/test_intake_tools.py
@@ -57,6 +57,29 @@ async def test_intake_workflow_upsert_posts_expected_payload() -> None:
     assert payload["provider"] == "composio"
     assert payload["assistant_instructions"] == ""
     assert payload["knowledge_file_ids"] == []
+    assert payload["reply_mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_intake_workflow_upsert_defaults_web_origin_to_draft() -> None:
+    runtime = DummyRuntime(
+        [Response(200, {"workflow": {"workflow_id": "iwf_web"}})],
+        thread_id="dashboard-owner-dep_123",
+    )
+    tools = register_runtime_tools(runtime)
+
+    result = await tools["intake_workflow_upsert"].ainvoke(
+        {
+            "name": "Car Wash Intake",
+            "intent_description": "Handle booking requests from Instagram DMs.",
+            "required_fields": ["day", "time"],
+            "sink_type": "local_csv",
+            "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+        }
+    )
+
+    assert result["workflow_id"] == "iwf_web"
+    assert runtime.calls[0][2]["json_body"]["reply_mode"] == "draft"
 
 
 @pytest.mark.asyncio
@@ -86,6 +109,7 @@ async def test_intake_workflow_upsert_accepts_telegram_business_fields() -> None
     assert payload["schedule"] == ""
     assert payload["assistant_instructions"] == "Be concise and friendly."
     assert payload["knowledge_file_ids"] == ["file_1", "file_2"]
+    assert payload["reply_mode"] == "auto"
 
 
 @pytest.mark.asyncio

--- a/tests/test_intake_workflow_routes.py
+++ b/tests/test_intake_workflow_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -16,6 +17,12 @@ class _DisabledComposio:
 
     def status(self) -> dict[str, object]:
         return {"ok": True, "enabled": False}
+
+
+class _RejectingDiscardIntakeService:
+    def discard_draft(self, **kwargs: Any) -> dict[str, Any] | None:
+        del kwargs
+        raise ValueError("only pending drafts can be discarded")
 
 
 def _mk_client(
@@ -42,6 +49,18 @@ def _mk_client(
         customer_profile_service=customer_profiles,
     )
     return TestClient(app)
+
+
+def test_intake_draft_discard_route_returns_400_for_non_pending_draft() -> None:
+    app = create_app(intake_workflow_service=_RejectingDiscardIntakeService())  # type: ignore[arg-type]
+    with TestClient(app) as client:
+        response = client.post(
+            "/internal/intake/drafts/discard",
+            json={"customer_id": "telegram_123", "draft_id": "dft_sent"},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "only pending drafts can be discarded"}
 
 
 def test_intake_workflow_routes_crud(tmp_path: Path) -> None:

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -852,6 +852,113 @@ async def test_draft_reply_mode_stores_pending_draft_until_approved(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_draft_reply_mode_returns_error_when_draft_cannot_be_created(
+    tmp_path: Path,
+) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_message_text_preview": "Can I book a wash today?",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Can I book a wash today?",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    decision = {
+        "ok": True,
+        "matches_workflow": True,
+        "booking_action": "ignore",
+        "reply_action": "send_reply",
+        "reply_text": "Yes, we can do 17:00 today.",
+        "ready_to_save": False,
+    }
+    runtime = _FakeRuntime([dict(decision), dict(decision), dict(decision)])
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=_FakeComposio(summary, conversation),
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day", "time"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="draft",
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+        force=True,
+    )
+
+    assert result["ok"] is False
+    assert result["results"] == []
+    assert result["errors"] == [
+        "conv_1: draft reply requires conversation_id and recipient_id"
+    ]
+    assert service.list_drafts(customer_id="telegram_123") == []
+
+
+@pytest.mark.asyncio
+async def test_approved_draft_rejects_stale_inbound_before_sending(
+    tmp_path: Path,
+) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_message_text_preview": "Can I book a wash today?",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Can I book a wash today?",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    composio = _FakeComposio(summary, conversation)
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=composio,
+    )
+    draft = _create_pending_reply_draft(service)
+    composio.summary = {
+        **summary,
+        "latest_inbound_message_id": "msg_2",
+        "latest_inbound_message_created_time": "2026-04-07T08:01:00+00:00",
+        "latest_inbound_message_text_preview": "Actually can I do 18:00?",
+    }
+    composio.conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_2",
+        latest_message_text="Actually can I do 18:00?",
+        latest_message_time="2026-04-07T08:01:00+00:00",
+    )
+
+    current, error = await service.approve_draft(
+        customer_id="telegram_123",
+        draft_id=draft["draft_id"],
+    )
+
+    assert current is not None
+    assert error == (
+        "draft is stale because a newer inbound message arrived before approval: msg_2"
+    )
+    assert current["status"] == "pending"
+    assert composio.execute_calls == []
+    persisted = service.get_draft(customer_id="telegram_123", draft_id=draft["draft_id"])
+    assert persisted is not None
+    assert persisted["status"] == "pending"
+
+
+@pytest.mark.asyncio
 async def test_sent_draft_cannot_be_edited_or_discarded(tmp_path: Path) -> None:
     summary = {
         "conversation_id": "conv_1",

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -735,6 +735,43 @@ async def test_intake_workflow_business_facts_do_not_store_large_source_blobs(tm
     assert "too large to store inline" in rendered
 
 
+def _create_pending_reply_draft(service: IntakeWorkflowService) -> dict[str, Any]:
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day", "time"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="draft",
+    )
+    return service.create_draft_reply(
+        workflow=workflow,
+        conversation_summary={
+            "conversation_id": "conv_1",
+            "recipient_id": "cust_1",
+            "latest_inbound_message_id": "msg_1",
+            "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+            "latest_inbound_message_text_preview": "Can I book a wash today?",
+        },
+        reply_text="Yes, we can do 17:00 today.",
+        conversation=_instagram_conversation(
+            conversation_id="conv_1",
+            latest_message_id="msg_1",
+            latest_message_text="Can I book a wash today?",
+            latest_message_time="2026-04-07T08:00:00+00:00",
+        ),
+        decision={
+            "ok": True,
+            "matches_workflow": True,
+            "booking_action": "ignore",
+            "reply_action": "send_reply",
+            "reply_text": "Yes, we can do 17:00 today.",
+            "ready_to_save": False,
+        },
+    )
+
+
 @pytest.mark.asyncio
 async def test_draft_reply_mode_stores_pending_draft_until_approved(tmp_path: Path) -> None:
     summary = {
@@ -812,6 +849,77 @@ async def test_draft_reply_mode_stores_pending_draft_until_approved(tmp_path: Pa
         assert [event["kind"] for event in events] == ["draft_reply", "assistant_message"]
     finally:
         set_default_web_event_store(None)
+
+
+@pytest.mark.asyncio
+async def test_sent_draft_cannot_be_edited_or_discarded(tmp_path: Path) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Can I book a wash today?",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=_FakeComposio(summary, conversation),
+    )
+    draft = _create_pending_reply_draft(service)
+
+    sent, error = await service.approve_draft(
+        customer_id="telegram_123",
+        draft_id=draft["draft_id"],
+    )
+
+    assert error is None
+    assert sent is not None
+    assert sent["status"] == "sent"
+    with pytest.raises(ValueError, match="only pending drafts can be edited"):
+        service.edit_draft(
+            customer_id="telegram_123",
+            draft_id=draft["draft_id"],
+            reply_text="Updated text",
+        )
+    with pytest.raises(ValueError, match="only pending drafts can be discarded"):
+        service.discard_draft(customer_id="telegram_123", draft_id=draft["draft_id"])
+    current = service.get_draft(customer_id="telegram_123", draft_id=draft["draft_id"])
+    assert current is not None
+    assert current["status"] == "sent"
+    assert current["reply_text"] == "Yes, we can do 17:00 today."
+
+
+def test_approved_draft_cannot_be_edited_or_discarded(tmp_path: Path) -> None:
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=_FakeComposio({}, {}),
+    )
+    draft = _create_pending_reply_draft(service)
+    with service._conn() as conn:  # noqa: SLF001
+        conn.execute(
+            "UPDATE intake_drafts SET status = 'approved' WHERE draft_id = ?",
+            (draft["draft_id"],),
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="only pending drafts can be edited"):
+        service.edit_draft(
+            customer_id="telegram_123",
+            draft_id=draft["draft_id"],
+            reply_text="Updated text",
+        )
+    with pytest.raises(ValueError, match="only pending drafts can be discarded"):
+        service.discard_draft(customer_id="telegram_123", draft_id=draft["draft_id"])
+    current = service.get_draft(customer_id="telegram_123", draft_id=draft["draft_id"])
+    assert current is not None
+    assert current["status"] == "approved"
+    assert current["reply_text"] == "Yes, we can do 17:00 today."
 
 
 @pytest.mark.asyncio

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -19,6 +19,7 @@ from opentulpa.interfaces.telegram.business import TelegramBusinessService
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
 from opentulpa.scheduler.service import SchedulerService
 from opentulpa.skills.service import SkillStoreService
+from opentulpa.web.events import WebEventStore, set_default_web_event_store
 from tests.workbook_fixtures import (
     SAMPLE_VEHICLE_SERVICES_XLSX_FILENAME,
     SAMPLE_VEHICLE_SERVICES_XLSX_MIME_TYPE,
@@ -665,12 +666,14 @@ async def test_intake_workflow_upsert_persists_telegram_business_fields(tmp_path
         knowledge_file_ids=[str(record["id"])],
         sink_type="local_csv",
         sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="draft",
     )
 
     assert workflow["channel"] == "telegram_business_dm"
     assert workflow["provider"] == "telegram_bot_api"
     assert workflow["schedule"] == ""
     assert workflow["routine_id"] == ""
+    assert workflow["reply_mode"] == "auto"
     assert workflow["assistant_instructions"] == "Be concise and never promise unavailable slots."
     assert workflow["business_facts"] == {"prices": {"basic_wash": "1000 RUB"}}
     assert workflow["knowledge_file_ids"] == [str(record["id"])]
@@ -730,6 +733,165 @@ async def test_intake_workflow_business_facts_do_not_store_large_source_blobs(tm
     rendered = json.dumps(workflow["business_facts"], ensure_ascii=False)
     assert len(rendered) < 1000
     assert "too large to store inline" in rendered
+
+
+@pytest.mark.asyncio
+async def test_draft_reply_mode_stores_pending_draft_until_approved(tmp_path: Path) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_message_text_preview": "Can I book a wash today?",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Can I book a wash today?",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "booking_action": "ignore",
+                "reply_action": "send_reply",
+                "reply_text": "Yes, we can do 17:00 today.",
+                "ready_to_save": False,
+            }
+        ]
+    )
+    composio = _FakeComposio(summary, conversation)
+    web_events = WebEventStore(tmp_path / "web_events.db")
+    set_default_web_event_store(web_events)
+    try:
+        service, _, _, _, _ = _mk_service(
+            tmp_path,
+            runtime=runtime,
+            composio=composio,
+        )
+
+        workflow = service.upsert_workflow(
+            customer_id="telegram_123",
+            name="Car Wash Intake",
+            intent_description="Handle Instagram DMs that ask to book a car wash service.",
+            required_fields=["day", "time"],
+            sink_type="local_csv",
+            sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+            reply_mode="draft",
+        )
+        result = await service.run_workflow(
+            customer_id="telegram_123",
+            workflow_id=workflow["workflow_id"],
+            force=True,
+        )
+
+        assert result["ok"] is True
+        assert result["results"][0]["status"] == "approval_pending"
+        assert result["results"][0]["replied"] is False
+        assert composio.execute_calls == []
+        drafts = service.list_drafts(customer_id="telegram_123")
+        assert len(drafts) == 1
+        assert drafts[0]["reply_text"] == "Yes, we can do 17:00 today."
+        assert drafts[0]["status"] == "pending"
+        draft_events = web_events.list_events(after_id=0, customer_id="telegram_123")
+        assert draft_events[0]["kind"] == "draft_reply"
+
+        sent, error = await service.approve_draft(
+            customer_id="telegram_123",
+            draft_id=drafts[0]["draft_id"],
+        )
+
+        assert error is None
+        assert sent is not None
+        assert sent["status"] == "sent"
+        assert composio.execute_calls[0]["tool_slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"
+        assert composio.execute_calls[0]["arguments"]["text"] == "Yes, we can do 17:00 today."
+        events = web_events.list_events(after_id=0, customer_id="telegram_123")
+        assert [event["kind"] for event in events] == ["draft_reply", "assistant_message"]
+    finally:
+        set_default_web_event_store(None)
+
+
+@pytest.mark.asyncio
+async def test_approved_draft_uses_decision_recovery_after_send_failure(tmp_path: Path) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_message_text_preview": "Can I book a wash today?",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Can I book a wash today?",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "booking_action": "ignore",
+                "reply_action": "send_reply",
+                "reply_text": "Yes, we can do 17:00 today.",
+                "ready_to_save": False,
+            },
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "booking_action": "ignore",
+                "reply_action": "send_reply",
+                "reply_text": "Yes, we can do 17:00 today. Please send your car model.",
+                "ready_to_save": False,
+            },
+        ]
+    )
+    composio = _FailingReplyOnceComposio(summary, conversation)
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=composio,
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day", "time"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="draft",
+    )
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+        force=True,
+    )
+
+    assert result["results"][0]["status"] == "approval_pending"
+    drafts = service.list_drafts(customer_id="telegram_123")
+    assert len(drafts) == 1
+
+    sent, error = await service.approve_draft(
+        customer_id="telegram_123",
+        draft_id=drafts[0]["draft_id"],
+    )
+
+    assert error is None
+    assert sent is not None
+    assert sent["status"] == "sent"
+    assert sent["reply_text"] == "Yes, we can do 17:00 today. Please send your car model."
+    assert len(runtime.calls) == 2
+    assert runtime.calls[1]["execution_feedback"][0]["phase"] == "reply_execution"
+    assert "Following fields are missing" in runtime.calls[1]["execution_feedback"][0]["error"]
+    assert len(composio.execute_calls) == 2
+    assert composio.execute_calls[0]["arguments"]["text"] == "Yes, we can do 17:00 today."
+    assert (
+        composio.execute_calls[1]["arguments"]["text"]
+        == "Yes, we can do 17:00 today. Please send your car model."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -135,9 +135,23 @@ def test_workflow_setup_begin_create_persists_session(tmp_path: Path) -> None:
     assert session["status"] == "active"
     assert session["mode"] == "create"
     assert session["draft_upsert"]["channel"] == "instagram_dm"
+    assert session["draft_upsert"]["reply_mode"] == "auto"
     assert session["scratchpad"]["mode"] == "create"
     assert session["scratchpad"]["source_file_ids"] == []
     assert session["scratchpad"]["knowledge_source_file_ids"] == []
+
+
+def test_workflow_setup_begin_web_create_defaults_to_draft_reply_mode(tmp_path: Path) -> None:
+    setup, _, _ = _mk_setup_service(tmp_path)
+
+    session = setup.begin_session(
+        customer_id="usr_default",
+        thread_id="dashboard-owner-dep_123",
+        mode="create",
+    )
+
+    assert session["draft_upsert"]["channel"] == "instagram_dm"
+    assert session["draft_upsert"]["reply_mode"] == "draft"
 
 
 def test_workflow_setup_begin_edit_loads_existing_workflow(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `reply_mode` support for intake workflows and default dashboard-created Instagram intake workflows to draft mode while keeping Telegram Business on auto-send.
- Persist pending intake drafts with workflow/conversation/decision context, expose draft list/edit/discard/approve APIs, and emit draft web events for the dashboard.
- Resume approved drafts through the intake send boundary and recovery loop so provider send failures can be repaired by the same agentic path.
- Add focused service coverage and an Instagram intake draft E2E, including a live LLM repair-path scenario with the Composio Instagram wrapper and stubbed SDK transport.

## Validation
- `uv run pytest -q tests/e2e/scenarios/test_instagram_intake_drafts.py::test_live_llm_instagram_intake_draft_approval_repairs_composio_payload --run-e2e --run-live-llm`
- `uv run pytest -q tests/e2e/scenarios/test_instagram_intake_drafts.py --run-e2e tests/test_intake_workflow_service.py::test_draft_reply_mode_stores_pending_draft_until_approved tests/test_intake_workflow_service.py::test_approved_draft_uses_decision_recovery_after_send_failure`
- `uv run pytest -q tests/test_intake_tools.py::test_intake_workflow_upsert_posts_expected_payload tests/test_intake_tools.py::test_intake_workflow_upsert_defaults_web_origin_to_draft tests/test_intake_tools.py::test_intake_workflow_upsert_accepts_telegram_business_fields tests/test_workflow_setup_service.py::test_workflow_setup_begin_create_persists_session tests/test_workflow_setup_service.py::test_workflow_setup_begin_web_create_defaults_to_draft_reply_mode tests/test_intake_workflow_service.py::test_intake_workflow_upsert_persists_telegram_business_fields tests/test_intake_workflow_service.py::test_draft_reply_mode_stores_pending_draft_until_approved tests/test_intake_workflow_service.py::test_approved_draft_uses_decision_recovery_after_send_failure tests/test_intake_workflow_routes.py tests/test_web_events.py`
- `uv run ruff check src/opentulpa/intake/service.py src/opentulpa/agent/tools/intake_workflow_tools.py src/opentulpa/intake/workflow_setup_service.py tests/test_intake_tools.py tests/test_workflow_setup_service.py tests/test_intake_workflow_service.py`
