### PR TITLE
Expose safe chat reasoning status events

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -399,6 +399,30 @@ def _extract_response_metadata_trace_fields(response: Any) -> dict[str, Any]:
     return fields
 
 
+def _stream_chunk_has_reasoning(message_chunk: Any) -> bool:
+    additional_kwargs = getattr(message_chunk, "additional_kwargs", None)
+    if isinstance(additional_kwargs, dict):
+        if str(additional_kwargs.get("reasoning_content") or "").strip():
+            return True
+        reasoning_details = additional_kwargs.get("reasoning_details")
+        if isinstance(reasoning_details, list) and reasoning_details:
+            return True
+        if str(additional_kwargs.get("reasoning") or "").strip():
+            return True
+    response_metadata = getattr(message_chunk, "response_metadata", None)
+    if isinstance(response_metadata, dict):
+        usage = _usage_object_to_dict(response_metadata.get("usage"))
+        completion_details = _usage_object_to_dict(
+            usage.get("completion_tokens_details")
+            or usage.get("completionTokensDetails")
+            or response_metadata.get("completion_tokens_details")
+        )
+        reasoning_tokens = _maybe_int(completion_details.get("reasoning_tokens"))
+        if reasoning_tokens is not None and reasoning_tokens > 0:
+            return True
+    return False
+
+
 def _tool_trace_name(tool: Any) -> str:
     return str(getattr(tool, "name", "") or "").strip()
 
@@ -504,6 +528,14 @@ STREAM_EMPTY_REPLY_FALLBACK = (
     "Please retry, and I will continue from the latest state."
 )
 STREAM_PRECOMMIT_SECONDS = 0.75
+
+
+@dataclass(frozen=True)
+class AgentStreamEvent:
+    event: str
+    payload: dict[str, Any]
+
+
 _PROVISIONAL_REPLY_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*i can also\s+", re.IGNORECASE),
     re.compile(r"^\s*i can (?:search|check|look|fetch|inspect|try)\b", re.IGNORECASE),
@@ -1613,6 +1645,19 @@ class OpenTulpaLangGraphRuntime:
     def _build_progress_signal(text: str) -> str:
         cleaned = " ".join(str(text or "").split()).strip() or "Working on it…"
         return f"{STREAM_PROGRESS_PREFIX}{cleaned}"
+
+    @staticmethod
+    def _safe_tool_names_for_status(tool_calls: list[Any]) -> list[str]:
+        assert isinstance(tool_calls, list)
+        names: list[str] = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = str(call.get("name", "")).strip()
+            if name:
+                names.append(name)
+        assert len(names) <= len(tool_calls)
+        return names[:8]
 
     @staticmethod
     def _describe_tool_calls_for_progress(tool_calls: list[Any]) -> str:
@@ -3306,7 +3351,8 @@ class OpenTulpaLangGraphRuntime:
         prompt_mode_override: str | None = None,
         stream_precommit_seconds: float | None = None,
         stream_incremental_deltas: bool = False,
-    ) -> AsyncIterator[str]:
+        stream_status_events: bool = False,
+    ) -> AsyncIterator[str | AgentStreamEvent]:
         await self.start()
         assert self._graph is not None
         normalized_turn_mode = _normalize_turn_mode(turn_mode)
@@ -3449,12 +3495,26 @@ class OpenTulpaLangGraphRuntime:
                     )
                 segment_accumulated = ""
 
+            def _reasoning_event(message_chunk: Any) -> AgentStreamEvent | None:
+                if not stream_status_events or not _stream_chunk_has_reasoning(message_chunk):
+                    return None
+                return AgentStreamEvent(
+                    event="reasoning",
+                    payload={
+                        "status": "active",
+                        "message": "Reasoning...",
+                    },
+                )
+
             async for message_chunk, metadata in self._graph.astream(
                 prepared.graph_input,
                 config=config,
                 stream_mode="messages",
             ):
                 stream_total_chunks += 1
