### PR TITLE
[codex] Improve Instagram intake decision context

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -750,6 +750,9 @@ def _build_intake_workflow_system_prompt() -> str:
         "Allowed booking_action values: ignore, update_active, edit_recent_completed, create_new_booking.\n"
         "Allowed reply_action values: none, send_reply, mark_cancelled.\n\n"
         "Decision policy:\n"
+        "- Treat conversation.unanswered_customer_messages as the active customer turn when present.\n"
+        "- If multiple unanswered customer messages are present, interpret them together before deciding fields, booking action, knowledge needs, and reply text.\n"
+        "- Do not base the decision only on latest_inbound_message_text_preview when unanswered_customer_messages contains more context.\n"
         "- Default mode is not an intent filter: unless workflow.intent_match_required is true, treat messages from the configured source as candidates for this workflow.\n"
         "- In default mode, set matches_workflow=true for greetings, casual openers, ambiguous early-stage messages, and business-adjacent questions when a useful reply can move the conversation forward.\n"
         "- Only when workflow.intent_match_required is true, use matches_workflow=false for messages that are not clearly pursuing the workflow intent.\n"
@@ -950,11 +953,11 @@ def _compact_workflow_for_prompt(workflow: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _compact_recent_messages(messages: Any) -> list[dict[str, str]]:
+def _compact_recent_messages(messages: Any, *, limit: int = 6) -> list[dict[str, str]]:
     if not isinstance(messages, list):
         return []
     compact: list[dict[str, str]] = []
-    for item in messages[-6:]:
+    for item in messages[-limit:]:
         if not isinstance(item, dict):
             continue
         compact.append(
@@ -968,6 +971,12 @@ def _compact_recent_messages(messages: Any) -> list[dict[str, str]]:
             }
         )
     return compact
+
+
+def _compact_unanswered_customer_messages(messages: Any) -> list[dict[str, str]]:
+    if not isinstance(messages, list):
+        return []
+    return _compact_recent_messages(messages, limit=40)
 
 
 def _compact_booking_for_prompt(booking: dict[str, Any] | None) -> dict[str, Any]:
