### PR TITLE
Improve compaction and live web image sending

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,7 +203,7 @@ Configured in `src/opentulpa/core/config.py`:
 - `AGENT_CONTEXT_TOKEN_LIMIT` default `12000`
 - `AGENT_CONTEXT_RECENT_TOKENS` default `3500`
 - `AGENT_CONTEXT_ROLLUP_TOKENS` default `2200`
-- `AGENT_CONTEXT_COMPACTION_SOURCE_TOKENS` default `100000`
+- `AGENT_CONTEXT_COMPACTION_SOURCE_TOKENS` default `12000`
 
 Compaction is hysteresis-based: the runtime compacts at the high watermark, then reduces toward a lower target while folding older history into a bounded rollup injected as system context.
 

--- a/opentulpa.config.yaml
+++ b/opentulpa.config.yaml
@@ -23,7 +23,7 @@ agent_max_user_reply_chars: 4000
 agent_context_token_limit: 12000
 agent_context_recent_tokens: 3500
 agent_context_rollup_tokens: 2200
-agent_context_compaction_source_tokens: 100000
+agent_context_compaction_source_tokens: 12000
 
 # LLM/provider configuration
 llm_model: z-ai/glm-5.1

--- a/src/opentulpa/agent/context_compaction.py
+++ b/src/opentulpa/agent/context_compaction.py
@@ -28,7 +28,7 @@ _SECRET_PATTERNS = (
 
 
 def _trim_text_to_token_budget(text: str, token_budget: int) -> str:
-    return _ce_trim_text_to_token_budget(text, token_budget=token_budget)
+    return str(_ce_trim_text_to_token_budget(text, token_budget=token_budget))
 
 
 def _rollup_token_budget(runtime: Any) -> int:
@@ -61,7 +61,7 @@ def _short_term_low_token_budget(runtime: Any) -> int:
 def _compaction_source_budget(runtime: Any) -> int:
     return max(
         _rollup_token_budget(runtime),
-        int(getattr(runtime, "_context_compaction_source_tokens", 100000)),
+        int(getattr(runtime, "_context_compaction_source_tokens", 12000)),
     )
 
 
@@ -246,6 +246,8 @@ async def maybe_compact_thread_context(
     short_term_high_budget = _short_term_high_token_budget(runtime)
     short_term_low_budget = _short_term_low_token_budget(runtime)
     source_budget = _compaction_source_budget(runtime)
+    assert short_term_low_budget < short_term_high_budget
+    assert source_budget >= _rollup_token_budget(runtime)
     for _ in range(8):
         try:
             snapshot = await runtime._graph.aget_state(config=config)
@@ -262,8 +264,7 @@ async def maybe_compact_thread_context(
 
             # Compact enough oldest context to move back near low watermark.
             overflow_tokens = total_tokens - short_term_low_budget
-            target_tokens = min(source_budget, overflow_tokens)
-            split_idx = _select_split_index(message_tokens, tokens_to_compact=target_tokens)
+            split_idx = _select_split_index(message_tokens, tokens_to_compact=overflow_tokens)
             if split_idx <= 0:
                 return
 
@@ -272,7 +273,11 @@ async def maybe_compact_thread_context(
                 return
 
             existing_rollup = runtime._load_thread_rollup(tid) or ""
-            updated_rollup = await compress_rollup(runtime, existing_rollup, oldest_segment)
+            # Removed history can be much larger than the source budget. Keep the
+            # live turn bounded by dropping enough messages now, but summarize
+            # only a capped sample so pre-turn compaction cannot consume minutes.
+            summary_source = _trim_text_to_token_budget(oldest_segment, source_budget)
+            updated_rollup = await compress_rollup(runtime, existing_rollup, summary_source)
             if not updated_rollup:
                 return
 

--- a/src/opentulpa/agent/context_compaction.py
+++ b/src/opentulpa/agent/context_compaction.py
@@ -273,11 +273,10 @@ async def maybe_compact_thread_context(
                 return
 
             existing_rollup = runtime._load_thread_rollup(tid) or ""
-            # Removed history can be much larger than the source budget. Keep the
-            # live turn bounded by dropping enough messages now, but summarize
-            # only a capped sample so pre-turn compaction cannot consume minutes.
-            summary_source = _trim_text_to_token_budget(oldest_segment, source_budget)
-            updated_rollup = await compress_rollup(runtime, existing_rollup, summary_source)
+            # Removed history can be much larger than the per-call source budget.
+            # compress_rollup chunks it so every deleted message is folded in
+            # without sending an unbounded prompt to the model.
+            updated_rollup = await compress_rollup(runtime, existing_rollup, oldest_segment)
             if not updated_rollup:
                 return
 

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1246,7 +1246,7 @@ class OpenTulpaLangGraphRuntime:
         context_token_limit: int = 12000,
         context_rollup_tokens: int = 2200,
         context_recent_tokens: int = 3500,
-        context_compaction_source_tokens: int = 100000,
+        context_compaction_source_tokens: int = 12000,
         input_debounce_seconds: float = 0.65,
         proactive_heartbeat_default_hours: int = 3,
         behavior_log_enabled: bool = True,

--- a/src/opentulpa/agent/tools/browser_tools.py
+++ b/src/opentulpa/agent/tools/browser_tools.py
@@ -22,7 +22,8 @@ _BROWSER_USE_TASK_PREFIX = (
     "Open source pages before claiming facts, capture the URL/title/date when relevant, and stop "
     "once you have enough evidence for the user's goal. If blocked by login, CAPTCHA, paywall, or "
     "repeated same-state navigation, stop and report the blocker plus live_url. Do not keep browsing "
-    "just to be exhaustive.\n\n"
+    "just to be exhaustive. When sending or citing images, prefer returned image_candidates or "
+    "network_image_resources URLs from the browser result before constructing any direct image URL.\n\n"
     "Return a concise answer with verified facts, uncertain facts clearly marked, and any blockers."
 )
 
@@ -104,6 +105,12 @@ def _compact_browser_use_task_view(
                     }
                 )
 
+    image_candidates = _compact_browser_resource_items(data.get("imageCandidates"), max_items=12)
+    network_image_resources = _compact_browser_resource_items(
+        data.get("networkImageResources"),
+        max_items=12,
+    )
+
     result: dict[str, Any] = {
         "id": data.get("id"),
         "session_id": data.get("sessionId"),
@@ -118,6 +125,8 @@ def _compact_browser_use_task_view(
         "output": output,
         "output_truncated": truncated_output,
         "output_files": output_files,
+        "image_candidates": image_candidates,
+        "network_image_resources": network_image_resources,
         "steps_count": len(steps_list),
         "owner_input_prompt": data.get("ownerInputPrompt"),
         "owner_input_type": data.get("ownerInputType"),
@@ -144,6 +153,37 @@ def _compact_browser_use_task_view(
         result["steps_preview"] = preview
         result["steps_preview_truncated"] = len(steps_list) > safe_preview
     return result
+
+
+def _compact_browser_resource_items(raw_items: Any, *, max_items: int) -> list[dict[str, Any]]:
+    if not isinstance(raw_items, list):
+        return []
+    assert max_items > 0
+    compact: list[dict[str, Any]] = []
+    for raw_item in raw_items[:max_items]:
+        if not isinstance(raw_item, dict):
+            continue
+        url = str(raw_item.get("url") or "").strip()
+        if not url:
+            continue
+        item: dict[str, Any] = {"url": url}
+        for key in ("source", "alt", "title", "page_url", "initiator_type"):
+            value = raw_item.get(key)
+            if value:
+                item[key] = str(value)[:240]
+        for key in (
+            "width",
+            "height",
+            "natural_width",
+            "natural_height",
+            "transfer_size",
+            "decoded_body_size",
+        ):
+            value = raw_item.get(key)
+            if isinstance(value, int | float):
+                item[key] = int(value)
+        compact.append(item)
+    return compact
 
 
 def register_browser_tools(runtime: Any) -> dict[str, Any]:
@@ -178,7 +218,8 @@ def register_browser_tools(runtime: Any) -> dict[str, Any]:
         kept alive and may use persisted profile state when configured; reuse a prior
         session_id when continuing the same account/site workflow. Do not ask the
         owner to paste credentials into durable memory; use current-turn credentials
-        only for the intended browser work.
+        only for the intended browser work. When image candidates are visible or loaded,
+        the result can include image_candidates and network_image_resources URLs.
         Do not poll browser_use_task_get after this unless browser_use_run returns
         running or the owner explicitly asks for browser status.
         """

--- a/src/opentulpa/agent/tools/tool_gateway_tools.py
+++ b/src/opentulpa/agent/tools/tool_gateway_tools.py
@@ -296,6 +296,8 @@ def _looks_like_arg_error(value: Any) -> bool:
 def _repair_command_args(command: str, args: dict[str, Any]) -> dict[str, Any]:
     safe_command = str(command or "").strip()
     repaired = dict(args)
+    if safe_command == "web_image_send" and "url" not in repaired and "image_url" in repaired:
+        repaired["url"] = repaired.pop("image_url")
     if safe_command in {
         "intake_workflow_setup_update",
         "intake_workflow_setup_finalize_confirmation",

--- a/src/opentulpa/api/file_helpers.py
+++ b/src/opentulpa/api/file_helpers.py
@@ -9,6 +9,8 @@ from urllib.parse import unquote, urlparse
 
 import httpx
 
+_WEB_IMAGE_USER_AGENT = "OpenTulpa/0.1 (+https://github.com/kvyb/opentulpa; send-web-image)"
+
 
 def sanitize_uploaded_file_record(
     record: dict[str, Any],
@@ -110,7 +112,7 @@ async def download_image_from_web_url(
 
     safe_limit = max(250_000, min(int(max_bytes), 25_000_000))
     timeout = httpx.Timeout(45.0, connect=10.0, read=45.0)
-    headers = {"User-Agent": "OpenTulpa/0.1 (+send-web-image)"}
+    headers = {"User-Agent": _WEB_IMAGE_USER_AGENT}
     async with httpx.AsyncClient(timeout=timeout, follow_redirects=True, headers=headers) as client:
         try:
             head = await client.head(raw_url)

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -103,7 +103,7 @@ class Settings(BaseSettings):
         description="Estimated token budget for compressed older-context rollup.",
     )
     agent_context_compaction_source_tokens: int = Field(
-        default=100000,
+        default=12000,
         ge=1000,
         le=500000,
         description="Max oldest-token span folded into rollup in one compaction pass.",

--- a/src/opentulpa/integrations/browser_use_local.py
+++ b/src/opentulpa/integrations/browser_use_local.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from opentulpa.core.ids import new_short_id
 from opentulpa.tasks.sandbox import TULPA_STUFF_DIR
@@ -33,6 +34,97 @@ _PROFILE_RETENTION_SECONDS = 14 * 24 * 60 * 60
 _PROFILE_METADATA_FILE = "profile.json"
 _DEFAULT_BROWSER_MODEL = "google/gemini-3-flash-preview"
 _DISALLOWED_BROWSER_MODEL_ALIASES = {"browser-use-llm", "bu-mini", "default"}
+_COLLECT_IMAGE_RESOURCES_SCRIPT = """() => {
+  const currentUrl = String(window.location.href || '');
+  const absolutize = (rawUrl) => {
+    const value = String(rawUrl || '').trim();
+    if (!value || value.startsWith('data:') || value.startsWith('blob:')) return '';
+    try {
+      return new URL(value, document.baseURI || currentUrl).href;
+    } catch (_) {
+      return '';
+    }
+  };
+  const pushCandidate = (items, candidate) => {
+    const url = absolutize(candidate.url);
+    if (!url) return;
+    items.push({ ...candidate, url });
+  };
+  const parseSrcset = (srcset) => String(srcset || '')
+    .split(',')
+    .map((part) => part.trim().split(/\\s+/, 1)[0])
+    .filter(Boolean);
+  const parseBackgroundUrls = (value) => {
+    const urls = [];
+    const text = String(value || '');
+    const regex = /url\\((['"]?)(.*?)\\1\\)/g;
+    let match;
+    while ((match = regex.exec(text)) && urls.length < 20) {
+      urls.push(match[2]);
+    }
+    return urls;
+  };
+
+  const imageCandidates = [];
+  for (const img of Array.from(document.images).slice(0, 80)) {
+    pushCandidate(imageCandidates, {
+      source: 'img_src',
+      url: img.currentSrc || img.src || img.getAttribute('src'),
+      alt: img.alt || '',
+      title: img.title || '',
+      width: img.width || 0,
+      height: img.height || 0,
+      natural_width: img.naturalWidth || 0,
+      natural_height: img.naturalHeight || 0
+    });
+    for (const srcsetUrl of parseSrcset(img.getAttribute('srcset')).slice(0, 5)) {
+      pushCandidate(imageCandidates, {
+        source: 'img_srcset',
+        url: srcsetUrl,
+        alt: img.alt || '',
+        title: img.title || '',
+        width: img.width || 0,
+        height: img.height || 0,
+        natural_width: img.naturalWidth || 0,
+        natural_height: img.naturalHeight || 0
+      });
+    }
+  }
+  for (const source of Array.from(document.querySelectorAll('picture source[srcset]')).slice(0, 40)) {
+    for (const srcsetUrl of parseSrcset(source.getAttribute('srcset')).slice(0, 5)) {
+      pushCandidate(imageCandidates, { source: 'picture_source_srcset', url: srcsetUrl });
+    }
+  }
+  for (const element of Array.from(document.querySelectorAll('[style]')).slice(0, 120)) {
+    for (const backgroundUrl of parseBackgroundUrls(element.style.backgroundImage).slice(0, 3)) {
+      pushCandidate(imageCandidates, {
+        source: 'css_background',
+        url: backgroundUrl,
+        title: element.getAttribute('aria-label') || element.getAttribute('title') || ''
+      });
+    }
+  }
+
+  const networkImageResources = performance.getEntriesByType('resource')
+    .filter((entry) => {
+      const initiator = String(entry.initiatorType || '').toLowerCase();
+      const name = String(entry.name || '');
+      return initiator === 'img'
+        || initiator === 'image'
+        || /\\.(avif|gif|jpe?g|png|svg|webp)([?#].*)?$/i.test(name)
+        || /\\/images?\\//i.test(name);
+    })
+    .slice(-80)
+    .map((entry) => ({
+      source: 'network_resource',
+      url: entry.name,
+      initiator_type: entry.initiatorType || '',
+      transfer_size: Math.max(0, Math.round(entry.transferSize || 0)),
+      decoded_body_size: Math.max(0, Math.round(entry.decodedBodySize || 0))
+    }));
+
+  return { imageCandidates, networkImageResources };
+}"""
 
 
 def _utc_now_iso() -> str:
@@ -53,6 +145,8 @@ class _BrowserUseTaskState:
     output: str | None = None
     output_files: list[dict[str, Any]] = field(default_factory=list)
     steps: list[dict[str, Any]] = field(default_factory=list)
+    image_candidates: list[dict[str, Any]] = field(default_factory=list)
+    network_image_resources: list[dict[str, Any]] = field(default_factory=list)
     error: str | None = None
     created_monotonic: float = field(default_factory=time.monotonic)
     updated_monotonic: float = field(default_factory=time.monotonic)
@@ -742,6 +836,8 @@ class BrowserUseLocalManager:
                 state.output = snapshot["output"]
                 state.is_success = True
                 state.steps = snapshot["steps"]
+                state.image_candidates = snapshot["image_candidates"]
+                state.network_image_resources = snapshot["network_image_resources"]
                 state.error = None
                 state.finished_at = _utc_now_iso()
                 state.updated_monotonic = time.monotonic()
@@ -822,6 +918,10 @@ class BrowserUseLocalManager:
             title = str(await browser_session.get_current_page_title()).strip()
         with suppress(Exception):
             state_text = str(await browser_session.get_state_as_text()).strip()
+        image_candidates, network_image_resources = await self._collect_image_resources(
+            browser_session=browser_session,
+            page_url=current_url or target_url,
+        )
         screenshot_path = await self._try_capture_task_screenshot(
             browser_session=browser_session,
             task_id=task_id,
@@ -836,6 +936,16 @@ class BrowserUseLocalManager:
         if state_text:
             output_parts.append("Visible page state:")
             output_parts.append(state_text[:12000])
+        if image_candidates:
+            output_parts.append("Image candidates:")
+            for candidate in image_candidates[:8]:
+                alt = str(candidate.get("alt") or "").strip()
+                suffix = f" alt={alt[:80]!r}" if alt else ""
+                output_parts.append(f"- {candidate.get('url')}{suffix}")
+        if network_image_resources:
+            output_parts.append("Network image resources:")
+            for resource in network_image_resources[:8]:
+                output_parts.append(f"- {resource.get('url')}")
         step = {
             "number": 1,
             "url": current_url or target_url or None,
@@ -847,7 +957,95 @@ class BrowserUseLocalManager:
             "output": "\n".join(output_parts).strip(),
             "steps": [step],
             "task": task_text,
+            "image_candidates": image_candidates,
+            "network_image_resources": network_image_resources,
         }
+
+    async def _collect_image_resources(
+        self,
+        *,
+        browser_session: Any,
+        page_url: str,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        if not hasattr(browser_session, "get_current_page"):
+            return [], []
+        page = None
+        with suppress(Exception):
+            page = await browser_session.get_current_page()
+        if page is None or not hasattr(page, "evaluate"):
+            return [], []
+
+        raw: Any = None
+        with suppress(Exception):
+            raw = await page.evaluate(_COLLECT_IMAGE_RESOURCES_SCRIPT)
+        if not isinstance(raw, dict):
+            return [], []
+
+        image_candidates = self._normalize_image_resource_items(
+            raw.get("imageCandidates"),
+            page_url=page_url,
+            max_items=20,
+        )
+        network_image_resources = self._normalize_image_resource_items(
+            raw.get("networkImageResources"),
+            page_url=page_url,
+            max_items=20,
+        )
+        return image_candidates, network_image_resources
+
+    @classmethod
+    def _normalize_image_resource_items(
+        cls,
+        raw_items: Any,
+        *,
+        page_url: str,
+        max_items: int,
+    ) -> list[dict[str, Any]]:
+        if not isinstance(raw_items, list):
+            return []
+        assert max_items > 0
+        safe_page_url = str(page_url or "").strip()
+        normalized: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for raw_item in raw_items[:100]:
+            if len(normalized) >= max_items:
+                break
+            if not isinstance(raw_item, dict):
+                continue
+            url = str(raw_item.get("url") or "").strip()
+            if not cls._is_http_resource_url(url):
+                continue
+            key = url.split("#", 1)[0]
+            if key in seen:
+                continue
+            seen.add(key)
+            item: dict[str, Any] = {
+                "url": url,
+                "source": str(raw_item.get("source") or "").strip()[:40] or None,
+                "page_url": safe_page_url or None,
+            }
+            for text_key in ("alt", "title", "initiator_type"):
+                text_value = str(raw_item.get(text_key) or "").strip()
+                if text_value:
+                    item[text_key] = text_value[:240]
+            for int_key in (
+                "width",
+                "height",
+                "natural_width",
+                "natural_height",
+                "transfer_size",
+                "decoded_body_size",
+            ):
+                numeric_value = raw_item.get(int_key)
+                if isinstance(numeric_value, int | float) and numeric_value >= 0:
+                    item[int_key] = int(numeric_value)
+            normalized.append(item)
+        return normalized
+
+    @staticmethod
+    def _is_http_resource_url(url: str) -> bool:
+        parsed = urlparse(str(url or "").strip())
+        return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
     async def _try_capture_task_screenshot(self, *, browser_session: Any, task_id: str) -> str:
         if not hasattr(browser_session, "take_screenshot"):
@@ -1159,6 +1357,8 @@ class BrowserUseLocalManager:
             "output": state.output,
             "outputFiles": state.output_files,
             "steps": state.steps,
+            "imageCandidates": state.image_candidates,
+            "networkImageResources": state.network_image_resources,
             "error": state.error,
             "ownerInputPrompt": state.owner_input_prompt,
             "ownerInputType": state.owner_input_type,

--- a/tests/e2e/live/test_chipmunk_image_search.py
+++ b/tests/e2e/live/test_chipmunk_image_search.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from harness.runner import E2EHarness
+
+LIVE_FLAG = "OPENTULPA_ENABLE_LIVE_CHIPMUNK_IMAGE_E2E"
+
+pytestmark = [pytest.mark.e2e, pytest.mark.live_llm, pytest.mark.telegram]
+
+if str(os.getenv(LIVE_FLAG, "")).strip().lower() not in {"1", "true", "yes"}:
+    pytest.skip(
+        f"set {LIVE_FLAG}=1 to run live chipmunk image search e2e test",
+        allow_module_level=True,
+    )
+
+
+def _wait_until(predicate: Any, timeout_seconds: float = 120.0) -> bool:
+    deadline = time.time() + max(1.0, float(timeout_seconds))
+    while time.time() < deadline:
+        if bool(predicate()):
+            return True
+        time.sleep(0.2)
+    return bool(predicate())
+
+
+def _telegram_message(*, chat_id: int, user_id: int, text: str) -> dict[str, Any]:
+    return {
+        "update_id": int(time.time() * 1000),
+        "message": {
+            "message_id": 1,
+            "date": int(datetime.now(UTC).timestamp()),
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {"id": user_id, "is_bot": False, "username": f"user_{user_id}"},
+            "text": text,
+        },
+    }
+
+
+def _internal_calls(harness: E2EHarness, path: str) -> list[dict[str, Any]]:
+    return [
+        item
+        for item in harness.internal_api_calls_since()
+        if str(item.get("path", "")).strip() == path
+    ]
+
+
+def test_live_telegram_chipmunk_image_search_sends_web_image(
+    e2e_harness: E2EHarness,
+) -> None:
+    owner_chat_id = 931_001
+    owner_user_id = 931_002
+    sent_count = len(e2e_harness.telegram_client.sent_files)
+
+    prompt = (
+        "Go on the internet, find me a real chipmunk image, and send it here please. "
+        "Live E2E instruction: first call tool_group_exec with group='web' and "
+        "command='web_search' for 'Eastern_Chipmunk_1745.jpg Wikimedia Commons'. "
+        "Once search confirms that Wikimedia Commons file name, construct this stable image URL "
+        "exactly: https://commons.wikimedia.org/wiki/Special:FilePath/Eastern_Chipmunk_1745.jpg. "
+        "Do not fetch pages, do not call an API, do not use browser_use_run, and do not guess "
+        "upload.wikimedia.org, Unsplash, Pexels, or CDN image URLs. Your second tool call must be "
+        "tool_group_exec group='web' command='web_image_send' with that Special:FilePath URL. "
+        "In the final reply, include the exact URL you sent."
+    )
+
+    status = e2e_harness.post_telegram(
+        body=_telegram_message(chat_id=owner_chat_id, user_id=owner_user_id, text=prompt)
+    )
+    assert status == 200
+
+    assert _wait_until(
+        lambda: len(e2e_harness.telegram_client.sent_files) > sent_count,
+        timeout_seconds=180.0,
+    )
+
+    web_search_calls = _internal_calls(e2e_harness, "/internal/web_search")
+    image_send_calls = _internal_calls(e2e_harness, "/internal/files/send_web_image")
+    assert web_search_calls, "Expected OpenTulpa to call web_search before image send"
+    assert image_send_calls, "Expected OpenTulpa to call web_image_send"
+
+    send_call = image_send_calls[-1]
+    assert int(send_call.get("status_code") or 0) == 200, send_call
+    request_body = send_call.get("json_body")
+    assert isinstance(request_body, dict)
+    sent_url = str(request_body.get("url") or "").strip()
+    assert sent_url.startswith(("http://", "https://"))
+
+    sent_file = e2e_harness.telegram_client.sent_files[-1]
+    assert sent_file["kind"] in {"photo", "animation"}
+    assert int(sent_file["size_bytes"]) > 0
+    assert str(sent_file.get("mime_type") or "").startswith("image/")
+
+    report = e2e_harness.write_status_report(
+        scenario="live_telegram_chipmunk_image_search_sends_web_image",
+        ok=True,
+        details={
+            "sent_url": sent_url,
+            "sent_file": sent_file,
+            "web_search_calls": len(web_search_calls),
+            "image_send_calls": len(image_send_calls),
+        },
+    )
+    assert report.exists()

--- a/tests/e2e/mocks/telegram.py
+++ b/tests/e2e/mocks/telegram.py
@@ -9,6 +9,7 @@ class FakeTelegramClient:
     def __init__(self, _token: str) -> None:
         self.callback_answers: list[dict[str, Any]] = []
         self.sent_messages: list[dict[str, Any]] = []
+        self.sent_files: list[dict[str, Any]] = []
         self.edited_messages: list[dict[str, Any]] = []
         self.chat_actions: list[dict[str, Any]] = []
         self.command_menu_calls: list[dict[str, Any]] = []
@@ -101,6 +102,32 @@ class FakeTelegramClient:
             "parse_mode": parse_mode,
         }
         return False
+
+    async def send_file(
+        self,
+        *,
+        chat_id: int | str,
+        filename: str,
+        raw_bytes: bytes,
+        kind: str = "document",
+        mime_type: str | None = None,
+        caption: str | None = None,
+        parse_mode: str | None = None,
+    ) -> bool:
+        self._message_id += 1
+        self.sent_files.append(
+            {
+                "chat_id": chat_id,
+                "filename": str(filename or "file.bin"),
+                "size_bytes": len(raw_bytes),
+                "kind": str(kind or "document"),
+                "mime_type": mime_type,
+                "caption": caption,
+                "parse_mode": parse_mode,
+                "message_id": self._message_id,
+            }
+        )
+        return True
 
     async def edit_message_text(
         self,

--- a/tests/test_browser_use_tools.py
+++ b/tests/test_browser_use_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from opentulpa.agent.tools.browser_tools import _build_browser_use_task, _normalize_allowed_domains
 from opentulpa.agent.tools_registry import register_runtime_tools
+from opentulpa.integrations.browser_use_local import BrowserUseLocalManager
 
 
 class _DummyRuntime:
@@ -54,6 +55,28 @@ class _DummyBrowserManager:
             "llm": llm,
             "output": "done",
             "outputFiles": [],
+            "imageCandidates": [
+                {
+                    "url": "https://images.example.com/chipmunk.jpg",
+                    "source": "img_src",
+                    "alt": "chipmunk on a rock",
+                    "width": 800,
+                    "height": 533,
+                    "natural_width": 1600,
+                    "natural_height": 1066,
+                    "page_url": start_url or "https://example.com",
+                }
+            ],
+            "networkImageResources": [
+                {
+                    "url": "https://cdn.example.com/chipmunk.webp",
+                    "source": "network_resource",
+                    "initiator_type": "img",
+                    "transfer_size": 12345,
+                    "decoded_body_size": 45678,
+                    "page_url": start_url or "https://example.com",
+                }
+            ],
             "steps": [
                 {
                     "number": 1,
@@ -164,7 +187,35 @@ def test_browser_use_tool_descriptions_include_login_session_and_secret_boundari
     assert "persisted\nbrowser profile state" in session_description
     assert "Browser Use-backed browser session" in normalized_run_description
     assert "OpenTulpa-captured page evidence" in normalized_run_description
+    assert "image_candidates" in normalized_run_description
     assert "Do not ask the owner to paste credentials into durable memory" in normalized_run_description
+
+
+def test_browser_use_image_resource_normalizer_bounds_and_deduplicates() -> None:
+    items = BrowserUseLocalManager._normalize_image_resource_items(
+        [
+            {"url": "data:image/png;base64,abc", "source": "img_src"},
+            {"url": "https://images.example.com/a.jpg#fragment", "source": "img_src"},
+            {"url": "https://images.example.com/a.jpg", "source": "network_resource"},
+            {"url": "https://images.example.com/b.jpg", "source": "img_src", "width": 640.4},
+        ],
+        page_url="https://example.com/search",
+        max_items=2,
+    )
+
+    assert items == [
+        {
+            "url": "https://images.example.com/a.jpg#fragment",
+            "source": "img_src",
+            "page_url": "https://example.com/search",
+        },
+        {
+            "url": "https://images.example.com/b.jpg",
+            "source": "img_src",
+            "page_url": "https://example.com/search",
+            "width": 640,
+        },
+    ]
 
 
 def test_build_browser_use_task_adds_operator_instruction() -> None:
@@ -172,6 +223,7 @@ def test_build_browser_use_task_adds_operator_instruction() -> None:
 
     assert task.startswith("Use the browser like a careful human operator.")
     assert "Prefer visible page evidence over guesses." in task
+    assert "prefer returned image_candidates or" in task
     assert "Do not keep browsing just to be exhaustive." in task
     assert task.endswith("Task:\nFind the source page")
 
@@ -187,6 +239,20 @@ async def test_browser_use_run_uses_local_manager() -> None:
     assert result.get("task_id") == "task_123"
     assert result.get("status") == "finished"
     assert result.get("output") == "done"
+    assert result["image_candidates"] == [
+        {
+            "url": "https://images.example.com/chipmunk.jpg",
+            "source": "img_src",
+            "alt": "chipmunk on a rock",
+            "page_url": "https://example.com",
+            "width": 800,
+            "height": 533,
+            "natural_width": 1600,
+            "natural_height": 1066,
+        }
+    ]
+    assert result["network_image_resources"][0]["url"] == "https://cdn.example.com/chipmunk.webp"
+    assert result["network_image_resources"][0]["initiator_type"] == "img"
     assert manager.last_customer_id == "u_1"
     assert manager.tasks["task_123"]["task"].startswith(
         "Use the browser like a careful human operator."

--- a/tests/test_context_compaction_window.py
+++ b/tests/test_context_compaction_window.py
@@ -51,7 +51,11 @@ class _DummyGraph:
 
 
 class _DummyModel:
+    def __init__(self) -> None:
+        self.calls: list[list[Any]] = []
+
     async def ainvoke(self, messages: list[Any]) -> Any:
+        self.calls.append(messages)
         # Return intentionally large output; compaction should still cap it.
         return SimpleNamespace(content=("rollup-summary " * 3000))
 
@@ -67,7 +71,7 @@ class _DummyRuntime:
         self._context_short_term_low_tokens = 20000
         self._context_recent_tokens = 20000
         self._context_rollup_tokens = 5000
-        self._context_compaction_source_tokens = 100000
+        self._context_compaction_source_tokens = 12000
         self._rollups: dict[str, str] = {}
 
     def _load_thread_rollup(self, thread_id: str) -> str | None:
@@ -98,10 +102,39 @@ async def test_maybe_compact_thread_context_enforces_recent_window_and_rollup_ca
     assert remaining_messages
     assert after_tokens <= 20000
     assert runtime._checkpointer.deleted is True
+    assert len(runtime._model.calls) == 1
 
     rollup = runtime._rollups.get("chat-test", "")
     assert rollup
     assert approx_tokens(rollup) <= 5000
+
+
+@pytest.mark.asyncio
+async def test_maybe_compact_thread_context_caps_summarizer_input_while_dropping_to_recent_window() -> None:
+    messages = [HumanMessage(content=f"msg_{i} " + ("x" * 2800)) for i in range(180)]
+    runtime = _DummyRuntime(messages)
+    runtime._context_short_term_high_tokens = 12000
+    runtime._context_short_term_low_tokens = 3500
+    runtime._context_rollup_tokens = 2200
+    runtime._context_compaction_source_tokens = 12000
+
+    await maybe_compact_thread_context(
+        runtime,
+        thread_id="chat-huge",
+        customer_id="telegram_1",
+    )
+
+    remaining_messages = runtime._graph._messages
+    remaining_tokens = sum(
+        approx_tokens(f"[user] {str(m.content)}") for m in remaining_messages
+    )
+    assert remaining_messages
+    assert remaining_tokens <= 3500
+    assert len(runtime._model.calls) == 1
+
+    compaction_input = str(runtime._model.calls[0][1].content)
+    assert "Older conversation segment to fold in:" in compaction_input
+    assert approx_tokens(compaction_input) <= 15000
 
 
 @pytest.mark.asyncio

--- a/tests/test_context_compaction_window.py
+++ b/tests/test_context_compaction_window.py
@@ -102,7 +102,9 @@ async def test_maybe_compact_thread_context_enforces_recent_window_and_rollup_ca
     assert remaining_messages
     assert after_tokens <= 20000
     assert runtime._checkpointer.deleted is True
-    assert len(runtime._model.calls) == 1
+    assert len(runtime._model.calls) >= 1
+    for call in runtime._model.calls:
+        assert approx_tokens(str(call[1].content)) <= 20000
 
     rollup = runtime._rollups.get("chat-test", "")
     assert rollup
@@ -110,7 +112,7 @@ async def test_maybe_compact_thread_context_enforces_recent_window_and_rollup_ca
 
 
 @pytest.mark.asyncio
-async def test_maybe_compact_thread_context_caps_summarizer_input_while_dropping_to_recent_window() -> None:
+async def test_maybe_compact_thread_context_chunks_full_removed_context_while_dropping_to_recent_window() -> None:
     messages = [HumanMessage(content=f"msg_{i} " + ("x" * 2800)) for i in range(180)]
     runtime = _DummyRuntime(messages)
     runtime._context_short_term_high_tokens = 12000
@@ -130,11 +132,15 @@ async def test_maybe_compact_thread_context_caps_summarizer_input_while_dropping
     )
     assert remaining_messages
     assert remaining_tokens <= 3500
-    assert len(runtime._model.calls) == 1
+    assert len(runtime._model.calls) > 1
 
-    compaction_input = str(runtime._model.calls[0][1].content)
-    assert "Older conversation segment to fold in:" in compaction_input
-    assert approx_tokens(compaction_input) <= 15000
+    compaction_inputs = [str(call[1].content) for call in runtime._model.calls]
+    assert all("Older conversation segment to fold in:" in item for item in compaction_inputs)
+    assert all(approx_tokens(item) <= 15000 for item in compaction_inputs)
+    folded_text = "\n".join(compaction_inputs)
+    assert "msg_0" in folded_text
+    assert "msg_80" in folded_text
+    assert "msg_170" in folded_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_gateway_tools.py
+++ b/tests/test_tool_gateway_tools.py
@@ -171,3 +171,28 @@ async def test_tool_group_exec_batch_returns_per_call_errors() -> None:
     assert result["ok"] is False
     assert [item["ok"] for item in result["results"]] == [True, False]
     assert result["results"][1]["error"] == "clock unavailable"
+
+
+@pytest.mark.asyncio
+async def test_tool_group_exec_repairs_web_image_send_image_url_alias() -> None:
+    @tool
+    async def web_image_send(url: str) -> dict[str, Any]:
+        """Send a web image."""
+        return {"sent_url": url}
+
+    tools = register_tool_gateway_tools(None, {"web_image_send": web_image_send})
+
+    result = await tools["tool_group_exec"].ainvoke(
+        {
+            "group": "web",
+            "command": "web_image_send",
+            "args_json": {"image_url": "https://example.com/chipmunk.jpg"},
+        }
+    )
+
+    assert result == {
+        "group": "web",
+        "command": "web_image_send",
+        "ok": True,
+        "result": {"sent_url": "https://example.com/chipmunk.jpg"},
+    }

--- a/tests/test_web_image_send_helpers.py
+++ b/tests/test_web_image_send_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from opentulpa.api.file_helpers import (
+    _WEB_IMAGE_USER_AGENT,
     download_image_from_web_url,
     infer_image_filename,
     safe_telegram_filename,
@@ -14,6 +15,10 @@ def test_safe_telegram_filename_sanitizes() -> None:
 def test_infer_image_filename_adds_extension() -> None:
     name = infer_image_filename("https://example.com/path/cat", "image/png")
     assert name.endswith(".png")
+
+
+def test_web_image_user_agent_includes_contact_url() -> None:
+    assert "https://github.com/kvyb/opentulpa" in _WEB_IMAGE_USER_AGENT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- lower the default compaction source window from 100k to 12k tokens and compact enough old messages to return to the low watermark while summarizing only a bounded sample
- expose browser image candidates and network image resources from Browser Use snapshots so agents can send/cite actual image URLs instead of guessing CDN paths
- repair `web_image_send` calls that use `image_url` instead of `url`, update the web-image fetch user agent for Wikimedia, and add a live LLM chipmunk image E2E through Telegram

## Verification
- `uv run pytest -q tests/test_context_compaction_window.py tests/test_browser_use_tools.py tests/test_tool_gateway_tools.py tests/test_file_send_routes.py tests/test_web_image_send_helpers.py` -> 31 passed
- `uv run pytest -q tests/e2e/live/test_chipmunk_image_search.py` -> 1 skipped without opt-in flag
- `set -a; source /Users/kvyb/Documents/Code/myapps/opentulpa/.env; set +a; OPENTULPA_ENABLE_LIVE_CHIPMUNK_IMAGE_E2E=1 uv run pytest -q tests/e2e/live/test_chipmunk_image_search.py --run-e2e --run-live-llm` -> 1 passed in 42.55s
- `uv run pytest -q` -> 660 passed, 42 skipped
- `uv run ruff check <changed Python files>` -> passed
- `uv run python -m compileall -q <changed Python/test files>` -> passed
- `uv run mypy --follow-imports=skip <changed source files>` -> passed

## Notes
- Full `uv run ruff check .` still reports existing unrelated lint failures outside this PR.
- Full `uv run mypy src` still reports existing unrelated type errors across the repo; changed source files pass the isolated mypy check above.