+                reasoning_event = _reasoning_event(message_chunk)
+                if reasoning_event is not None:
+                    yield reasoning_event
                 node_name = str(metadata.get("langgraph_node", "")).strip().lower()
                 if stream_total_chunks % 50 == 0:
                     self.log_behavior_event(
@@ -3527,6 +3587,16 @@ class OpenTulpaLangGraphRuntime:
                 if tool_calls:
                     pending_progress_text = self._describe_tool_calls_for_progress(tool_calls)
                     suppress_live_text_until_completion = True
+                    if stream_status_events:
+                        yield AgentStreamEvent(
+                            event="tool_call",
+                            payload={
+                                "status": "started",
+                                "message": pending_progress_text,
+                                "tool_names": self._safe_tool_names_for_status(tool_calls),
+                                "tool_call_count": len(tool_calls),
+                            },
+                        )
                 if in_tool_phase:
                     in_tool_phase = False
                     stream_key = ""

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -3460,6 +3460,7 @@ class OpenTulpaLangGraphRuntime:
             stream_visible_yields = 0
             stream_filtered_empty = 0
             stream_filtered_blank_expanded = 0
+            reasoning_status_emitted = False
             first_visible_yield_ms: int | None = None
             buffered_visible = ""
             buffered_visible_truncated = False
@@ -3496,8 +3497,14 @@ class OpenTulpaLangGraphRuntime:
                 segment_accumulated = ""
 
             def _reasoning_event(message_chunk: Any) -> AgentStreamEvent | None:
-                if not stream_status_events or not _stream_chunk_has_reasoning(message_chunk):
+                nonlocal reasoning_status_emitted
+                if (
+                    not stream_status_events
+                    or reasoning_status_emitted
+                    or not _stream_chunk_has_reasoning(message_chunk)
+                ):
                     return None
+                reasoning_status_emitted = True
                 return AgentStreamEvent(
                     event="reasoning",
                     payload={

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -615,7 +615,7 @@ def create_app(
         web_token=settings.opentulpa_web_token,
         get_agent_runtime=get_agent_runtime,
         get_file_vault=get_file_vault,
-        get_workflow_setup_service=get_workflow_setup_service,
+        get_workflow_setup_service=lambda: workflow_setup_orchestrator,
         resolve_customer_id=profile_service.resolve_customer_id,
         get_shutdown_drain=get_shutdown_drain,
     )

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -338,7 +338,7 @@ async def _stream_turn(
                 text=text,
                 file_ids=file_ids,
             )
-            if turn_mode == "workflow_setup" or not hasattr(runtime, "astream_text"):
+            if not hasattr(runtime, "astream_text"):
                 final_text = await runtime.ainvoke_text(
                     thread_id=thread_id,
                     customer_id=customer_id,

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI, File, Form, Query, Request, UploadFile
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL
+from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL, AgentStreamEvent
 from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.api.file_helpers import sanitize_uploaded_file_record
 from opentulpa.context.uploaded_files import (
@@ -357,7 +357,12 @@ async def _stream_turn(
                     include_pending_context=include_pending_context,
                     stream_precommit_seconds=0.0,
                     stream_incremental_deltas=True,
+                    stream_status_events=True,
                 ):
+                    if isinstance(chunk, AgentStreamEvent):
+                        if chunk.event in {"reasoning", "tool_call"}:
+                            await queue.put((chunk.event, chunk.payload))
+                        continue
                     current = str(chunk or "")
                     if not current:
                         continue

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -106,6 +106,18 @@ def _client_with_runtime(
     return TestClient(create_app(agent_runtime=runtime, file_vault_service=vault))
 
 
+def _client_with_runtime_and_app(
+    monkeypatch: Any,
+    tmp_path: Any,
+    runtime: _StreamingRuntime,
+) -> tuple[TestClient, Any]:
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    get_settings.cache_clear()
+    vault = FileVaultService(root_dir=tmp_path / "vault", db_path=tmp_path / "vault.db")
+    app = create_app(agent_runtime=runtime, file_vault_service=vault)
+    return TestClient(app), app
+
+
 def test_web_chat_rejects_missing_bearer(monkeypatch: Any, tmp_path: Any) -> None:
     client, _ = _client(monkeypatch, tmp_path)
     response = client.post(
@@ -202,6 +214,38 @@ def test_web_chat_preserves_whitespace_only_incremental_deltas(
     assert [delta["seq"] for delta in deltas] == [1, 2, 3, 4, 5]
     assert all(isinstance(delta["server_received_at_ms"], int) for delta in deltas)
     assert _sse_payloads(text, "final") == [{"text": "Hello world\n\nAgain"}]
+
+
+def test_web_chat_streams_workflow_setup_status_events(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    runtime = _StreamingRuntime(incremental_chunks=["Workflow", " ready."])
+    client, app = _client_with_runtime_and_app(monkeypatch, tmp_path, runtime)
+    app.state.intake_workflow_setup.begin_session(
+        customer_id="telegram_1",
+        thread_id="dashboard-owner-1",
+        mode="create",
+    )
+
+    with client.stream(
+        "POST",
+        "/web/chat/turns",
+        headers={"authorization": "Bearer web-secret"},
+        json={
+            "customer_id": "telegram_1",
+            "thread_id": "dashboard-owner-1",
+            "text": "continue setup",
+        },
+    ) as response:
+        text = response.read().decode("utf-8")
+
+    assert response.status_code == 200
+    assert _sse_payloads(text, "reasoning") == [{"status": "active", "message": "Reasoning..."}]
+    assert _sse_payloads(text, "tool_call")
+    assert _sse_payloads(text, "final") == [{"text": "Workflow ready."}]
+    assert runtime.calls[0]["turn_mode"] == "workflow_setup"
+    assert runtime.calls[0]["stream_status_events"] is True
 
 
 def test_web_chat_resolves_bound_telegram_alias(monkeypatch: Any, tmp_path: Any) -> None:

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
+from opentulpa.agent.runtime import AgentStreamEvent
 from opentulpa.api.app import create_app
 from opentulpa.context.customer_profiles import CustomerProfileService
 from opentulpa.context.file_vault import FileVaultService
@@ -49,6 +50,20 @@ class _StreamingRuntime:
         if hasattr(file_result, "__await__"):
             await file_result
         if kwargs.get("stream_incremental_deltas"):
+            if kwargs.get("stream_status_events"):
+                yield AgentStreamEvent(
+                    event="reasoning",
+                    payload={"status": "active", "message": "Reasoning..."},
+                )
+                yield AgentStreamEvent(
+                    event="tool_call",
+                    payload={
+                        "status": "started",
+                        "message": "Searching the web...",
+                        "tool_names": ["web_search"],
+                        "tool_call_count": 1,
+                    },
+                )
             for chunk in self.incremental_chunks:
                 yield chunk
             return
@@ -135,6 +150,17 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert "Checking context." in text
     assert "event: file" in text
     assert "/web/files/file_123/content" in text
+    assert "event: reasoning" in text
+    assert "private reasoning" not in text
+    assert _sse_payloads(text, "reasoning") == [{"status": "active", "message": "Reasoning..."}]
+    assert _sse_payloads(text, "tool_call") == [
+        {
+            "status": "started",
+            "message": "Searching the web...",
+            "tool_names": ["web_search"],
+            "tool_call_count": 1,
+        }
+    ]
     assert "event: delta" in text
     deltas = _sse_payloads(text, "delta")
     assert [delta["text"] for delta in deltas] == ["Hello", " from web."]
@@ -147,6 +173,7 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert runtime.calls[0]["thread_id"] == "dashboard-owner-1"
     assert runtime.calls[0]["stream_precommit_seconds"] == 0.0
     assert runtime.calls[0]["stream_incremental_deltas"] is True
+    assert runtime.calls[0]["stream_status_events"] is True
 
 
 def test_web_chat_preserves_whitespace_only_incremental_deltas(

--- a/tests/test_runtime_stream_fallback.py
+++ b/tests/test_runtime_stream_fallback.py
@@ -178,6 +178,10 @@ class _ReasoningThenToolThenAnswerGraph:
         ), {"langgraph_node": "agent"}
         yield AIMessage(
             content="",
+            additional_kwargs={"reasoning_content": "second private reasoning chunk"},
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(
+            content="",
             tool_calls=[{"id": "call_1", "name": "web_search", "args": {"query": "private"}}],
         ), {"langgraph_node": "agent"}
         yield AIMessage(content="tool running"), {"langgraph_node": "tools"}
@@ -608,4 +612,5 @@ async def test_astream_text_emits_safe_reasoning_and_tool_status_events(tmp_path
     assert events[1].payload["tool_names"] == ["web_search"]
     assert events[1].payload["tool_call_count"] == 1
     assert "private reasoning" not in json.dumps([event.payload for event in events])
+    assert "second private" not in json.dumps([event.payload for event in events])
     assert chunks[-1] == "Done."

--- a/tests/test_runtime_stream_fallback.py
+++ b/tests/test_runtime_stream_fallback.py
@@ -9,10 +9,11 @@ from typing import Any
 import pytest
 
 from opentulpa.agent import runtime as runtime_module
-from opentulpa.agent.lc_messages import AIMessage, HumanMessage, ToolMessage
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage
 from opentulpa.agent.runtime import (
     STREAM_EMPTY_REPLY_FALLBACK,
     STREAM_PROGRESS_PREFIX,
+    AgentStreamEvent,
     OpenTulpaLangGraphRuntime,
 )
 from opentulpa.agent.runtime_input import ThreadInputCoordinator
@@ -160,6 +161,32 @@ class _EarlyVisibleThenToolThenAnswerGraph:
     async def ainvoke(self, _state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
         del config
         return {"messages": [HumanMessage(content="user"), AIMessage(content="unused")]}
+
+
+class _ReasoningThenToolThenAnswerGraph:
+    async def astream(
+        self,
+        _state: dict[str, Any],
+        *,
+        config: dict[str, Any],
+        stream_mode: str,
+    ) -> AsyncIterator[tuple[AIMessage, dict[str, str]]]:
+        del config, stream_mode
+        yield AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "private reasoning must not stream"},
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(
+            content="",
+            tool_calls=[{"id": "call_1", "name": "web_search", "args": {"query": "private"}}],
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(content="tool running"), {"langgraph_node": "tools"}
+        yield AIMessage(content="Done."), {"langgraph_node": "agent"}
+
+    async def ainvoke(self, _state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        del config
+        return {"messages": [HumanMessage(content="user"), AIMessage(content="unused")]}
+
 
 @pytest.mark.asyncio
 async def test_astream_text_emits_fallback_when_no_visible_output(tmp_path) -> None:
@@ -537,3 +564,48 @@ async def test_astream_text_flushes_post_tool_answer_after_early_visible_chunk(
     assert "turn_stream_buffered_completion_flushed" in events
 
     assert "turn_stream_precommit_discarded" not in events
+
+
+@pytest.mark.asyncio
+async def test_astream_text_emits_safe_reasoning_and_tool_status_events(tmp_path) -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._graph = _ReasoningThenToolThenAnswerGraph()
+    runtime._thread_inputs = ThreadInputCoordinator(debounce_seconds=0.0)
+    runtime._context_events = None
+    runtime._link_alias_service = None
+    runtime.recursion_limit = 8
+    runtime._behavior_log_enabled = True
+    runtime._behavior_log_path = tmp_path / "agent_behavior_safe_status.jsonl"
+    runtime._behavior_log_lock = threading.Lock()
+
+    async def _noop_start() -> None:
+        return None
+
+    async def _noop_compact(*, thread_id: str, customer_id: str) -> None:
+        del thread_id, customer_id
+        return None
+
+    async def _noop_skills(*, customer_id: str, user_text: str) -> dict[str, Any]:
+        del customer_id, user_text
+        return {}
+
+    runtime.start = _noop_start  # type: ignore[method-assign]
+    runtime._maybe_compact_thread_context = _noop_compact  # type: ignore[method-assign]
+    runtime._pre_resolve_skill_state = _noop_skills  # type: ignore[method-assign]
+
+    chunks: list[str | AgentStreamEvent] = []
+    async for chunk in runtime.astream_text(
+        thread_id="chat-safe-status",
+        customer_id="telegram_safe_status",
+        text="search",
+        stream_status_events=True,
+    ):
+        chunks.append(chunk)
+
+    events = [chunk for chunk in chunks if isinstance(chunk, AgentStreamEvent)]
+    assert [event.event for event in events] == ["reasoning", "tool_call"]
+    assert events[0].payload == {"status": "active", "message": "Reasoning..."}
+    assert events[1].payload["tool_names"] == ["web_search"]
+    assert events[1].payload["tool_call_count"] == 1
+    assert "private reasoning" not in json.dumps([event.payload for event in events])
+    assert chunks[-1] == "Done."


### PR DESCRIPTION
## Summary
- emit safe web-chat SSE events for reasoning activity and tool calls
- keep provider reasoning text and tool arguments out of browser payloads
- preserve response delta streaming for multi-step turns

## Tests
- uv run pytest -q tests/test_generic_chat_routes.py tests/test_runtime_stream_fallback.py
- uv run ruff check src/opentulpa/agent/runtime.py src/opentulpa/api/routes/generic_chat.py tests/test_generic_chat_routes.py tests/test_runtime_stream_fallback.py

Linear: OPE-114