@@ -1051,6 +1060,9 @@ def _compact_conversation_for_prompt(conversation: dict[str, Any]) -> dict[str, 
     return {
         "summary": compact_summary,
         "recent_messages": _compact_recent_messages(safe_conversation.get("recent_messages")),
+        "unanswered_customer_messages": _compact_unanswered_customer_messages(
+            safe_conversation.get("unanswered_customer_messages")
+        ),
     }
 
 
@@ -1074,6 +1086,7 @@ def _build_intake_workflow_agent_prompt(
         "Primary goal:\n"
         "- Decide whether this conversation is an active match for the workflow.\n"
         "- Extract reliable booking fields.\n"
+        "- Use all unanswered customer messages as one active customer turn when provided.\n"
         "- Inspect external state only when the workflow explicitly requires it before this decision.\n"
         "- Return strict JSON only as the final answer.\n\n"
         "Tool-use guidance:\n"

--- a/src/opentulpa/agent/tools/intake_workflow_tools.py
+++ b/src/opentulpa/agent/tools/intake_workflow_tools.py
@@ -98,7 +98,7 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         required_fields: list[str],
         sink_type: str,
         sink_config: dict[str, Any],
-        schedule: str = "*/5 * * * *",
+        schedule: str = "*/2 * * * *",
         channel: str = "instagram_dm",
         provider: str = "composio",
         source_config: dict[str, Any] | None | str = None,
@@ -204,7 +204,7 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         safe_intent = str(intent_description or "").strip()
         safe_channel = str(channel or "").strip() or "instagram_dm"
         safe_provider = str(provider or "").strip() or "composio"
-        safe_schedule = "" if safe_channel == "telegram_business_dm" else (str(schedule or "").strip() or "*/5 * * * *")
+        safe_schedule = "" if safe_channel == "telegram_business_dm" else (str(schedule or "").strip() or "*/2 * * * *")
         safe_thread_id = _active_thread_id(runtime, thread_id)
         requested_reply_mode = str(reply_mode or "").strip().lower()
         safe_reply_mode = requested_reply_mode or _default_reply_mode_for_origin(

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -51,7 +51,7 @@ def register_intake_workflow_routes(
                 knowledge_file_ids=body.get("knowledge_file_ids") if isinstance(body.get("knowledge_file_ids"), list) else None,
                 sink_type=str(body.get("sink_type", "")).strip(),
                 sink_config=body.get("sink_config") if isinstance(body.get("sink_config"), dict) else None,
-                schedule=str(body.get("schedule", "*/5 * * * *")).strip() or "*/5 * * * *",
+                schedule=str(body.get("schedule", "*/2 * * * *")).strip() or "*/2 * * * *",
                 notify_user=bool(body.get("notify_user", True)),
                 enabled=bool(body.get("enabled", True)),
                 reply_mode=str(body.get("reply_mode", "auto")).strip() or "auto",

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -27,11 +27,11 @@ _ALLOWED_PROVIDERS = {"composio", "telegram_bot_api"}
 _ALLOWED_SINK_TYPES = {"google_sheets_composio", "local_csv", "generic_composio_write"}
 _ALLOWED_REPLY_MODES = {"auto", "draft"}
 _DRAFT_SENDABLE_STATUSES = {"pending", "edited"}
-_DEFAULT_SCHEDULE = "*/5 * * * *"
+_DEFAULT_SCHEDULE = "*/2 * * * *"
 _DEFAULT_EDIT_WINDOW = timedelta(hours=2)
 _MAX_LATEST_INBOUND_AGE = timedelta(minutes=1)
 _SCHEDULED_INBOUND_AGE_GRACE = timedelta(minutes=1)
-_DEFAULT_SCHEDULED_INBOUND_AGE = timedelta(minutes=6)
+_DEFAULT_SCHEDULED_INBOUND_AGE = timedelta(minutes=5)
 _MAX_SCHEDULED_INBOUND_AGE = timedelta(hours=1)
 _MAX_TELEGRAM_BUSINESS_WEBHOOK_INBOUND_AGE = timedelta(hours=24)
 _MAX_DECISION_RECOVERY_ATTEMPTS = 2
@@ -39,12 +39,18 @@ _TELEGRAM_BUSINESS_WEBHOOK_DEBOUNCE_SECONDS = 1.5
 _TELEGRAM_BUSINESS_WEBHOOK_SETTLE_SECONDS = 5.0
 _TELEGRAM_BUSINESS_STALE_REQUEUE_SECONDS = 3.0
 _TELEGRAM_BUSINESS_SETTLED_EVENT_TYPE = "telegram_business_webhook_settled"
+_UNANSWERED_CUSTOMER_BURST_WINDOW = timedelta(minutes=5)
+_INSTAGRAM_STALE_DECISION_REFRESH_ATTEMPTS = 2
+_RECENT_MESSAGE_HISTORY_LIMIT = 80
 _PENDING_RUN_POLL_SECONDS = 0.2
 _PENDING_RUN_MAX_CONCURRENCY = 4
 _BUSINESS_FACTS_MAX_KEYS = 32
 _BUSINESS_FACTS_MAX_LIST_ITEMS = 20
 _BUSINESS_FACTS_MAX_STRING_CHARS = 500
 _BUSINESS_FACTS_MAX_JSON_CHARS = 12000
+_DEFAULT_INSTAGRAM_SCAN_LIMIT = 20
+_MAX_INSTAGRAM_SCAN_LIMIT = 20
+_STALE_TERMINAL_STATUSES = {"stale_requeued", "stale_waiting_for_next_poll"}
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +84,7 @@ def _scheduled_inbound_max_age(workflow: dict[str, Any]) -> timedelta:
     if interval is None:
         return _DEFAULT_SCHEDULED_INBOUND_AGE
     return min(
-        max(interval + _SCHEDULED_INBOUND_AGE_GRACE, _MAX_LATEST_INBOUND_AGE),
+        max(interval + _SCHEDULED_INBOUND_AGE_GRACE, _DEFAULT_SCHEDULED_INBOUND_AGE),
         _MAX_SCHEDULED_INBOUND_AGE,
     )
 
@@ -598,7 +604,7 @@ class IntakeWorkflowService:
         return _MAX_LATEST_INBOUND_AGE
 
     @staticmethod
-    def _uses_telegram_business_stale_guard(
+    def _uses_latest_inbound_stale_guard(
         *,
         workflow: dict[str, Any],
         event_type: str,
@@ -608,11 +614,19 @@ class IntakeWorkflowService:
             return False
         channel = str(workflow.get("channel", "") or "").strip().lower()
         provider = str(workflow.get("provider", "") or "").strip().lower()
-        return (
+        if (
             channel == "telegram_business_dm"
             and provider == "telegram_bot_api"
             and IntakeWorkflowService._is_telegram_business_webhook_event(event_type)
-        )
+        ):
+            return True
+        return channel == "instagram_dm" and provider == "composio"
+
+    @staticmethod
+    def _refreshes_stale_decision_inline(*, workflow: dict[str, Any]) -> bool:
+        channel = str(workflow.get("channel", "") or "").strip().lower()
+        provider = str(workflow.get("provider", "") or "").strip().lower()
+        return channel == "instagram_dm" and provider == "composio"
 
     @staticmethod
     def _pending_due_at(delay_seconds: float) -> str:
@@ -1093,11 +1107,16 @@ class IntakeWorkflowService:
             )
         if not stale:
             return None
-        self._requeue_stale_telegram_business_run(
-            workflow=workflow,
-            conversation_id=conversation_id,
-            latest_summary=latest_summary,
-        )
+        channel = str(workflow.get("channel", "") or "").strip().lower()
+        provider = str(workflow.get("provider", "") or "").strip().lower()
+        requeued = channel == "telegram_business_dm" and provider == "telegram_bot_api"
+        if requeued:
+            self._requeue_stale_telegram_business_run(
+                workflow=workflow,
+                conversation_id=conversation_id,
+                latest_summary=latest_summary,
+            )
+        status = "stale_requeued" if requeued else "stale_waiting_for_next_poll"
         self._emit_observability(
             event="intake.conversation.stale",
             workflow=workflow,
@@ -1105,11 +1124,12 @@ class IntakeWorkflowService:
             latest_inbound_message_id=str(
                 latest_summary.get("latest_inbound_message_id", "") or ""
             ).strip(),
+            requeued=requeued,
         )
         return {
             "conversation_id": conversation_id,
             "matched": bool(matched),
-            "status": "stale_requeued",
+            "status": status,
             "replied": False,
         }
 
@@ -2612,7 +2632,7 @@ class IntakeWorkflowService:
                     }
                 )
             normalized.sort(key=lambda item: str(item.get("created_time", "")))
-            return normalized[-12:]
+            return normalized[-_RECENT_MESSAGE_HISTORY_LIMIT:]
         payload = _safe_dict(conversation.get("data")) if "data" in conversation else _safe_dict(conversation)
         participants = _safe_list(_safe_dict(payload.get("participants")).get("data"))
         messages = _safe_list(_safe_dict(payload.get("messages")).get("data"))
@@ -2641,7 +2661,35 @@ class IntakeWorkflowService:
                 }
             )
         normalized.sort(key=lambda item: str(item.get("created_time", "")))
-        return normalized[-12:]
+        return normalized[-_RECENT_MESSAGE_HISTORY_LIMIT:]
+
+    def _unanswered_customer_messages(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        if not messages:
+            return []
+        last_assistant_index = -1
+        for index, item in enumerate(messages):
+            if str(item.get("sender_role", "") or "").strip() == "assistant":
+                last_assistant_index = index
+        unanswered = [
+            item
+            for item in messages[last_assistant_index + 1 :]
+            if str(item.get("sender_role", "") or "").strip() == "customer"
+        ]
+        if len(unanswered) <= 1:
+            return unanswered
+
+        latest_time = _parse_datetime(unanswered[-1].get("created_time"))
+        if latest_time is None:
+            return unanswered
+        cutoff = latest_time - _UNANSWERED_CUSTOMER_BURST_WINDOW
+        return [
+            item
+            for item in unanswered
+            if (parsed := _parse_datetime(item.get("created_time"))) is None or parsed >= cutoff
+        ]
 
     def _source_matches_workflow(
         self,
@@ -2828,7 +2876,16 @@ class IntakeWorkflowService:
                 return [], f"Workflow {workflow['name']} failed: Composio is not available.", []
             source_config = _safe_dict(workflow.get("source_config"))
             connected_account_id = str(source_config.get("connected_account_id", "") or "").strip() or None
-            scan_limit = max(1, min(int(source_config.get("scan_limit", 10) or 10), 25))
+            scan_limit = max(
+                1,
+                min(
+                    int(
+                        source_config.get("scan_limit", _DEFAULT_INSTAGRAM_SCAN_LIMIT)
+                        or _DEFAULT_INSTAGRAM_SCAN_LIMIT
+                    ),
+                    _MAX_INSTAGRAM_SCAN_LIMIT,
+                ),
+            )
             configured_conversation_ids = _unique_string_list(
                 source_config.get("conversation_ids")
                 if isinstance(source_config.get("conversation_ids"), list)
@@ -3505,23 +3562,123 @@ class IntakeWorkflowService:
                         error=error,
                     )
                     continue
-                intent_match_required = _workflow_requires_intent_match(workflow)
-                decision_matches = bool(decision.get("matches_workflow"))
-                effective_matches = decision_matches or not intent_match_required
-                if self._uses_telegram_business_stale_guard(
+                skip_conversation = False
+                if self._uses_latest_inbound_stale_guard(
                     workflow=workflow,
                     event_type=event_type,
                     force=force,
                 ):
-                    stale_result = self._requeue_if_conversation_stale(
-                        workflow=workflow,
-                        conversation_id=conversation_id,
-                        conversation_summary=cursor_summary,
-                        matched=effective_matches,
-                    )
-                    if stale_result is not None:
-                        result_items.append(stale_result)
-                        continue
+                    for attempt in range(_INSTAGRAM_STALE_DECISION_REFRESH_ATTEMPTS + 1):
+                        stale, latest_summary, stale_error = self._conversation_became_stale(
+                            workflow=workflow,
+                            conversation_id=conversation_id,
+                            decided_summary=cursor_summary,
+                        )
+                        if stale_error:
+                            self._emit_observability(
+                                event="intake.conversation.error",
+                                workflow=workflow,
+                                conversation_summary=cursor_summary,
+                                phase="stale_check",
+                                error=stale_error,
+                            )
+                        if not stale:
+                            break
+                        can_refresh_inline = self._refreshes_stale_decision_inline(
+                            workflow=workflow
+                        )
+                        if not can_refresh_inline or attempt >= _INSTAGRAM_STALE_DECISION_REFRESH_ATTEMPTS:
+                            intent_match_required = _workflow_requires_intent_match(workflow)
+                            decision_matches = bool(decision.get("matches_workflow"))
+                            effective_matches = decision_matches or not intent_match_required
+                            stale_result = self._requeue_if_conversation_stale(
+                                workflow=workflow,
+                                conversation_id=conversation_id,
+                                conversation_summary=cursor_summary,
+                                matched=effective_matches,
+                            )
+                            if stale_result is not None:
+                                result_items.append(stale_result)
+                                skip_conversation = True
+                            break
+                        self._emit_observability(
+                            event="intake.conversation.stale_refresh",
+                            workflow=workflow,
+                            conversation_summary=cursor_summary,
+                            latest_inbound_message_id=str(
+                                latest_summary.get("latest_inbound_message_id", "") or ""
+                            ).strip(),
+                            attempt=attempt + 1,
+                        )
+                        try:
+                            detailed_summary, conversation, detail_error = self._load_source_conversation(
+                                workflow=workflow,
+                                conversation_id=conversation_id,
+                            )
+                        except Exception as exc:
+                            detailed_summary = {}
+                            detail_error = str(exc)
+                        if detail_error:
+                            error_text = str(detail_error)
+                            errors.append(f"{conversation_id}: {error_text}")
+                            self._emit_observability(
+                                event="intake.conversation.error",
+                                workflow=workflow,
+                                conversation_summary=cursor_summary,
+                                phase="stale_refresh",
+                                error=error_text,
+                            )
+                            skip_conversation = True
+                            break
+                        cursor_summary = self._enrich_conversation_summary(
+                            workflow=workflow,
+                            conversation_summary=detailed_summary or latest_summary,
+                        )
+                        latest_inbound_id = str(
+                            cursor_summary.get("latest_inbound_message_id", "") or ""
+                        ).strip()
+                        latest_inbound_time = str(
+                            cursor_summary.get("latest_inbound_message_created_time", "") or ""
+                        ).strip()
+                        conversation_updated_time = str(
+                            cursor_summary.get("conversation_updated_time", "") or ""
+                        ).strip()
+                        latest_outbound_id = str(
+                            cursor_summary.get("latest_outbound_message_id", "") or ""
+                        ).strip()
+                        active_booking = self._get_active_booking(
+                            customer_id=str(workflow["customer_id"]),
+                            workflow_id=str(workflow["workflow_id"]),
+                            conversation_id=conversation_id,
+                        )
+                        recent_completed_booking = self._get_recent_completed_booking(
+                            customer_id=str(workflow["customer_id"]),
+                            workflow_id=str(workflow["workflow_id"]),
+                            conversation_id=conversation_id,
+                        )
+                        decision, error = await self._decide_workflow_action(
+                            workflow=workflow,
+                            conversation_summary=cursor_summary,
+                            conversation=conversation,
+                            active_booking=active_booking,
+                            recent_completed_booking=recent_completed_booking,
+                        )
+                        if error:
+                            errors.append(f"{conversation_id}: {error}")
+                            self._emit_observability(
+                                event="intake.conversation.error",
+                                workflow=workflow,
+                                conversation_summary=cursor_summary,
+                                phase="decision",
+                                error=error,
+                            )
+                            skip_conversation = True
+                            break
+                if skip_conversation:
+                    continue
+                intent_match_required = _workflow_requires_intent_match(workflow)
+                decision_matches = bool(decision.get("matches_workflow"))
+                effective_matches = decision_matches or not intent_match_required
                 if not effective_matches:
                     reply_action = str(decision.get("reply_action", "none") or "none").strip().lower()
                     reply_text = str(decision.get("reply_text", "") or "").strip()
@@ -3541,7 +3698,7 @@ class IntakeWorkflowService:
                                 reply_text=reply_text,
                             )
                     if reply_action == "send_reply" and reply_text:
-                        if self._uses_telegram_business_stale_guard(
+                        if self._uses_latest_inbound_stale_guard(
                             workflow=workflow,
                             event_type=event_type,
                             force=force,
@@ -3715,7 +3872,7 @@ class IntakeWorkflowService:
                         active_booking=active_booking,
                         recent_completed_booking=recent_completed_booking,
                         decision=decision,
-                        stale_guard=self._uses_telegram_business_stale_guard(
+                        stale_guard=self._uses_latest_inbound_stale_guard(
                             workflow=workflow,
                             event_type=event_type,
                             force=force,
@@ -3764,7 +3921,7 @@ class IntakeWorkflowService:
                         error=apply_error,
                     )
                     continue
-                if str(applied.get("status", "") or "").strip() == "stale_requeued":
+                if str(applied.get("status", "") or "").strip() in _STALE_TERMINAL_STATUSES:
                     result_items.append(applied)
                     continue
                 self._set_cursor(
@@ -3835,6 +3992,7 @@ class IntakeWorkflowService:
             conversation=conversation,
             recipient_id=str(conversation_summary.get("recipient_id", "") or "").strip() or None,
         )
+        unanswered_customer_messages = self._unanswered_customer_messages(recent_messages)
         workflow_context = {
             "workflow_id": workflow.get("workflow_id"),
             "name": workflow.get("name"),
@@ -3875,6 +4033,7 @@ class IntakeWorkflowService:
                 conversation={
                     "summary": conversation_summary,
                     "recent_messages": recent_messages,
+                    "unanswered_customer_messages": unanswered_customer_messages,
                 },
                 active_booking=active_booking,
                 recent_completed_booking=recent_completed_booking,

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -4120,6 +4120,7 @@ class IntakeWorkflowService:
                     conversation={
                         "summary": conversation_summary,
                         "recent_messages": recent_messages,
+                        "unanswered_customer_messages": unanswered_customer_messages,
                     },
                     active_booking=active_booking,
                     recent_completed_booking=recent_completed_booking,

--- a/src/opentulpa/intake/workflow_setup_service.py
+++ b/src/opentulpa/intake/workflow_setup_service.py
@@ -108,7 +108,7 @@ def _normalize_schedule_for_channel(draft: dict[str, Any]) -> dict[str, Any]:
     if channel == "telegram_business_dm":
         normalized["schedule"] = ""
     else:
-        normalized["schedule"] = str(normalized.get("schedule", "*/5 * * * *") or "*/5 * * * *")
+        normalized["schedule"] = str(normalized.get("schedule", "*/2 * * * *") or "*/2 * * * *")
     return normalized
 
 
@@ -196,7 +196,7 @@ class WorkflowSetupService:
                     "knowledge_file_ids": [],
                     "sink_type": "",
                     "sink_config": {},
-                    "schedule": "*/5 * * * *",
+                    "schedule": "*/2 * * * *",
                     "notify_user": True,
                     "enabled": True,
                     "reply_mode": "",
@@ -355,7 +355,7 @@ class WorkflowSetupService:
                     "sink_type": str(workflow_snapshot.get("sink_type", "") or ""),
                     "sink_config": _safe_dict(workflow_snapshot.get("sink_config")),
                     "schedule": str(
-                        workflow_snapshot.get("schedule", "*/5 * * * *") or "*/5 * * * *"
+                        workflow_snapshot.get("schedule", "*/2 * * * *") or "*/2 * * * *"
                     ),
                     "notify_user": bool(workflow_snapshot.get("notify_user", True)),
                     "enabled": bool(workflow_snapshot.get("enabled", True)),
@@ -466,7 +466,7 @@ class WorkflowSetupService:
                 knowledge_file_ids=_safe_list(draft.get("knowledge_file_ids")),
                 sink_type=str(draft.get("sink_type", "") or ""),
                 sink_config=_safe_dict(draft.get("sink_config")),
-                schedule=str(draft.get("schedule", "*/5 * * * *") or "*/5 * * * *"),
+                schedule=str(draft.get("schedule", "*/2 * * * *") or "*/2 * * * *"),
                 notify_user=bool(draft.get("notify_user", True)),
                 enabled=bool(draft.get("enabled", True)),
                 reply_mode=str(draft.get("reply_mode", "auto") or "auto"),

--- a/tests/e2e/scenarios/test_instagram_intake_drafts.py
+++ b/tests/e2e/scenarios/test_instagram_intake_drafts.py
@@ -6,9 +6,10 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 from harness.runner import build_harness, close_harness
-from mocks.composio_instagram import build_instagram_conversation
+from mocks.composio_instagram import FakeComposioInstagramService, build_instagram_conversation
 
 from opentulpa.api.app import create_app
+from opentulpa.intake import service as intake_service_module
 from opentulpa.integrations.composio import ComposioService
 from opentulpa.scheduler.service import SchedulerService
 
@@ -133,6 +134,72 @@ def _post_json(client: TestClient, path: str, body: dict[str, Any]) -> dict[str,
     payload = response.json()
     assert payload.get("ok") is True
     return payload
+
+
+def _scheduled_instagram_burst_conversation() -> dict[str, Any]:
+    conversation_id = "conv_live_llm_burst_1"
+    recipient_id = "178900177"
+    created_latest = "2026-04-14T10:24:30+0000"
+    return {
+        "summary": {
+            "conversation_id": conversation_id,
+            "recipient_id": recipient_id,
+            "latest_message_id": "mid_burst_5",
+            "latest_message_created_time": created_latest,
+            "latest_inbound_message_id": "mid_burst_5",
+            "latest_inbound_message_created_time": created_latest,
+            "latest_inbound_message_text_preview": "Pleeeeease",
+            "message_count": 6,
+        },
+        "conversation": {
+            "id": conversation_id,
+            "participants": {
+                "data": [
+                    {"id": "page_live_llm_burst", "username": "salon_test"},
+                    {"id": recipient_id, "username": "lead_burst_e2e"},
+                ]
+            },
+            "messages": {
+                "data": [
+                    {
+                        "id": "mid_prev_out_1",
+                        "created_time": "2026-04-14T10:19:30+0000",
+                        "from": {"id": "page_live_llm_burst", "username": "salon_test"},
+                        "to": {"data": [{"id": recipient_id}]},
+                        "message": "We can book your blow dry on June 8. What time works, and what phone number should we use?",
+                    },
+                    {
+                        "id": "mid_burst_1",
+                        "created_time": "2026-04-14T10:20:00+0000",
+                        "from": {"id": recipient_id, "username": "lead_burst_e2e"},
+                        "to": {"data": [{"id": "page_live_llm_burst"}]},
+                        "message": "Reach ma ballls",
+                    },
+                    {
+                        "id": "mid_burst_2",
+                        "created_time": "2026-04-14T10:22:00+0000",
+                        "from": {"id": recipient_id, "username": "lead_burst_e2e"},
+                        "to": {"data": [{"id": "page_live_llm_burst"}]},
+                        "message": "Can u do that for me",
+                    },
+                    {
+                        "id": "mid_burst_3",
+                        "created_time": "2026-04-14T10:23:30+0000",
+                        "from": {"id": recipient_id, "username": "lead_burst_e2e"},
+                        "to": {"data": [{"id": "page_live_llm_burst"}]},
+                        "message": "?",
+                    },
+                    {
+                        "id": "mid_burst_5",
+                        "created_time": created_latest,
+                        "from": {"id": recipient_id, "username": "lead_burst_e2e"},
+                        "to": {"data": [{"id": "page_live_llm_burst"}]},
+                        "message": "Pleeeeease",
+                    },
+                ]
+            },
+        },
+    }
 
 
 def test_instagram_intake_draft_approval_resumes_and_repairs_composio_payload(
@@ -354,5 +421,99 @@ def test_live_llm_instagram_intake_draft_approval_repairs_composio_payload(
         assert send_calls[0]["arguments"]["text"] == drafts[0]["reply_text"]
         assert send_calls[-1]["arguments"]["text"] == approved["reply_text"]
         assert "conversation_id" not in send_calls[-1]["arguments"]
+    finally:
+        close_harness(harness)
+
+
+@pytest.mark.live_llm
+def test_live_llm_instagram_scheduled_burst_replies_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: intake_service_module.datetime(2026, 4, 14, 10, 24, 45, tzinfo=intake_service_module.UTC),
+    )
+    conversation_item = _scheduled_instagram_burst_conversation()
+    composio = FakeComposioInstagramService(reply_fail_once_for_invalid_mid=False)
+    composio.conversations["conv_live_llm_burst_1"] = conversation_item
+    harness = build_harness(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        scenario_name="instagram_scheduled_burst_live_llm",
+        composio_service=composio,
+    )
+    try:
+        workflow_payload = _post_json(
+            harness.client,
+            "/internal/intake/workflows/upsert",
+            {
+                "customer_id": "cust_e2e_burst",
+                "name": "Live LLM E2E Instagram Burst",
+                "channel": "instagram_dm",
+                "provider": "composio",
+                "source_config": {
+                    "connected_account_id": "acct_e2e_burst",
+                    "scan_limit": 20,
+                },
+                "intent_description": (
+                    "Reply to Instagram DMs for salon booking requests. Treat multiple "
+                    "customer messages after the last assistant reply as one active turn."
+                ),
+                "required_fields": ["time", "phone"],
+                "field_guidance": {
+                    "time": "Requested appointment time on June 8.",
+                    "phone": "Customer phone number.",
+                },
+                "assistant_instructions": (
+                    "Live E2E contract: answer as the salon. Use the whole active customer "
+                    "turn, not only the latest short message. Since time and phone are still "
+                    "missing, send one concise reply asking for both. Do not save a booking."
+                ),
+                "sink_type": "local_csv",
+                "sink_config": {"file_path": "tulpa_stuff/e2e/live_llm_burst.csv"},
+                "reply_mode": "auto",
+                "notify_user": False,
+                "enabled": True,
+            },
+        )
+        workflow = workflow_payload["workflow"]
+        assert workflow["schedule"] == "*/2 * * * *"
+
+        first = _post_json(
+            harness.client,
+            "/internal/intake/workflows/run",
+            {
+                "customer_id": "cust_e2e_burst",
+                "workflow_id": workflow["workflow_id"],
+                "event_type": "scheduled",
+            },
+        )
+        second = _post_json(
+            harness.client,
+            "/internal/intake/workflows/run",
+            {
+                "customer_id": "cust_e2e_burst",
+                "workflow_id": workflow["workflow_id"],
+                "event_type": "scheduled",
+            },
+        )
+
+        send_calls = [
+            call
+            for call in composio.calls
+            if call["method"] == "execute_tool"
+            and call["tool_slug"] == "INSTAGRAM_SEND_TEXT_MESSAGE"
+        ]
+        assert first["processed_conversations"] == 1
+        assert first["matched_conversations"] == 1
+        assert first["results"][0]["replied"] is True
+        assert second["processed_conversations"] == 0
+        assert len(send_calls) == 1
+        reply_text = str(send_calls[0]["arguments"]["text"])
+        assert reply_text.strip()
+        assert send_calls[0]["arguments"]["recipient_id"] == "178900177"
+        assert send_calls[0]["arguments"]["reply_to_message_id"] == "mid_burst_5"
     finally:
         close_harness(harness)

--- a/tests/test_intake_tools.py
+++ b/tests/test_intake_tools.py
@@ -52,7 +52,7 @@ async def test_intake_workflow_upsert_posts_expected_payload() -> None:
     payload = kwargs["json_body"]
     assert payload["customer_id"] == "telegram_123"
     assert payload["name"] == "Car Wash Intake"
-    assert payload["schedule"] == "*/5 * * * *"
+    assert payload["schedule"] == "*/2 * * * *"
     assert payload["channel"] == "instagram_dm"
     assert payload["provider"] == "composio"
     assert payload["assistant_instructions"] == ""

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -165,6 +165,7 @@ class _FakeComposio:
         }
         self.execute_calls: list[dict[str, Any]] = []
         self.list_calls = 0
+        self.list_limits: list[int] = []
         self.get_calls = 0
         self.list_sheet_names_calls: list[dict[str, Any]] = []
 
@@ -175,8 +176,9 @@ class _FakeComposio:
         connected_account_id: str | None = None,
         limit: int = 10,
     ) -> dict[str, Any]:
-        del customer_id, connected_account_id, limit
+        del customer_id, connected_account_id
         self.list_calls += 1
+        self.list_limits.append(limit)
         return {"ok": True, "items": [self.summary], "warnings": self.list_warnings}
 
     def get_instagram_conversation(
@@ -610,7 +612,7 @@ async def test_intake_workflow_upsert_creates_routine_and_skill(tmp_path: Path) 
 
     assert workflow["channel"] == "instagram_dm"
     assert workflow["provider"] == "composio"
-    assert workflow["schedule"] == "*/5 * * * *"
+    assert workflow["schedule"] == "*/2 * * * *"
     assert scheduler.get_routine(workflow["routine_id"]) is not None
     skill = skills.get_skill(
         customer_id="telegram_123",
@@ -1403,14 +1405,14 @@ async def test_instagram_scheduled_workflow_uses_poll_interval_for_fresh_inbound
         "conversation_id": "conv_1",
         "recipient_id": "cust_1",
         "latest_inbound_message_id": "msg_1",
-        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+        "latest_inbound_message_created_time": "2026-04-07T08:02:00+00:00",
         "latest_inbound_sender_username": "alice",
     }
     conversation = _instagram_conversation(
         conversation_id="conv_1",
         latest_message_id="msg_1",
         latest_message_text="Need a car wash tomorrow 3pm.",
-        latest_message_time="2026-04-07T08:00:00+00:00",
+        latest_message_time="2026-04-07T08:02:00+00:00",
     )
     runtime = _FakeRuntime(
         [
@@ -1446,15 +1448,369 @@ async def test_instagram_scheduled_workflow_uses_poll_interval_for_fresh_inbound
         workflow_id=workflow["workflow_id"],
     )
 
-    assert workflow["schedule"] == "*/5 * * * *"
+    assert workflow["schedule"] == "*/2 * * * *"
     assert service._latest_inbound_max_age_for_event(  # noqa: SLF001
         event_type="scheduled",
         workflow=workflow,
-    ) == timedelta(minutes=6)
+    ) == timedelta(minutes=5)
     assert result["ok"] is True
     assert result["processed_conversations"] == 1
     assert result["matched_conversations"] == 1
     assert len(runtime.calls) == 1
+    assert composio.list_limits
+    assert set(composio.list_limits) == {20}
+
+
+@pytest.mark.asyncio
+async def test_instagram_decision_uses_unanswered_customer_burst(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: datetime(2026, 4, 7, 8, 4, 45, tzinfo=UTC),
+    )
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_5",
+        "latest_inbound_message_created_time": "2026-04-07T08:04:30+00:00",
+        "latest_inbound_message_text_preview": "Pleeeeease",
+        "latest_inbound_sender_username": "alice",
+    }
+    conversation = {
+        "data": {
+            "id": "conv_1",
+            "updated_time": "2026-04-07T08:04:30+00:00",
+            "participants": {
+                "data": [
+                    {"id": "business_1", "username": "salon"},
+                    {"id": "cust_1", "username": "alice"},
+                ]
+            },
+            "messages": {
+                "data": [
+                    {
+                        "id": "msg_0",
+                        "created_time": "2026-04-07T07:59:00+00:00",
+                        "message": "What time works on June 8?",
+                        "from": {"id": "business_1", "username": "salon"},
+                    },
+                    {
+                        "id": "msg_1",
+                        "created_time": "2026-04-07T08:00:00+00:00",
+                        "message": "Reach ma ballls",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_1b",
+                        "created_time": "2026-04-07T08:00:30+00:00",
+                        "message": "I mean it",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_1c",
+                        "created_time": "2026-04-07T08:01:00+00:00",
+                        "message": "Please answer",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_1d",
+                        "created_time": "2026-04-07T08:01:30+00:00",
+                        "message": "Need help",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_2",
+                        "created_time": "2026-04-07T08:02:00+00:00",
+                        "message": "Can u do that for me",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_3",
+                        "created_time": "2026-04-07T08:03:00+00:00",
+                        "message": "Still here",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_3b",
+                        "created_time": "2026-04-07T08:03:30+00:00",
+                        "message": "Can you reply",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_4",
+                        "created_time": "2026-04-07T08:04:00+00:00",
+                        "message": "?",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                    {
+                        "id": "msg_5",
+                        "created_time": "2026-04-07T08:04:30+00:00",
+                        "message": "Pleeeeease",
+                        "from": {"id": "cust_1", "username": "alice"},
+                    },
+                ]
+            },
+        }
+    }
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Customer sent a burst of unanswered messages.",
+                "extracted_fields": {},
+                "missing_fields": [],
+                "reply_action": "none",
+                "reply_text": "",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Use full unanswered burst.",
+            }
+        ]
+    )
+    composio = _FakeComposio(summary, conversation)
+    service, _, _, _, _ = _mk_service(tmp_path, runtime=runtime, composio=composio)
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Salon Intake",
+        intent_description="Handle Instagram DMs that ask to book salon appointments.",
+        required_fields=["time", "phone"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+
+    assert result["ok"] is True
+    assert len(runtime.calls) == 1
+    burst = runtime.calls[0]["conversation"]["unanswered_customer_messages"]
+    assert [item["text"] for item in burst] == [
+        "Reach ma ballls",
+        "I mean it",
+        "Please answer",
+        "Need help",
+        "Can u do that for me",
+        "Still here",
+        "Can you reply",
+        "?",
+        "Pleeeeease",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_instagram_stale_decision_refreshes_before_replying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: datetime(2026, 4, 7, 8, 4, 30, tzinfo=UTC),
+    )
+    initial_summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:02:00+00:00",
+        "latest_inbound_sender_username": "alice",
+    }
+    initial_conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Need a car wash tomorrow 3pm.",
+        latest_message_time="2026-04-07T08:02:00+00:00",
+    )
+    composio = _FakeComposio(initial_summary, initial_conversation)
+
+    class _Runtime(_FakeRuntime):
+        async def decide_intake_workflow(self, **kwargs: Any) -> dict[str, Any]:
+            decision = await super().decide_intake_workflow(**kwargs)
+            if len(self.calls) == 1:
+                composio.summary = {
+                    **initial_summary,
+                    "latest_inbound_message_id": "msg_2",
+                    "latest_inbound_message_created_time": "2026-04-07T08:04:00+00:00",
+                    "latest_inbound_message_text_preview": "Actually make it 4pm.",
+                }
+                composio.conversation = _instagram_conversation(
+                    conversation_id="conv_1",
+                    latest_message_id="msg_2",
+                    latest_message_text="Actually make it 4pm.",
+                    latest_message_time="2026-04-07T08:04:00+00:00",
+                )
+            return decision
+
+    runtime = _Runtime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Customer wants a car wash booking.",
+                "extracted_fields": {},
+                "missing_fields": ["time"],
+                "reply_action": "send_reply",
+                "reply_text": "What time works?",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Ask for missing time.",
+            },
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Customer changed the requested time.",
+                "extracted_fields": {"time": "4pm"},
+                "missing_fields": [],
+                "reply_action": "send_reply",
+                "reply_text": "Great, I have 4pm.",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Reply to the latest inbound message.",
+            },
+        ]
+    )
+    service, _, _, _, _ = _mk_service(tmp_path, runtime=runtime, composio=composio)
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["day"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="auto",
+    )
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+    cursor = service._get_cursor(  # noqa: SLF001
+        workflow_id=workflow["workflow_id"],
+        conversation_id="conv_1",
+    )
+
+    assert workflow["schedule"] == "*/2 * * * *"
+    assert result["processed_conversations"] == 1
+    assert result["results"][0]["status"] == "ignored"
+    assert result["results"][0]["replied"] is True
+    assert cursor["last_seen_inbound_message_id"] == "msg_2"
+    assert composio.execute_calls == [
+        {
+            "customer_id": "telegram_123",
+            "tool_slug": "INSTAGRAM_SEND_TEXT_MESSAGE",
+            "arguments": {
+                "recipient_id": "cust_1",
+                "conversation_id": "conv_1",
+                "text": "Great, I have 4pm.",
+                "reply_to_message_id": "msg_2",
+            },
+            "connected_account_id": None,
+            "text": None,
+        }
+    ]
+    assert len(runtime.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_instagram_apply_stale_wait_does_not_advance_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        intake_service_module,
+        "_utc_now",
+        lambda: datetime(2026, 4, 7, 8, 4, 30, tzinfo=UTC),
+    )
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:02:00+00:00",
+        "latest_inbound_sender_username": "alice",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Need a car wash tomorrow 3pm.",
+        latest_message_time="2026-04-07T08:02:00+00:00",
+    )
+    runtime = _FakeRuntime(
+        [
+            {
+                "ok": True,
+                "matches_workflow": True,
+                "confidence": 0.95,
+                "conversation_summary": "Customer wants a car wash booking.",
+                "extracted_fields": {},
+                "missing_fields": ["vehicle"],
+                "reply_action": "send_reply",
+                "reply_text": "What vehicle should we book?",
+                "ready_to_save": False,
+                "booking_action": "ignore",
+                "save_payload": {},
+                "reason": "Ask for missing vehicle.",
+            }
+        ]
+    )
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=runtime,
+        composio=_FakeComposio(summary, conversation),
+    )
+    workflow = service.upsert_workflow(
+        customer_id="telegram_123",
+        name="Car Wash Intake",
+        intent_description="Handle Instagram DMs that ask to book a car wash service.",
+        required_fields=["vehicle"],
+        sink_type="local_csv",
+        sink_config={"file_path": "tulpa_stuff/bookings.csv"},
+        reply_mode="auto",
+    )
+    stale_checks = 0
+
+    def _fake_stale_check(**kwargs: Any) -> tuple[bool, dict[str, Any], str | None]:
+        nonlocal stale_checks
+        stale_checks += 1
+        raw_summary = kwargs.get("decided_summary")
+        decided_summary = dict(raw_summary if isinstance(raw_summary, dict) else {})
+        if stale_checks == 1:
+            return False, decided_summary, None
+        latest_summary = dict(decided_summary)
+        latest_summary["latest_inbound_message_id"] = "msg_2"
+        latest_summary["latest_inbound_message_created_time"] = "2026-04-07T08:04:00+00:00"
+        return True, latest_summary, None
+
+    monkeypatch.setattr(service, "_conversation_became_stale", _fake_stale_check)
+
+    result = await service.run_workflow(
+        customer_id="telegram_123",
+        workflow_id=workflow["workflow_id"],
+    )
+
+    assert result["results"] == [
+        {
+            "conversation_id": "conv_1",
+            "matched": True,
+            "status": "stale_waiting_for_next_poll",
+            "replied": False,
+        }
+    ]
+    assert stale_checks == 2
+    assert service._get_cursor(  # noqa: SLF001
+        workflow_id=workflow["workflow_id"],
+        conversation_id="conv_1",
+    ) == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -2077,6 +2077,9 @@ async def test_telegram_business_workflow_uses_bound_files_and_replies_via_busin
     assert runtime.calls[0]["workflow"]["knowledge_file_ids"] == [str(knowledge["id"])]
     assert runtime.calls[0]["workflow"]["knowledge_answer"] == ""
     assert "Reference numbers" in runtime.calls[1]["workflow"]["knowledge_answer"]
