### PR TITLE
Fix web chat streaming and web intake drafts

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -745,6 +745,7 @@ def build_runtime_graph(runtime: Any):
 
     async def agent_node(
         state: AgentState,
+        config: Any | None = None,
     ) -> Command[Literal["agent", "validate_tools", "finalize_turn"]]:
         customer_id = state.get("customer_id", "")
         thread_id = state.get("thread_id", "")
@@ -1342,6 +1343,7 @@ def build_runtime_graph(runtime: Any):
                 model_messages,
                 stable_prefix_count=stable_prefix_count,
                 call_context=call_context,
+                stream_config=config,
             )
         elif callable(ainvoke_fn):
             response = await ainvoke_fn(

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -488,6 +488,7 @@ async def astream_model(
     model_name: str | None = None,
     stable_prefix_count: int = 0,
     call_context: dict[str, Any] | None = None,
+    stream_config: Any | None = None,
 ) -> Any:
     resolved_model_name = runtime._resolve_model_name_for_runtime_call(
         model, explicit_name=model_name
@@ -527,8 +528,18 @@ async def astream_model(
         error_text: str | None = None
         try:
             accumulated: Any | None = None
+            stream_kwargs = dict(invoke_extras)
+            if stream_config is not None:
+                stream_kwargs["config"] = stream_config
             if supports_astream_kwargs(callback_target, invoke_extras):
-                stream = astream(prepared_messages, **invoke_extras)
+                if supports_astream_kwargs(callback_target, stream_kwargs):
+                    stream = astream(prepared_messages, **stream_kwargs)
+                else:
+                    stream = astream(prepared_messages, **invoke_extras)
+            elif stream_config is not None and supports_astream_kwargs(
+                callback_target, {"config": stream_config}
+            ):
+                stream = astream(prepared_messages, config=stream_config)
             else:
                 stream = astream(prepared_messages)
             async for chunk in stream:

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1615,6 +1615,7 @@ class OpenTulpaLangGraphRuntime:
         model_name: str | None = None,
         stable_prefix_count: int = 0,
         call_context: dict[str, Any] | None = None,
+        stream_config: Any | None = None,
     ) -> Any:
         return await _model_pool.astream_model(
             self,
@@ -1623,6 +1624,7 @@ class OpenTulpaLangGraphRuntime:
             model_name=model_name,
             stable_prefix_count=stable_prefix_count,
             call_context=call_context,
+            stream_config=stream_config,
         )
 
     @staticmethod

--- a/src/opentulpa/intake/workflow_setup_service.py
+++ b/src/opentulpa/intake/workflow_setup_service.py
@@ -128,6 +128,9 @@ def _normalize_reply_mode_for_origin(draft: dict[str, Any], *, thread_id: str) -
     if channel == "telegram_business_dm":
         normalized["reply_mode"] = "auto"
         return normalized
+    if str(thread_id or "").strip().lower().startswith("dashboard-owner-"):
+        normalized["reply_mode"] = "draft"
+        return normalized
     reply_mode = str(normalized.get("reply_mode", "") or "").strip().lower()
     if reply_mode not in {"auto", "draft"}:
         normalized["reply_mode"] = _default_reply_mode_for_setup_origin(

--- a/tests/test_runtime_model_streaming.py
+++ b/tests/test_runtime_model_streaming.py
@@ -68,6 +68,15 @@ class _StreamingToolCallModel:
         )
 
 
+class _ConfigCapturingStreamModel:
+    def __init__(self) -> None:
+        self.config_seen: Any | None = None
+
+    async def astream(self, _messages: list[Any], config: Any | None = None):
+        self.config_seen = config
+        yield AIMessageChunk(content="hello")
+
+
 @pytest.mark.asyncio
 async def test_astream_model_preserves_streamed_tool_calls(tmp_path) -> None:
     runtime = OpenTulpaLangGraphRuntime(
@@ -88,3 +97,27 @@ async def test_astream_model_preserves_streamed_tool_calls(tmp_path) -> None:
     assert response.tool_calls == [
         {"name": "fake_tool", "args": {"step": 1}, "id": "call_1", "type": "tool_call"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_astream_model_forwards_graph_stream_config(tmp_path) -> None:
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="z-ai/glm-5.1",
+        checkpoint_db_path=str(tmp_path / "checkpoint.sqlite"),
+    )
+    model = _ConfigCapturingStreamModel()
+    stream_config = {"callbacks": ["graph-callback-marker"]}
+
+    response = await runtime.astream_model(
+        model,
+        [HumanMessage(content="hi")],
+        model_name="z-ai/glm-5.1",
+        call_context={"call_site": "graph_agent"},
+        stream_config=stream_config,
+    )
+
+    assert model.config_seen is stream_config
+    assert isinstance(response, AIMessage)
+    assert response.content == "hello"

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -154,6 +154,25 @@ def test_workflow_setup_begin_web_create_defaults_to_draft_reply_mode(tmp_path: 
     assert session["draft_upsert"]["reply_mode"] == "draft"
 
 
+def test_workflow_setup_web_update_forces_instagram_reply_mode_to_draft(
+    tmp_path: Path,
+) -> None:
+    setup, _, _ = _mk_setup_service(tmp_path)
+    setup.begin_session(
+        customer_id="usr_default",
+        thread_id="dashboard-owner-dep_123",
+        mode="create",
+    )
+
+    session = setup.update_session(
+        customer_id="usr_default",
+        thread_id="dashboard-owner-dep_123",
+        draft_patch={"channel": "instagram_dm", "reply_mode": "auto"},
+    )
+
+    assert session["draft_upsert"]["reply_mode"] == "draft"
+
+
 def test_workflow_setup_begin_edit_loads_existing_workflow(tmp_path: Path) -> None:
     setup, intake_service, _ = _mk_setup_service(tmp_path)
     workflow = intake_service.upsert_workflow(
@@ -266,6 +285,37 @@ def test_workflow_setup_finalize_confirmation_applies_final_patch_and_commits(
     workflows = intake_service.list_workflows(customer_id="telegram_123", include_disabled=True)
     assert len(workflows) == 1
     assert workflows[0]["assistant_instructions"].endswith("use '-' after one hour.")
+
+
+def test_workflow_setup_web_finalize_forces_instagram_reply_mode_to_draft(
+    tmp_path: Path,
+) -> None:
+    setup, intake_service, _ = _mk_setup_service(tmp_path)
+    setup.begin_session(customer_id="usr_default", thread_id="dashboard-owner-dep_123", mode="create")
+    setup.update_session(
+        customer_id="usr_default",
+        thread_id="dashboard-owner-dep_123",
+        draft_patch={
+            "name": "Car Wash Intake",
+            "intent_description": "Handle booking requests from Instagram DMs.",
+            "required_fields": ["day", "time"],
+            "sink_type": "local_csv",
+            "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+            "reply_mode": "auto",
+        },
+    )
+    setup.mark_proposed(customer_id="usr_default", thread_id="dashboard-owner-dep_123")
+
+    session = setup.finalize_confirmation(
+        customer_id="usr_default",
+        thread_id="dashboard-owner-dep_123",
+        draft_patch={"reply_mode": "auto"},
+    )
+
+    assert session["status"] == "completed"
+    workflows = intake_service.list_workflows(customer_id="usr_default", include_disabled=True)
+    assert len(workflows) == 1
+    assert workflows[0]["reply_mode"] == "draft"
 
 
 def test_workflow_setup_commit_edit_recreates_telegram_workflow(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Forward LangGraph runnable config into streamed model calls so web chat can receive provider chunks before the final answer.
- Force dashboard-origin Instagram workflow setup to use draft replies, including updates/finalization that try to set `reply_mode: auto`.
- Add regression coverage for stream-config forwarding and web-origin intake draft enforcement.

## Evidence
- Public dashboard debug stream endpoint streamed chunks normally, so the website proxy path was not the bottleneck.
- Direct probe against the customer deployment `/web/chat/turns` emitted status, then one large delta and final together after the model wait.
- Deployment logs showed the runtime completed normally, which pointed to upstream model stream callback propagation rather than route failure.

## Validation
- `uv run pytest -q tests/test_runtime_model_streaming.py tests/test_generic_chat_routes.py tests/test_runtime_stream_fallback.py::test_astream_text_streams_post_tool_incremental_chunks tests/test_runtime_stream_fallback.py::test_astream_text_flushes_post_tool_answer_after_early_visible_chunk tests/test_runtime_reply_limits.py::test_astream_text_can_emit_incremental_visible_deltas tests/test_workflow_setup_service.py tests/test_intake_tools.py::test_intake_workflow_upsert_defaults_web_origin_to_draft tests/test_intake_workflow_service.py::test_draft_reply_mode_stores_pending_draft_until_approved`
- `uv run ruff check src/opentulpa/agent/graph_builder.py src/opentulpa/agent/runtime.py src/opentulpa/agent/model_pool.py src/opentulpa/intake/workflow_setup_service.py tests/test_runtime_model_streaming.py tests/test_workflow_setup_service.py`