### PR TITLE
Preserve buffered post-tool flush after visible chunks

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -3595,7 +3595,7 @@ class OpenTulpaLangGraphRuntime:
                 stream_agent_chunks += 1
                 if in_tool_phase:
                     in_tool_phase = False
-                    suppress_live_text_until_completion = False
+                    suppress_live_text_until_completion = yielded_any
                     stream_key = ""
                     _finalize_segment()
                 tool_calls = getattr(message_chunk, "tool_calls", []) or []


### PR DESCRIPTION
Fixes the stream fallback regression called out on the runtime streaming change.

- keeps post-tool completion text buffered when the turn already emitted an early visible chunk
- preserves tool-first post-tool incremental streaming when no visible chunk was emitted yet
- restores the existing turn_stream_buffered_completion_flushed telemetry contract for the early-visible-then-tool path

Validation:
- uv run pytest -q tests/test_runtime_stream_fallback.py::test_astream_text_flushes_post_tool_answer_after_early_visible_chunk tests/test_runtime_stream_fallback.py::test_astream_text_streams_post_tool_incremental_chunks tests/test_runtime_stream_fallback.py::test_astream_text_keeps_second_tool_draft_buffered_after_tool_phase tests/test_runtime_stream_fallback.py::test_astream_text_holds_agent_draft_when_segment_declares_tool_calls
- uv run pytest -q tests/test_runtime_stream_fallback.py
- uv run ruff check src/opentulpa/agent/runtime.py tests/test_runtime_stream_fallback.py