### PR TITLE
Stream post-tool assistant chunks

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -3593,6 +3593,11 @@ class OpenTulpaLangGraphRuntime:
                         break
                     continue
                 stream_agent_chunks += 1
+                if in_tool_phase:
+                    in_tool_phase = False
+                    suppress_live_text_until_completion = False
+                    stream_key = ""
+                    _finalize_segment()
                 tool_calls = getattr(message_chunk, "tool_calls", []) or []
                 if tool_calls:
                     pending_progress_text = self._describe_tool_calls_for_progress(tool_calls)
@@ -3607,10 +3612,6 @@ class OpenTulpaLangGraphRuntime:
                                 "tool_call_count": len(tool_calls),
                             },
                         )
-                if in_tool_phase:
-                    in_tool_phase = False
-                    stream_key = ""
-                    _finalize_segment()
                 chunk_key = str(getattr(message_chunk, "id", "") or "")
                 if chunk_key and stream_key and chunk_key != stream_key:
                     _finalize_segment()

--- a/tests/test_runtime_stream_fallback.py
+++ b/tests/test_runtime_stream_fallback.py
@@ -157,6 +157,54 @@ class _DraftThenToolThenAnswerGraph:
         return {"messages": [HumanMessage(content="user"), AIMessage(content="unused")]}
 
 