+    assert runtime.calls[1]["conversation"]["unanswered_customer_messages"] == runtime.calls[0][
+        "conversation"
+    ]["unanswered_customer_messages"]
     sent = telegram_business.client.sent_messages[0]
     assert sent["chat_id"] == "555"
     assert sent["business_connection_id"] == "bc_123"

--- a/tests/test_prompt_policy_hardening.py
+++ b/tests/test_prompt_policy_hardening.py
@@ -438,12 +438,12 @@ async def test_routine_create_allows_scheduled_instagram_intake_workflow() -> No
             "channel": "instagram_dm",
             "provider": "composio",
             "routine_id": "",
-            "schedule": "*/5 * * * *",
+            "schedule": "*/2 * * * *",
         }
     )
     args = {
         "name": "Instagram intake poller",
-        "schedule": "*/5 * * * *",
+        "schedule": "*/2 * * * *",
         "implementation_command": "python3 -m opentulpa.intake_runner --workflow-id iwf_insta",
         "instruction": "Run intake workflow iwf_insta.",
     }

--- a/tests/test_runtime_structured_model.py
+++ b/tests/test_runtime_structured_model.py
@@ -742,6 +742,7 @@ async def test_decide_intake_workflow_uses_stronger_policy_prompt() -> None:
         conversation={
             "summary": {"conversation_id": "conv_1"},
             "recent_messages": [{"sender_role": "customer", "text": "thanks"}],
+            "unanswered_customer_messages": [{"sender_role": "customer", "text": "thanks"}],
         },
         active_booking=None,
         recent_completed_booking=None,
