### PR TITLE
Fix provider streaming for web chat

### DIFF
--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -194,6 +194,7 @@ def chat_model_init_kwargs_for_model(
     reasoning_effort: str | None,
 ) -> dict[str, Any]:
     model_kwargs = cap_max_completion_tokens_for_model(dict(base_kwargs), model_name=model_name)
+    model_kwargs.setdefault("streaming", True)
     extra = disable_deepseek_v4_pro_thinking_extra(
         model_name=model_name,
         reasoning_effort=reasoning_effort,
@@ -221,6 +222,7 @@ def init_runtime_chat_model(
             "temperature": base_kwargs.get("temperature"),
             "max_completion_tokens": base_kwargs.get("max_completion_tokens"),
             "reasoning": openrouter_reasoning_config(reasoning_effort),
+            "streaming": bool(base_kwargs.get("streaming", True)),
         }
         if referer := app_headers.get("HTTP-Referer"):
             adapter_kwargs["app_url"] = referer

--- a/tests/test_runtime_reasoning_effort.py
+++ b/tests/test_runtime_reasoning_effort.py
@@ -29,6 +29,7 @@ def test_runtime_passes_reasoning_effort_to_init_chat_model(monkeypatch) -> None
 
     assert calls
     assert calls[0]["reasoning_effort"] == "medium"
+    assert calls[0]["streaming"] is True
 
 
 def test_runtime_caps_gemini_flash_lite_preview_output_tokens(monkeypatch) -> None:
@@ -176,6 +177,7 @@ def test_runtime_uses_openrouter_adapter_for_deepseek_reasoning(monkeypatch) -> 
     assert deepseek_call["api_key"] == "test-key"
     assert deepseek_call["base_url"] == "https://openrouter.ai/api/v1"
     assert deepseek_call["reasoning"] == {"effort": "high", "exclude": False}
+    assert deepseek_call["streaming"] is True
     assert deepseek_call["app_url"] == "https://github.com/kvyb/opentulpa"
     assert deepseek_call["app_title"] == "OpenTulpa"
     assert "reasoning_effort" not in deepseek_call


### PR DESCRIPTION
## Summary

Fixes the production dashboard chat stream path by enabling real provider streaming when OpenTulpa initializes runtime chat models.

The live repro showed `/web/chat/turns` returned `status` immediately, then waited ~23s before sending one large `delta` and `final` together. The website proxy was already streaming; the upstream runtime model call was not requesting real streaming from the provider.

## Changes

- Set `streaming=True` for OpenAI-compatible runtime chat model initialization.
- Set `streaming=True` for the DeepSeek OpenRouter adapter path.
- Add regression assertions so runtime model init keeps streaming enabled.

## Validation

- `uv run pytest -q tests/test_runtime_model_streaming.py tests/test_generic_chat_routes.py::test_web_chat_streams_owner_updates_files_and_final tests/test_runtime_reply_limits.py::test_astream_text_can_emit_incremental_visible_deltas tests/test_runtime_reasoning_effort.py`
- `uv run ruff check src/opentulpa/agent/model_pool.py tests/test_runtime_reasoning_effort.py`