+class _DraftThenToolThenStreamingAnswerGraph:
+    async def astream(
+        self,
+        _state: dict[str, Any],
+        *,
+        config: dict[str, Any],
+        stream_mode: str,
+    ) -> AsyncIterator[tuple[AIMessage, dict[str, str]]]:
+        del config, stream_mode
+        yield AIMessage(
+            content="",
+            tool_calls=[{"id": "call_1", "name": "memory_search", "args": {"query": "context"}}],
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(content="tool running"), {"langgraph_node": "tools"}
+        yield AIMessage(content="Hello"), {"langgraph_node": "agent"}
+        yield AIMessage(content=" world"), {"langgraph_node": "agent"}
+
+    async def ainvoke(self, _state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        del config
+        return {"messages": [HumanMessage(content="user"), AIMessage(content="unused")]}
+
+
+class _DraftThenToolThenDraftToolThenAnswerGraph:
+    async def astream(
+        self,
+        _state: dict[str, Any],
+        *,
+        config: dict[str, Any],
+        stream_mode: str,
+    ) -> AsyncIterator[tuple[AIMessage, dict[str, str]]]:
+        del config, stream_mode
+        yield AIMessage(
+            content="",
+            tool_calls=[{"id": "call_1", "name": "memory_search", "args": {"query": "context"}}],
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(content="tool running"), {"langgraph_node": "tools"}
+        yield AIMessage(
+            content="I need to check one more thing.",
+            tool_calls=[{"id": "call_2", "name": "skill_get", "args": {"name": "followup"}}],
+        ), {"langgraph_node": "agent"}
+        yield AIMessage(content="tool running again"), {"langgraph_node": "tools"}
+        yield AIMessage(content="Final answer."), {"langgraph_node": "agent"}
+
+    async def ainvoke(self, _state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        del config
+        return {"messages": [HumanMessage(content="user"), AIMessage(content="unused")]}
+
+
 class _EarlyVisibleThenToolThenAnswerGraph:
     async def astream(
         self,
@@ -578,6 +626,94 @@ async def test_astream_text_holds_agent_draft_when_segment_declares_tool_calls(
     assert len(chunks) == 2
     assert chunks[0].startswith(STREAM_PROGRESS_PREFIX)
     assert chunks[1] == "I checked it. 3 priority emails found."
+
+
+@pytest.mark.asyncio
+async def test_astream_text_streams_post_tool_incremental_chunks(
+    tmp_path,
+) -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._graph = _DraftThenToolThenStreamingAnswerGraph()
+    runtime._thread_inputs = ThreadInputCoordinator(debounce_seconds=0.0)
+    runtime._context_events = None
+    runtime._link_alias_service = None
+    runtime.recursion_limit = 8
+    runtime._behavior_log_enabled = True
+    runtime._behavior_log_path = tmp_path / "agent_behavior_post_tool_stream.jsonl"
+    runtime._behavior_log_lock = threading.Lock()
+
+    async def _noop_start() -> None:
+        return None
+
+    async def _noop_compact(*, thread_id: str, customer_id: str) -> None:
+        del thread_id, customer_id
+        return None
+
+    async def _noop_skills(*, customer_id: str, user_text: str) -> dict[str, Any]:
+        del customer_id, user_text
+        return {}
+
+    runtime.start = _noop_start  # type: ignore[method-assign]
+    runtime._maybe_compact_thread_context = _noop_compact  # type: ignore[method-assign]
+    runtime._pre_resolve_skill_state = _noop_skills  # type: ignore[method-assign]
+
+    chunks: list[str] = []
+    async for chunk in runtime.astream_text(
+        thread_id="chat-post-tool-stream",
+        customer_id="telegram_post_tool_stream",
+        text="answer after context",
+        stream_precommit_seconds=0.0,
+        stream_incremental_deltas=True,
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 3
+    assert chunks[0].startswith(STREAM_PROGRESS_PREFIX)
+    assert chunks[1:] == ["Hello", " world"]
+
+
+@pytest.mark.asyncio
+async def test_astream_text_keeps_second_tool_draft_buffered_after_tool_phase(
+    tmp_path,
+) -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._graph = _DraftThenToolThenDraftToolThenAnswerGraph()
+    runtime._thread_inputs = ThreadInputCoordinator(debounce_seconds=0.0)
+    runtime._context_events = None
+    runtime._link_alias_service = None
+    runtime.recursion_limit = 8
+    runtime._behavior_log_enabled = True
+    runtime._behavior_log_path = tmp_path / "agent_behavior_second_tool_draft.jsonl"
+    runtime._behavior_log_lock = threading.Lock()
+
+    async def _noop_start() -> None:
+        return None
+
+    async def _noop_compact(*, thread_id: str, customer_id: str) -> None:
+        del thread_id, customer_id
+        return None
+
+    async def _noop_skills(*, customer_id: str, user_text: str) -> dict[str, Any]:
+        del customer_id, user_text
+        return {}
+
+    runtime.start = _noop_start  # type: ignore[method-assign]
+    runtime._maybe_compact_thread_context = _noop_compact  # type: ignore[method-assign]
+    runtime._pre_resolve_skill_state = _noop_skills  # type: ignore[method-assign]
+
+    chunks: list[str] = []
+    async for chunk in runtime.astream_text(
+        thread_id="chat-second-tool-draft",
+        customer_id="telegram_second_tool_draft",
+        text="answer after two tool phases",
+        stream_precommit_seconds=0.0,
+        stream_incremental_deltas=True,
+    ):
+        chunks.append(chunk)
+
+    visible = "\n".join(chunks)
+    assert "I need to check one more thing." not in visible
+    assert chunks[-1] == "Final answer."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes web chat streaming after the runtime enters a tool phase.

The live dashboard chat showed the dashboard proxy returning successfully, while the OpenTulpa runtime entered `skills/list` and `memory/search` before flushing the assistant reply near completion. The runtime kept the live-text suppression flag enabled after leaving the tool phase, so post-tool assistant chunks were buffered instead of emitted incrementally.

## Changes

- Clear `suppress_live_text_until_completion` when streaming returns from the tools node to the agent node.
- Add a regression graph that yields a tool call, tool phase, then two assistant chunks and verifies those chunks stream separately.

## Validation

```bash
uv run pytest -q tests/test_runtime_stream_fallback.py::test_astream_text_streams_post_tool_incremental_chunks tests/test_runtime_stream_fallback.py::test_astream_text_holds_agent_draft_when_segment_declares_tool_calls tests/test_runtime_stream_fallback.py::test_astream_text_emits_wait_signal_before_tool_first_result tests/test_runtime_reply_limits.py::test_astream_text_can_emit_incremental_visible_deltas
```