@@ -763,6 +764,7 @@ async def test_decide_intake_workflow_uses_stronger_policy_prompt() -> None:
     assert messages[0].content[0]["cache_control"] == {"type": "ephemeral"}
     assert isinstance(messages[1].content, str)
     assert "Default mode is not an intent filter" in system_text
+    assert "conversation.unanswered_customer_messages as the active customer turn" in system_text
     assert "workflow.intent_match_required is true" in system_text
     assert "If customer messages conflict, prefer the latest customer-provided value" in system_text
     assert "Ask at most one compact question at a time" in system_text

--- a/tests/test_workflow_setup_service.py
+++ b/tests/test_workflow_setup_service.py
@@ -377,7 +377,7 @@ def test_workflow_setup_update_clears_schedule_for_telegram_channel(tmp_path: Pa
         draft_patch={
             "channel": "telegram_business_dm",
             "provider": "telegram_bot_api",
-            "schedule": "*/5 * * * *",
+            "schedule": "*/2 * * * *",
         },
     )
 


### PR DESCRIPTION
## What changed

- Changed default Instagram intake cron from `*/5 * * * *` to `*/2 * * * *` across service defaults, setup flow, API route, and intake workflow tool.
- Set scheduled Instagram inbound lookback to 5 minutes.
- Set Instagram intake's default and max Composio scan limit to 20 recent conversations.
- Generalized the Telegram Business stale-inbound guard into a shared latest-inbound guard.
- Kept Telegram Business behavior the same: stale webhook work is requeued.
- Added Instagram Composio behavior: if a newer inbound message arrives after the intake decision was made, refetch the latest conversation and rerun the decision inside the same cron run, bounded to two refresh attempts.
- If Instagram messages keep changing through those bounded refresh attempts, skip the stale reply and leave it for the next scheduled poll.
- Treat both stale terminal statuses (`stale_requeued`, `stale_waiting_for_next_poll`) as terminal after apply so stale Instagram waits do not advance the cursor for the old inbound.
- Added `unanswered_customer_messages` so Instagram decisions see the customer messages after the last assistant reply within the 5-minute active window, not only the latest message preview.
- Increased intake message history and prompt compaction limits so short multi-message bursts are preserved.
- Added a live LLM E2E that simulates scheduled Instagram conversations, verifies a burst reply is sent once, then verifies the cursor prevents a duplicate reply on the next scheduled run.

