### PR TITLE
Move compaction memory persistence off hot path

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -404,6 +404,7 @@ def main() -> None:
             context_recent_tokens=settings.agent_context_recent_tokens,
             context_rollup_tokens=settings.agent_context_rollup_tokens,
             context_compaction_source_tokens=settings.agent_context_compaction_source_tokens,
+            context_compaction_model_name=settings.agent_context_compaction_model,
             proactive_heartbeat_default_hours=settings.proactive_heartbeat_default_hours,
             behavior_log_enabled=settings.agent_behavior_log_enabled,
             behavior_log_path=settings.agent_behavior_log_path,

--- a/src/opentulpa/agent/context_compaction.py
+++ b/src/opentulpa/agent/context_compaction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import re
 from contextlib import suppress
 from typing import Any
@@ -25,6 +27,8 @@ _SECRET_PATTERNS = (
     r"\bmlsn\.[A-Za-z0-9._-]+",
     r"\bGOCSPX-[A-Za-z0-9._-]+",
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _trim_text_to_token_budget(text: str, token_budget: int) -> str:
@@ -115,6 +119,39 @@ def _select_split_index(message_tokens: list[int], *, tokens_to_compact: int) ->
     return max(0, split_idx)
 
 
+async def thread_context_needs_compaction(runtime: Any, *, thread_id: str) -> bool:
+    tid = str(thread_id or "").strip()
+    if not tid:
+        return False
+    graph = getattr(runtime, "_graph", None)
+    if graph is None:
+        return False
+    checkpointer = getattr(runtime, "_checkpointer", None)
+    if checkpointer is None or not hasattr(checkpointer, "adelete_thread"):
+        return False
+
+    config = {"configurable": {"thread_id": tid}, "recursion_limit": runtime.recursion_limit}
+    try:
+        snapshot = await graph.aget_state(config=config)
+        values = getattr(snapshot, "values", {}) or {}
+        state_messages = values.get("messages", [])
+        if not isinstance(state_messages, list) or not state_messages:
+            return False
+        message_texts = [_message_to_text(m) for m in state_messages]
+        message_tokens = [_approx_tokens(t) for t in message_texts]
+        total_tokens = sum(message_tokens)
+        short_term_high_budget = _short_term_high_token_budget(runtime)
+        if total_tokens < short_term_high_budget:
+            return False
+        overflow_tokens = total_tokens - _short_term_low_token_budget(runtime)
+        split_idx = _select_split_index(message_tokens, tokens_to_compact=overflow_tokens)
+        if split_idx <= 0:
+            return False
+        return bool("\n\n".join(message_texts[:split_idx]).strip())
+    except Exception:
+        return False
+
+
 def split_text_chunks(text: str, *, approx_tokens_per_chunk: int = 25000) -> list[str]:
     raw = str(text or "").strip()
     if not raw:
@@ -178,16 +215,18 @@ async def compress_rollup(runtime: Any, existing_rollup: str, additional_text: s
             ),
         ]
         ainvoke_model = getattr(runtime, "ainvoke_model", None)
+        model = getattr(runtime, "_context_compaction_model", runtime._model)
         if callable(ainvoke_model):
             response = await ainvoke_model(
-                runtime._model,
+                model,
                 messages,
                 call_context={
                     "call_site": "context_compaction",
+                    "model_name": getattr(runtime, "_context_compaction_model_name", ""),
                 },
             )
         else:
-            response = await runtime._model.ainvoke(messages)
+            response = await model.ainvoke(messages)
         running = _sanitize_rollup_text(_content_to_text(getattr(response, "content", "")).strip() or running)
         running = _trim_text_to_token_budget(running, rollup_budget)
     return _trim_text_to_token_budget(_sanitize_rollup_text(running), rollup_budget)
@@ -226,6 +265,38 @@ async def persist_rollup_memory(
             timeout=10.0,
             retries=1,
         )
