### PR TITLE
Expose deployment identity in health checks

### DIFF
--- a/src/opentulpa/api/routes/health.py
+++ b/src/opentulpa/api/routes/health.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+
+STARTED_AT = datetime.now(UTC).isoformat()
 
 
 def register_health_routes(
@@ -27,12 +31,29 @@ def register_health_routes(
                 content={
                     "status": "draining",
                     "active_turns": int(getattr(status, "active_turns", 0)),
+                    **_deployment_identity(),
                 },
             )
-        return {"status": "ok"}
+        return {"status": "ok", **_deployment_identity()}
 
     @app.get("/agent/healthz")
     async def agent_health() -> dict[str, Any]:
         runtime = get_agent_runtime()
         healthy = bool(runtime and getattr(runtime, "healthy", lambda: False)())
-        return {"status": "ok" if healthy else "degraded", "backend": "langgraph"}
+        return {"status": "ok" if healthy else "degraded", "backend": "langgraph", **_deployment_identity()}
+
+
+def _deployment_identity() -> dict[str, str | None]:
+    return {
+        "commit_sha": _clean_env("RAILWAY_GIT_COMMIT_SHA") or _clean_env("GIT_COMMIT_SHA"),
+        "deployment_id": _clean_env("RAILWAY_DEPLOYMENT_ID") or _clean_env("OPENTULPA_DEPLOYMENT_ID"),
+        "started_at": STARTED_AT,
+    }
+
+
+def _clean_env(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -41,9 +41,12 @@ def test_internal_routes_blocked_from_public_clients(
 
         healthz = client.get("/healthz")
         assert healthz.status_code == 200
+        assert "started_at" in healthz.json()
 
         agent_healthz = client.get("/agent/healthz")
         assert agent_healthz.status_code == 200
+        assert agent_healthz.json()["backend"] == "langgraph"
+        assert "started_at" in agent_healthz.json()
     get_settings.cache_clear()
 
 
@@ -57,7 +60,9 @@ def test_healthz_reports_draining_during_shutdown(tmp_path: Path) -> None:
         draining = client.get("/healthz")
 
     assert draining.status_code == 503
-    assert draining.json() == {"status": "draining", "active_turns": 0}
+    assert draining.json()["status"] == "draining"
+    assert draining.json()["active_turns"] == 0
+    assert "started_at" in draining.json()
     get_settings.cache_clear()
 
 


### PR DESCRIPTION
## Summary
- Add deployment identity fields to `/healthz` and `/agent/healthz`.
- Include `commit_sha`, `deployment_id`, and `started_at` in normal and draining health responses.
- Keep existing public health route access behavior intact.

## Why
The dashboard monitor needs to distinguish a newly redeployed OpenTulpa instance from an old container that is still serving during a Railway swap. Without identity in health responses, a redeploy can look healthy before the target deployment is actually active.

## Validation
- `uv run pytest -q tests/test_internal_api_auth.py`
- `uv run ruff check src/opentulpa/api/routes/health.py tests/test_internal_api_auth.py`