## Intended flow

1. Cron fires every 2 minutes.
2. Intake asks Composio for 20 recent Instagram conversations.
3. Intake considers conversations whose latest inbound is within the 5-minute scheduled lookback and has not already been cursor-processed.
4. For each eligible conversation, intake fetches conversation detail and builds the active customer turn from unanswered customer messages after the last OpenTulpa reply within the 5-minute window.
5. Runtime checks workflow intent/active booking state and drafts or sends a reply using that whole active customer turn.

## Validation

- `uv run pytest -q tests/test_intake_workflow_service.py`
- `uv run pytest -q tests/test_intake_workflow_service.py -k "instagram_apply_stale_wait_does_not_advance_cursor or instagram_stale_decision_refreshes_before_replying or telegram_business_final_stale_guard_prevents_sink_and_reply"`
- `uv run pytest -q --run-e2e --run-live-llm -rs tests/e2e/scenarios/test_instagram_intake_drafts.py::test_live_llm_instagram_intake_draft_approval_repairs_composio_payload tests/e2e/scenarios/test_instagram_intake_drafts.py::test_live_llm_instagram_scheduled_burst_replies_once`
- `uv run ruff check src/opentulpa/intake/service.py tests/test_intake_workflow_service.py tests/e2e/scenarios/test_instagram_intake_drafts.py`
- `git diff --check`

## Note

Existing persisted workflows that already store `*/5 * * * *` may need an explicit workflow update or data migration to move their stored schedule to `*/2 * * * *`.

`mypy` still fails on existing repo-wide/imported type debt unrelated to this patch.
