### PR TITLE
Fix Instagram intake scheduled freshness window

### DIFF
--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -30,6 +30,9 @@ _DRAFT_SENDABLE_STATUSES = {"pending", "edited"}
 _DEFAULT_SCHEDULE = "*/5 * * * *"
 _DEFAULT_EDIT_WINDOW = timedelta(hours=2)
 _MAX_LATEST_INBOUND_AGE = timedelta(minutes=1)
+_SCHEDULED_INBOUND_AGE_GRACE = timedelta(minutes=1)
+_DEFAULT_SCHEDULED_INBOUND_AGE = timedelta(minutes=6)
+_MAX_SCHEDULED_INBOUND_AGE = timedelta(hours=1)
 _MAX_TELEGRAM_BUSINESS_WEBHOOK_INBOUND_AGE = timedelta(hours=24)
 _MAX_DECISION_RECOVERY_ATTEMPTS = 2
 _TELEGRAM_BUSINESS_WEBHOOK_DEBOUNCE_SECONDS = 1.5
@@ -48,6 +51,36 @@ logger = logging.getLogger(__name__)
 
 def _channel_uses_scheduler(channel: str) -> bool:
     return str(channel or "").strip().lower() != "telegram_business_dm"
+
+
+def _scheduled_poll_interval(schedule: Any) -> timedelta | None:
+    parts = str(schedule or "").strip().split()
+    if len(parts) < 5:
+        return None
+    minute = parts[0].strip()
+    if minute == "*":
+        return timedelta(minutes=1)
+    for prefix in ("*/", "0/"):
+        if not minute.startswith(prefix):
+            continue
+        raw_step = minute[len(prefix) :].strip()
+        if not raw_step.isdigit():
+            return None
+        step = int(raw_step)
+        if step <= 0:
+            return None
+        return timedelta(minutes=step)
+    return None
+
+
+def _scheduled_inbound_max_age(workflow: dict[str, Any]) -> timedelta:
+    interval = _scheduled_poll_interval(workflow.get("schedule"))
+    if interval is None:
+        return _DEFAULT_SCHEDULED_INBOUND_AGE
+    return min(
+        max(interval + _SCHEDULED_INBOUND_AGE_GRACE, _MAX_LATEST_INBOUND_AGE),
+        _MAX_SCHEDULED_INBOUND_AGE,
+    )
 
 
 def _utc_now() -> datetime:
@@ -550,9 +583,18 @@ class IntakeWorkflowService:
         }
 
     @classmethod
-    def _latest_inbound_max_age_for_event(cls, event_type: str) -> timedelta:
+    def _latest_inbound_max_age_for_event(
+        cls,
+        *,
+        event_type: str,
+        workflow: dict[str, Any],
+    ) -> timedelta:
         if cls._is_telegram_business_webhook_event(event_type):
             return _MAX_TELEGRAM_BUSINESS_WEBHOOK_INBOUND_AGE
+        channel = str(workflow.get("channel", "") or "").strip().lower()
+        provider = str(workflow.get("provider", "") or "").strip().lower()
+        if channel == "instagram_dm" and provider == "composio":
+            return _scheduled_inbound_max_age(workflow)
         return _MAX_LATEST_INBOUND_AGE
 
     @staticmethod
@@ -3373,7 +3415,10 @@ class IntakeWorkflowService:
                     continue
                 if not force and _is_older_than(
                     conversation_summary.get("latest_inbound_message_created_time"),
-                    max_age=self._latest_inbound_max_age_for_event(event_type),
+                    max_age=self._latest_inbound_max_age_for_event(
+                        event_type=event_type,
+                        workflow=workflow,
+                    ),
                 ):
                     self._set_cursor(
                         workflow_id=str(workflow["workflow_id"]),

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -4,7 +4,7 @@ import asyncio
 import csv
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1390,14 +1390,82 @@ async def test_intake_workflow_run_saves_local_csv_and_skips_reprocessing_same_m
 
 
 @pytest.mark.asyncio
-async def test_intake_workflow_ignores_latest_inbound_older_than_one_minute(
+async def test_instagram_scheduled_workflow_uses_poll_interval_for_fresh_inbound(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         intake_service_module,
         "_utc_now",
-        lambda: datetime(2026, 4, 7, 8, 2, 0, tzinfo=UTC),
+        lambda: datetime(2026, 4, 7, 8, 4, 30, tzinfo=UTC),
+    )
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_sender_username": "alice",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Need a car wash tomorrow 3pm.",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Customer wants a car wash booking.",
+                "extracted_fields": {},
+                "missing_fields": [],
+                "reply_action": "none",
+                "reply_text": "",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Within the scheduled polling window.",
+            }
+        ]
+    )
+    composio = _FakeComposio(summary, conversation)
+    service, _, _, _, _ = _mk_service(tmp_path, runtime=runtime, composio=composio)
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+
+    assert workflow["schedule"] == "*/5 * * * *"
+    assert service._latest_inbound_max_age_for_event(  # noqa: SLF001
+        event_type="scheduled",
+        workflow=workflow,
+    ) == timedelta(minutes=6)
+    assert result["ok"] is True
+    assert result["processed_conversations"] == 1
+    assert result["matched_conversations"] == 1
+    assert len(runtime.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_intake_workflow_ignores_latest_inbound_older_than_poll_interval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: datetime(2026, 4, 7, 8, 7, 0, tzinfo=UTC),
     )
     summary = {
         "conversation_id": "conv_1",


### PR DESCRIPTION
## Summary
- align Instagram scheduled intake freshness with its poll interval, including the 5 minute Composio polling window plus grace
- keep stale-message cursor behavior for messages older than the poll window
- add regression coverage for fresh and stale scheduled Instagram intake messages

## Validation
- uv run ruff check src/opentulpa/intake/service.py tests/test_intake_workflow_service.py src/opentulpa/agent/context_compaction.py tests/test_context_compaction_window.py
- uv run pytest -q tests/test_context_compaction_window.py tests/test_intake_workflow_service.py