### PR TITLE
Add web intake workflow routes

### DIFF
--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -575,6 +575,7 @@ def create_app(
             and not path.startswith("/webhook/")
             and path != "/web/events"
             and not path.startswith("/web/chat/")
+            and not path.startswith("/web/intake/workflows")
             and not path.startswith("/web/files/")
             and not path.startswith("/web/local-files/")
             and path not in public_health_paths
@@ -659,6 +660,7 @@ def create_app(
         app,
         get_intake_workflows=get_intake_workflows,
         get_workflow_setup_service=get_workflow_setup_service,
+        get_file_vault=get_file_vault,
         resolve_customer_id=profile_service.resolve_customer_id,
         web_token=settings.opentulpa_web_token,
     )

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -499,9 +499,11 @@ async def _postprocess_uploaded_file(
 def _web_file_metadata(record: dict[str, Any]) -> dict[str, Any]:
     clean = sanitize_uploaded_file_record(record, include_excerpt=False)
     file_id = str(clean.get("id") or "").strip()
+    customer_id = str(clean.get("customer_id") or "").strip()
     if file_id:
-        clean["content_path"] = f"/web/files/{quote(file_id)}/content"
-        clean["metadata_path"] = f"/web/files/{quote(file_id)}/metadata"
+        query = f"?customer_id={quote(customer_id, safe='')}" if customer_id else ""
+        clean["content_path"] = f"/web/files/{quote(file_id)}/content{query}"
+        clean["metadata_path"] = f"/web/files/{quote(file_id)}/metadata{query}"
     return clean
 
 

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hmac
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import quote
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from opentulpa.api.customer_ids import resolve_body_customer_id
+from opentulpa.api.file_helpers import sanitize_uploaded_file_record
 
 
 def register_intake_workflow_routes(
@@ -16,12 +19,56 @@ def register_intake_workflow_routes(
     *,
     get_intake_workflows: Callable[[], Any],
     get_workflow_setup_service: Callable[[], Any],
+    get_file_vault: Callable[[], Any] | None = None,
     resolve_customer_id: Callable[[str], str] | None = None,
     web_token: str | None = None,
 ) -> None:
     """Register internal intake workflow endpoints."""
 
-    _ = web_token
+    def _authorized_web_request(request: Request) -> bool:
+        expected = str(web_token or "").strip()
+        if not expected:
+            return False
+        header = str(request.headers.get("authorization", "") or "").strip()
+        scheme, _, token = header.partition(" ")
+        return scheme.lower() == "bearer" and hmac.compare_digest(token.strip(), expected)
+
+    def _web_customer_id(request: Request) -> str:
+        raw = str(request.query_params.get("customer_id", "") or "").strip()
+        return resolve_body_customer_id({"customer_id": raw}, resolve_customer_id)
+
+    def _workflow_with_knowledge_files(workflow: dict[str, Any]) -> dict[str, Any]:
+        item = dict(workflow)
+        file_vault = get_file_vault() if get_file_vault is not None else None
+        customer_id = str(item.get("customer_id", "") or "").strip()
+        file_ids = [
+            str(file_id or "").strip()
+            for file_id in item.get("knowledge_file_ids", [])
+            if str(file_id or "").strip()
+        ]
+        knowledge_files: list[dict[str, Any]] = []
+        if file_vault is not None and customer_id and file_ids:
+            for record in file_vault.get_many(customer_id, file_ids):
+                clean = sanitize_uploaded_file_record(record, include_excerpt=False)
+                file_id = str(clean.get("id") or "").strip()
+                if not file_id:
+                    continue
+                knowledge_files.append(
+                    {
+                        "id": file_id,
+                        "kind": clean.get("kind"),
+                        "original_filename": clean.get("original_filename"),
+                        "mime_type": clean.get("mime_type"),
+                        "size_bytes": clean.get("size_bytes"),
+                        "caption": clean.get("caption"),
+                        "summary": clean.get("summary"),
+                        "created_at": clean.get("created_at"),
+                        "content_path": f"/web/files/{quote(file_id)}/content",
+                        "metadata_path": f"/web/files/{quote(file_id)}/metadata",
+                    }
+                )
+        item["knowledge_files"] = knowledge_files
+        return item
 
     @app.post("/internal/intake/workflows/upsert")
     async def internal_intake_workflows_upsert(request: Request) -> Any:
@@ -106,6 +153,89 @@ def register_intake_workflow_routes(
         )
         status_code = 200 if bool(result.get("ok", False)) else 400
         return JSONResponse(status_code=status_code, content=result)
+
+    @app.get("/web/intake/workflows")
+    async def web_intake_workflows_list(request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        customer_id = _web_customer_id(request)
+        if not customer_id:
+            return JSONResponse(status_code=400, content={"detail": "customer_id is required"})
+        workflows = get_intake_workflows().list_workflows(
+            customer_id=customer_id,
+            include_disabled=True,
+        )
+        return {
+            "ok": True,
+            "workflows": [_workflow_with_knowledge_files(workflow) for workflow in workflows],
+        }
+
+    @app.get("/web/intake/workflows/{workflow_id}")
+    async def web_intake_workflows_get(workflow_id: str, request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        customer_id = _web_customer_id(request)
+        if not customer_id:
+            return JSONResponse(status_code=400, content={"detail": "customer_id is required"})
+        workflow = get_intake_workflows().get_workflow(
+            customer_id=customer_id,
+            workflow_id=str(workflow_id or "").strip(),
+        )
+        if workflow is None:
+            return JSONResponse(status_code=404, content={"detail": "workflow not found"})
+        return {"ok": True, "workflow": _workflow_with_knowledge_files(workflow)}
+
+    @app.put("/web/intake/workflows/{workflow_id}")
+    async def web_intake_workflows_put(workflow_id: str, request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        body = await request.json()
+        if not isinstance(body, dict):
+            return JSONResponse(status_code=400, content={"detail": "workflow payload must be an object"})
+        customer_id = resolve_body_customer_id(body, resolve_customer_id)
+        if not customer_id:
+            return JSONResponse(status_code=400, content={"detail": "customer_id is required"})
+        payload = dict(body)
+        payload["workflow_id"] = str(workflow_id or "").strip()
+        try:
+            workflow = get_intake_workflows().upsert_workflow(
+                customer_id=customer_id,
+                workflow_id=payload["workflow_id"],
+                name=str(payload.get("name", "")).strip(),
+                channel=str(payload.get("channel", "instagram_dm")).strip() or "instagram_dm",
+                provider=str(payload.get("provider", "composio")).strip() or "composio",
+                source_config=payload.get("source_config") if isinstance(payload.get("source_config"), dict) else None,
+                intent_description=str(payload.get("intent_description", "")).strip(),
+                required_fields=payload.get("required_fields") if isinstance(payload.get("required_fields"), list) else [],
+                field_guidance=payload.get("field_guidance") if isinstance(payload.get("field_guidance"), dict) else None,
+                assistant_instructions=str(payload.get("assistant_instructions", "")).strip(),
+                business_facts=payload.get("business_facts") if isinstance(payload.get("business_facts"), dict) else None,
+                knowledge_file_ids=payload.get("knowledge_file_ids") if isinstance(payload.get("knowledge_file_ids"), list) else None,
+                sink_type=str(payload.get("sink_type", "")).strip(),
+                sink_config=payload.get("sink_config") if isinstance(payload.get("sink_config"), dict) else None,
+                schedule=str(payload.get("schedule") or "*/2 * * * *").strip() or "*/2 * * * *",
+                notify_user=bool(payload.get("notify_user", True)),
+                enabled=bool(payload.get("enabled", True)),
+                reply_mode=str(payload.get("reply_mode", "auto")).strip() or "auto",
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return {"ok": True, "workflow": _workflow_with_knowledge_files(workflow)}
+
+    @app.delete("/web/intake/workflows/{workflow_id}")
+    async def web_intake_workflows_delete(workflow_id: str, request: Request) -> Any:
+        if not _authorized_web_request(request):
+            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        customer_id = _web_customer_id(request)
+        if not customer_id:
+            return JSONResponse(status_code=400, content={"detail": "customer_id is required"})
+        result = get_intake_workflows().delete_workflow(
+            customer_id=customer_id,
+            workflow_id=str(workflow_id or "").strip(),
+        )
+        if not bool(result.get("deleted", False)):
+            return JSONResponse(status_code=404, content={"detail": "workflow not found"})
+        return result
 
     @app.post("/internal/intake/setup/begin")
     async def internal_intake_setup_begin(request: Request) -> Any:

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -63,8 +63,12 @@ def register_intake_workflow_routes(
                         "caption": clean.get("caption"),
                         "summary": clean.get("summary"),
                         "created_at": clean.get("created_at"),
-                        "content_path": f"/web/files/{quote(file_id)}/content",
-                        "metadata_path": f"/web/files/{quote(file_id)}/metadata",
+                        "content_path": (
+                            f"/web/files/{quote(file_id)}/content?customer_id={quote(customer_id, safe='')}"
+                        ),
+                        "metadata_path": (
+                            f"/web/files/{quote(file_id)}/metadata?customer_id={quote(customer_id, safe='')}"
+                        ),
                     }
                 )
         item["knowledge_files"] = knowledge_files

--- a/tests/test_web_intake_workflows.py
+++ b/tests/test_web_intake_workflows.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opentulpa.api.routes.intake import register_intake_workflow_routes
+from opentulpa.context.file_vault import FileVaultService
+from opentulpa.intake.service import IntakeWorkflowService
+
+
+def _service(tmp_path: Path) -> IntakeWorkflowService:
+    return IntakeWorkflowService(
+        db_path=tmp_path / "intake.db",
+        project_root=tmp_path,
+    )
+
+
+def _file_vault(tmp_path: Path) -> FileVaultService:
+    return FileVaultService(
+        root_dir=tmp_path / "files",
+        db_path=tmp_path / "files.db",
+    )
+
+
+def _app(service: IntakeWorkflowService, vault: FileVaultService) -> FastAPI:
+    app = FastAPI()
+    register_intake_workflow_routes(
+        app,
+        get_intake_workflows=lambda: service,
+        get_workflow_setup_service=lambda: None,
+        get_file_vault=lambda: vault,
+        web_token="secret",
+    )
+    return app
+
+
+def _workflow_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "customer_id": "dashboard",
+        "name": "Car wash booking",
+        "channel": "instagram_dm",
+        "provider": "composio",
+        "source_config": {"conversation_filter": "booking intent"},
+        "intent_description": "Book qualified car wash leads.",
+        "required_fields": ["name", "phone", "service"],
+        "field_guidance": {"service": "Ask for package type."},
+        "assistant_instructions": "Keep replies short.",
+        "business_facts": {"deposit_required": False},
+        "knowledge_file_ids": [],
+        "sink_type": "local_csv",
+        "sink_config": {"file_path": "tulpa_stuff/bookings.csv"},
+        "schedule": "*/5 * * * *",
+        "notify_user": True,
+        "enabled": True,
+        "reply_mode": "auto",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_web_workflow_routes_require_bearer_token(tmp_path: Path) -> None:
+    app = _app(_service(tmp_path), _file_vault(tmp_path))
+
+    with TestClient(app) as client:
+        rejected = client.get("/web/intake/workflows", params={"customer_id": "dashboard"})
+        accepted = client.get(
+            "/web/intake/workflows",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+
+    assert rejected.status_code == 401
+    assert accepted.status_code == 200
+    assert accepted.json() == {"ok": True, "workflows": []}
+
+
+def test_web_workflow_list_and_get_include_knowledge_files(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    vault = _file_vault(tmp_path)
+    file_record = vault.ingest_file(
+        customer_id="dashboard",
+        chat_id=None,
+        kind="document",
+        telegram_file_id=None,
+        original_filename="services.txt",
+        mime_type="text/plain",
+        caption="Service menu",
+        raw_bytes=b"Basic wash\nFull detail",
+    )
+    workflow = service.upsert_workflow(
+        **_workflow_payload(knowledge_file_ids=[file_record["id"]])  # type: ignore[arg-type]
+    )
+    app = _app(service, vault)
+
+    with TestClient(app) as client:
+        list_response = client.get(
+            "/web/intake/workflows",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+        get_response = client.get(
+            f"/web/intake/workflows/{workflow['workflow_id']}",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+
+    assert list_response.status_code == 200
+    assert get_response.status_code == 200
+    listed = list_response.json()["workflows"][0]
+    fetched = get_response.json()["workflow"]
+    assert listed["workflow_id"] == workflow["workflow_id"]
+    assert fetched["knowledge_files"][0]["original_filename"] == "services.txt"
+    assert fetched["knowledge_files"][0]["content_path"].endswith("/content")
+    assert fetched["knowledge_files"][0]["metadata_path"].endswith("/metadata")
+
+
+def test_web_workflow_put_validates_and_persists(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    vault = _file_vault(tmp_path)
+    workflow = service.upsert_workflow(**_workflow_payload())  # type: ignore[arg-type]
+    app = _app(service, vault)
+    payload = _workflow_payload(
+        workflow_id=workflow["workflow_id"],
+        name="Updated booking",
+        enabled=False,
+        required_fields=["name", "vehicle"],
+    )
+
+    with TestClient(app) as client:
+        updated = client.put(
+            f"/web/intake/workflows/{workflow['workflow_id']}",
+            json=payload,
+            headers={"authorization": "Bearer secret"},
+        )
+        invalid = client.put(
+            f"/web/intake/workflows/{workflow['workflow_id']}",
+            json={**payload, "name": ""},
+            headers={"authorization": "Bearer secret"},
+        )
+
+    assert updated.status_code == 200
+    assert updated.json()["workflow"]["name"] == "Updated booking"
+    assert updated.json()["workflow"]["enabled"] is False
+    assert service.get_workflow(
+        customer_id="dashboard",
+        workflow_id=str(workflow["workflow_id"]),
+    )["required_fields"] == ["name", "vehicle"]
+    assert invalid.status_code == 400
+    assert "name is required" in invalid.json()["detail"]
+
+
+def test_web_workflow_delete_removes_workflow(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    vault = _file_vault(tmp_path)
+    workflow = service.upsert_workflow(**_workflow_payload())  # type: ignore[arg-type]
+    app = _app(service, vault)
+
+    with TestClient(app) as client:
+        deleted = client.delete(
+            f"/web/intake/workflows/{workflow['workflow_id']}",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+        missing = client.get(
+            f"/web/intake/workflows/{workflow['workflow_id']}",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+
+    assert deleted.status_code == 200
+    assert deleted.json()["deleted"] is True
+    assert missing.status_code == 404

--- a/tests/test_web_intake_workflows.py
+++ b/tests/test_web_intake_workflows.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from opentulpa.api.routes.generic_chat import register_generic_chat_routes
 from opentulpa.api.routes.intake import register_intake_workflow_routes
 from opentulpa.context.file_vault import FileVaultService
 from opentulpa.intake.service import IntakeWorkflowService
@@ -32,6 +33,13 @@ def _app(service: IntakeWorkflowService, vault: FileVaultService) -> FastAPI:
         get_workflow_setup_service=lambda: None,
         get_file_vault=lambda: vault,
         web_token="secret",
+    )
+    register_generic_chat_routes(
+        app,
+        web_token="secret",
+        get_agent_runtime=lambda: None,
+        get_file_vault=lambda: vault,
+        get_workflow_setup_service=lambda: None,
     )
     return app
 
@@ -105,15 +113,27 @@ def test_web_workflow_list_and_get_include_knowledge_files(tmp_path: Path) -> No
             params={"customer_id": "dashboard"},
             headers={"authorization": "Bearer secret"},
         )
+        content_response = client.get(
+            get_response.json()["workflow"]["knowledge_files"][0]["content_path"],
+            headers={"authorization": "Bearer secret"},
+        )
+        metadata_response = client.get(
+            get_response.json()["workflow"]["knowledge_files"][0]["metadata_path"],
+            headers={"authorization": "Bearer secret"},
+        )
 
     assert list_response.status_code == 200
     assert get_response.status_code == 200
+    assert content_response.status_code == 200
+    assert metadata_response.status_code == 200
     listed = list_response.json()["workflows"][0]
     fetched = get_response.json()["workflow"]
     assert listed["workflow_id"] == workflow["workflow_id"]
     assert fetched["knowledge_files"][0]["original_filename"] == "services.txt"
-    assert fetched["knowledge_files"][0]["content_path"].endswith("/content")
-    assert fetched["knowledge_files"][0]["metadata_path"].endswith("/metadata")
+    assert fetched["knowledge_files"][0]["content_path"].endswith("/content?customer_id=dashboard")
+    assert fetched["knowledge_files"][0]["metadata_path"].endswith("/metadata?customer_id=dashboard")
+    assert content_response.text == "Basic wash\nFull detail"
+    assert metadata_response.json()["file"]["content_path"].endswith("/content?customer_id=dashboard")
 
 
 def test_web_workflow_put_validates_and_persists(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add token-protected /web/intake/workflows routes for dashboard workflow management
- include linked knowledge file metadata and web file paths
- allow the public route boundary and pass FileVault into intake routes

## Validation
- uv run ruff check src/opentulpa/api/routes/intake.py src/opentulpa/api/app.py tests/test_web_intake_workflows.py
- uv run pytest -q tests/test_web_events.py tests/test_web_intake_workflows.py