+
+
+def schedule_rollup_memory_persist(
+    runtime: Any,
+    *,
+    customer_id: str,
+    thread_id: str,
+    rollup: str,
+) -> None:
+    cid = str(customer_id or "").strip()
+    tid = str(thread_id or "").strip()
+    if not cid or not tid or not str(rollup or "").strip():
+        return
+
+    async def _persist() -> None:
+        try:
+            await persist_rollup_memory(
+                runtime,
+                customer_id=cid,
+                thread_id=tid,
+                rollup=rollup,
+            )
+        except Exception:
+            logger.exception("Failed to persist compacted thread rollup memory.")
+
+    task = asyncio.create_task(_persist())
+    background_tasks = getattr(runtime, "_context_compaction_background_tasks", None)
+    if not isinstance(background_tasks, set):
+        background_tasks = set()
+        runtime._context_compaction_background_tasks = background_tasks
+    background_tasks.add(task)
+    task.add_done_callback(background_tasks.discard)
 
 
 async def maybe_compact_thread_context(
@@ -281,7 +352,7 @@ async def maybe_compact_thread_context(
                 return
 
             runtime._save_thread_rollup(tid, updated_rollup)
-            await persist_rollup_memory(
+            schedule_rollup_memory_persist(
                 runtime,
                 customer_id=customer_id,
                 thread_id=tid,

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -50,6 +50,9 @@ from opentulpa.agent.context_compaction import (
 from opentulpa.agent.context_compaction import (
     split_text_chunks as _split_text_chunks,
 )
+from opentulpa.agent.context_compaction import (
+    thread_context_needs_compaction as _thread_context_needs_compaction,
+)
 from opentulpa.agent.context_engineer import ContextEngineer
 from opentulpa.agent.context_engineer import (
     trim_text_to_token_budget as _trim_text_to_token_budget,
@@ -528,6 +531,7 @@ STREAM_EMPTY_REPLY_FALLBACK = (
     "Please retry, and I will continue from the latest state."
 )
 STREAM_PRECOMMIT_SECONDS = 0.75
+CONTEXT_COMPACTION_BACKGROUND_DRAIN_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -1260,6 +1264,7 @@ class OpenTulpaLangGraphRuntime:
         context_rollup_tokens: int = 2200,
         context_recent_tokens: int = 3500,
         context_compaction_source_tokens: int = 12000,
+        context_compaction_model_name: str | None = "google/gemini-3-flash-preview",
         input_debounce_seconds: float = 0.65,
         proactive_heartbeat_default_hours: int = 3,
         behavior_log_enabled: bool = True,
@@ -1309,6 +1314,11 @@ class OpenTulpaLangGraphRuntime:
         self._workflow_setup_input_classifier_model_name = _normalize_model_name(
             workflow_setup_classifier_model
         )
+        self._context_compaction_model_name = (
+            _normalize_model_name(str(context_compaction_model_name).strip())
+            if str(context_compaction_model_name or "").strip()
+            else self.model_name
+        )
         self.checkpoint_db_path = checkpoint_db_path
         self.recursion_limit = recursion_limit
         self._context_events = context_events
@@ -1347,6 +1357,7 @@ class OpenTulpaLangGraphRuntime:
         self._llm_call_trace_limit = _LLM_CALL_TRACE_LIMIT
         self._thread_checkpoint_locks: dict[str, asyncio.Lock] = {}
         self._thread_checkpoint_locks_guard = asyncio.Lock()
+        self._context_compaction_background_tasks: set[asyncio.Task[Any]] = set()
         if self._behavior_log_enabled:
             self._behavior_log_path.parent.mkdir(parents=True, exist_ok=True)
         self._browser_use_headless = bool(browser_use_headless)
@@ -1497,6 +1508,32 @@ class OpenTulpaLangGraphRuntime:
                     self.model_name,
                 )
                 self._workflow_setup_input_classifier_model = self._model
+        if self._context_compaction_model_name == self.model_name:
+            self._context_compaction_model = self._model
+        elif self._context_compaction_model_name == self._wake_classifier_model_name:
+            self._context_compaction_model = self._wake_classifier_model
+        elif self._context_compaction_model_name == self._wake_execution_model_name:
+            self._context_compaction_model = self._wake_execution_model
+        elif self._context_compaction_model_name == self._telegram_media_model_name:
+            self._context_compaction_model = self._telegram_media_model
+        elif self._context_compaction_model_name == self._workflow_setup_input_classifier_model_name:
+            self._context_compaction_model = self._workflow_setup_input_classifier_model
+        else:
+            try:
+                self._context_compaction_model = _init_runtime_chat_model(
+                    self._context_compaction_model_name,
+                    base_kwargs=model_init_kwargs,
+                    openrouter_base_url=self.openrouter_base_url,
+                    reasoning_effort=self._reasoning_effort,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to initialize context compaction model '%s'; "
+                    "falling back to main model '%s'.",
+                    self._context_compaction_model_name,
+                    self.model_name,
+                )
+                self._context_compaction_model = self._model
 
         self._checkpointer_cm: Any | None = None
         self._checkpointer: Any | None = None
@@ -2986,7 +3023,34 @@ class OpenTulpaLangGraphRuntime:
             if preflight_error:
                 logger.warning("browser_use local preflight warning: %s", preflight_error)
 
+    async def _drain_context_compaction_background_tasks(self) -> None:
+        task_set = getattr(self, "_context_compaction_background_tasks", None)
+        if not isinstance(task_set, set):
+            return
+        pending = {task for task in task_set if not task.done()}
+        task_set.intersection_update(pending)
+        if not pending:
+            task_set.clear()
+            return
+        done, still_pending = await asyncio.wait(
+            pending,
+            timeout=CONTEXT_COMPACTION_BACKGROUND_DRAIN_SECONDS,
+        )
+        for task in done:
+            with suppress(BaseException):
+                task.result()
+        task_set.difference_update(done)
+        if still_pending:
+            logger.warning(
+                "context_compaction background persistence drain timed out pending_tasks=%s",
+                len(still_pending),
+            )
+            for task in still_pending:
+                task.cancel()
+            task_set.difference_update(still_pending)
+
     async def shutdown(self) -> None:
+        await self._drain_context_compaction_background_tasks()
         manager = self._browser_use_local_manager
         if manager is not None:
             with suppress(Exception):
@@ -3569,6 +3633,25 @@ class OpenTulpaLangGraphRuntime:
                     thread_id=thread_id,
                     customer_id=customer_id,
                     waited_ms=checkpoint_waited_ms,
+                )
+            if stream_status_events and await _thread_context_needs_compaction(
+                self,
+                thread_id=thread_id,
+            ):
+                self.log_behavior_event(
+                    event="turn_context_compaction_status_emitted",
+                    trace_id=turn_trace_id,
+                    mode="astream",
+                    thread_id=thread_id,
+                    customer_id=customer_id,
+                    turn_mode=normalized_turn_mode,
+                )
+                yield AgentStreamEvent(
+                    event="status",
+                    payload={
+                        "status": "active",
+                        "message": "Compacting chat history...",
+                    },
                 )
             await self._maybe_compact_thread_context(
                 thread_id=thread_id,

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -360,7 +360,7 @@ async def _stream_turn(
                     stream_status_events=True,
                 ):
                     if isinstance(chunk, AgentStreamEvent):
-                        if chunk.event in {"reasoning", "tool_call"}:
+                        if chunk.event in {"reasoning", "status", "tool_call"}:
                             if chunk.event == "tool_call":
                                 final_text = ""
                             await queue.put((chunk.event, chunk.payload))

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -108,6 +108,10 @@ class Settings(BaseSettings):
         le=500000,
         description="Max oldest-token span folded into rollup in one compaction pass.",
     )
+    agent_context_compaction_model: str = Field(
+        default="google/gemini-3-flash-preview",
+        description="Model used to compact old thread history before normal chat turns.",
+    )
     link_alias_db_path: str = Field(
         default=".opentulpa/link_aliases.db",
         description="SQLite path for customer-scoped long-link alias registry.",

--- a/tests/test_context_compaction_window.py
+++ b/tests/test_context_compaction_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -10,6 +11,7 @@ from opentulpa.agent.context_compaction import (
     _select_split_index,
     _trim_text_to_token_budget,
     maybe_compact_thread_context,
+    persist_rollup_memory,
 )
 from opentulpa.agent.lc_messages import HumanMessage
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
@@ -34,6 +36,10 @@ def test_select_split_index_compacts_enough_without_dropping_all() -> None:
 
 def test_context_compaction_default_threshold_is_20000() -> None:
     assert Settings.model_fields["agent_context_token_limit"].default == 20000
+    assert (
+        Settings.model_fields["agent_context_compaction_model"].default
+        == "google/gemini-3-flash-preview"
+    )
 
 
 def test_runtime_context_token_limit_clamps_at_30000(tmp_path) -> None:
@@ -84,6 +90,8 @@ class _DummyRuntime:
         self._graph = _DummyGraph(messages)
         self._checkpointer = _DummyCheckpointer()
         self._model = _DummyModel()
+        self._context_compaction_model = self._model
+        self._context_compaction_model_name = "google/gemini-3-flash-preview"
         self.recursion_limit = 30
         self._context_token_limit = 40000
         self._context_short_term_high_tokens = 40000
@@ -92,12 +100,38 @@ class _DummyRuntime:
         self._context_rollup_tokens = 5000
         self._context_compaction_source_tokens = 12000
         self._rollups: dict[str, str] = {}
+        self.memory_add_calls: list[dict[str, Any]] = []
+        self.memory_persist_started = False
+        self.memory_persist_continue: asyncio.Event | None = None
 
     def _load_thread_rollup(self, thread_id: str) -> str | None:
         return self._rollups.get(thread_id)
 
     def _save_thread_rollup(self, thread_id: str, rollup: str) -> None:
         self._rollups[thread_id] = str(rollup or "").strip()
+
+    async def _request_with_backoff(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any],
+        timeout: float,
+        retries: int,
+    ) -> dict[str, Any]:
+        self.memory_persist_started = True
+        self.memory_add_calls.append(
+            {
+                "method": method,
+                "path": path,
+                "json_body": json_body,
+                "timeout": timeout,
+                "retries": retries,
+            }
+        )
+        if self.memory_persist_continue is not None:
+            await self.memory_persist_continue.wait()
+        return {"ok": True}
 
 
 @pytest.mark.asyncio
@@ -128,6 +162,107 @@ async def test_maybe_compact_thread_context_enforces_recent_window_and_rollup_ca
     rollup = runtime._rollups.get("chat-test", "")
     assert rollup
     assert approx_tokens(rollup) <= 5000
+
+
+@pytest.mark.asyncio
+async def test_compaction_schedules_rollup_memory_persist_off_hot_path() -> None:
+    messages = [HumanMessage(content=f"msg_{i} " + ("x" * 2800)) for i in range(70)]
+    runtime = _DummyRuntime(messages)
+    runtime.memory_persist_continue = asyncio.Event()
+
+    await maybe_compact_thread_context(
+        runtime,
+        thread_id="chat-background",
+        customer_id="telegram_1",
+    )
+
+    assert runtime._rollups.get("chat-background")
+    assert runtime._checkpointer.deleted is True
+    assert runtime._context_compaction_background_tasks
+
+    for _ in range(20):
+        if runtime.memory_persist_started:
+            break
+        await asyncio.sleep(0)
+    assert runtime.memory_persist_started is True
+    assert runtime.memory_add_calls
+    body = runtime.memory_add_calls[0]["json_body"]
+    assert "infer" not in body
+    assert body["metadata"] == {
+        "kind": "thread_context_rollup",
+        "thread_id": "chat-background",
+    }
+
+    runtime.memory_persist_continue.set()
+    await asyncio.gather(*runtime._context_compaction_background_tasks)
+    assert not runtime._context_compaction_background_tasks
+
+
+@pytest.mark.asyncio
+async def test_runtime_shutdown_drains_compaction_memory_tasks_before_teardown() -> None:
+    events: list[str] = []
+
+    class _Manager:
+        async def shutdown(self) -> None:
+            events.append("manager_shutdown")
+
+    async def _background_persist() -> None:
+        await asyncio.sleep(0)
+        events.append("persist_done")
+
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    task = asyncio.create_task(_background_persist())
+    runtime._context_compaction_background_tasks = {task}
+    runtime._browser_use_local_manager = _Manager()
+    runtime._langfuse_tracer = None
+    runtime._checkpointer_cm = None
+    runtime._checkpointer = object()
+    runtime._graph = object()
+    runtime._model_with_tools = object()
+    runtime._workflow_setup_model_with_tools = object()
+    runtime._wake_execution_model_with_tools = object()
+
+    await runtime.shutdown()
+
+    assert events == ["persist_done", "manager_shutdown"]
+    assert runtime._context_compaction_background_tasks == set()
+    assert runtime._browser_use_local_manager is None
+    assert runtime._checkpointer is None
+    assert runtime._graph is None
+
+
+@pytest.mark.asyncio
+async def test_persist_rollup_memory_leaves_mem0_inference_enabled() -> None:
+    runtime = _DummyRuntime([])
+
+    await persist_rollup_memory(
+        runtime,
+        customer_id="telegram_1",
+        thread_id="chat-direct",
+        rollup="durable summary",
+    )
+
+    assert runtime.memory_add_calls
+    assert runtime.memory_add_calls[0]["path"] == "/internal/memory/add"
+    assert "infer" not in runtime.memory_add_calls[0]["json_body"]
+
+
+@pytest.mark.asyncio
+async def test_maybe_compact_thread_context_uses_configured_compaction_model() -> None:
+    messages = [HumanMessage(content=f"msg_{i} " + ("x" * 2800)) for i in range(70)]
+    runtime = _DummyRuntime(messages)
+    compaction_model = _DummyModel()
+    runtime._context_compaction_model = compaction_model
+    runtime._context_compaction_model_name = "google/gemini-3-flash-preview"
+
+    await maybe_compact_thread_context(
+        runtime,
+        thread_id="chat-compaction-model",
+        customer_id="telegram_1",
+    )
+
+    assert compaction_model.calls
+    assert not runtime._model.calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_generic_chat_routes.py
+++ b/tests/test_generic_chat_routes.py
@@ -52,6 +52,10 @@ class _StreamingRuntime:
         if kwargs.get("stream_incremental_deltas"):
             if kwargs.get("stream_status_events"):
                 yield AgentStreamEvent(
+                    event="status",
+                    payload={"status": "active", "message": "Compacting chat history..."},
+                )
+                yield AgentStreamEvent(
                     event="reasoning",
                     payload={"status": "active", "message": "Reasoning..."},
                 )
@@ -162,6 +166,9 @@ def test_web_chat_streams_owner_updates_files_and_final(monkeypatch: Any, tmp_pa
     assert "Checking context." in text
     assert "event: file" in text
     assert "/web/files/file_123/content" in text
+    assert {"status": "active", "message": "Compacting chat history..."} in _sse_payloads(
+        text, "status"
+    )
     assert "event: reasoning" in text
     assert "private reasoning" not in text
     assert _sse_payloads(text, "reasoning") == [{"status": "active", "message": "Reasoning..."}]

--- a/tests/test_runtime_stream_fallback.py
+++ b/tests/test_runtime_stream_fallback.py
@@ -809,3 +809,57 @@ async def test_astream_text_emits_safe_reasoning_and_tool_status_events(tmp_path
     assert "private reasoning" not in json.dumps([event.payload for event in events])
     assert "second private" not in json.dumps([event.payload for event in events])
     assert chunks[-1] == "Done."
+
+
+@pytest.mark.asyncio
+async def test_astream_text_emits_compaction_status_before_compacting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = object.__new__(OpenTulpaLangGraphRuntime)
+    runtime._graph = _ReasoningThenToolThenAnswerGraph()
+    runtime._thread_inputs = ThreadInputCoordinator(debounce_seconds=0.0)
+    runtime._context_events = None
+    runtime._link_alias_service = None
+    runtime.recursion_limit = 8
+    runtime._behavior_log_enabled = True
+    runtime._behavior_log_path = tmp_path / "agent_behavior_compaction_status.jsonl"
+    runtime._behavior_log_lock = threading.Lock()
+    compact_calls: list[tuple[str, str]] = []
+
+    async def _noop_start() -> None:
+        return None
+
+    async def _needs_compaction(_runtime: Any, *, thread_id: str) -> bool:
+        assert _runtime is runtime
+        assert thread_id == "chat-compaction-status"
+        return True
+
+    async def _noop_compact(*, thread_id: str, customer_id: str) -> None:
+        compact_calls.append((thread_id, customer_id))
+        return None
+
+    async def _noop_skills(*, customer_id: str, user_text: str) -> dict[str, Any]:
+        del customer_id, user_text
+        return {}
+
+    monkeypatch.setattr(runtime_module, "_thread_context_needs_compaction", _needs_compaction)
+    runtime.start = _noop_start  # type: ignore[method-assign]
+    runtime._maybe_compact_thread_context = _noop_compact  # type: ignore[method-assign]
+    runtime._pre_resolve_skill_state = _noop_skills  # type: ignore[method-assign]
+
+    chunks: list[str | AgentStreamEvent] = []
+    async for chunk in runtime.astream_text(
+        thread_id="chat-compaction-status",
+        customer_id="telegram_compaction_status",
+        text="search",
+        stream_status_events=True,
+    ):
+        chunks.append(chunk)
+
+    events = [chunk for chunk in chunks if isinstance(chunk, AgentStreamEvent)]
+    assert events[0] == AgentStreamEvent(
+        event="status",
+        payload={"status": "active", "message": "Compacting chat history..."},
+    )
+    assert compact_calls == [("chat-compaction-status", "telegram_compaction_status")]


### PR DESCRIPTION
## Summary

- Move thread-rollup memory persistence off the synchronous compaction path.
- Keep mem0 inference enabled for the background write.
- Add `AGENT_CONTEXT_COMPACTION_MODEL`, defaulting to `google/gemini-3-flash-preview`, and use it for context compaction calls.

## Why

A live dashboard chat turn waited about 90s before the assistant response appeared. Langfuse showed the actual answer generation took ~3s; the delay was context compaction plus mem0/Qdrant inference work happening before normal chat streaming.

## Behavior

Compaction still saves the thread rollup before trimming old checkpoint messages. The mem0 `/internal/memory/add` call is scheduled in the background afterward, so its inference/update/vector-store work no longer blocks the reply path.

## Validation

- `uv run pytest tests/test_context_compaction_window.py tests/test_config_api_key_alias.py -q`
- `uv run ruff check src/opentulpa/agent/context_compaction.py src/opentulpa/agent/runtime.py src/opentulpa/core/config.py src/opentulpa/__main__.py tests/test_context_compaction_window.py`
