### PR TITLE
Add qwen prompt caching defaults

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -196,7 +196,7 @@ Telegram is optional in server mode. For web/API-only deployments, leave Telegra
 
 - `COMPOSIO_API_KEY` for connector integrations such as Google Sheets and Instagram
 - `OPENTULPA_SHUTDOWN_DRAIN_TIMEOUT_SECONDS=300` to let active web or Telegram turns finish during Railway deploy shutdown
-- Model defaults live in `opentulpa.config.yaml` (`LLM_MODEL=z-ai/glm-5.1`, `LLM_REASONING_EFFORT=medium`, `WAKE_EXECUTION_MODEL=z-ai/glm-5.1`, Gemini Flash for memory/media, Gemini Flash Lite for the business knowledge oracle)
+- Model defaults live in `opentulpa.config.yaml` (`LLM_MODEL=qwen/qwen3.7-max`, `LLM_REASONING_EFFORT=medium`, `WAKE_EXECUTION_MODEL=qwen/qwen3.7-max`, Gemini Flash for memory/media, Gemini Flash Lite for the business knowledge oracle)
 
 Browser Use reuses `MULTIMODAL_LLM` by default unless `BROWSER_USE_MODEL` is set.
 

--- a/opentulpa.config.yaml
+++ b/opentulpa.config.yaml
@@ -26,11 +26,11 @@ agent_context_rollup_tokens: 2200
 agent_context_compaction_source_tokens: 12000
 
 # LLM/provider configuration
-llm_model: z-ai/glm-5.1
+llm_model: qwen/qwen3.7-max
 memory_llm_model: google/gemini-3-flash-preview
 llm_reasoning_effort: medium
 wake_classifier_model: null
-wake_execution_model: z-ai/glm-5.1
+wake_execution_model: qwen/qwen3.7-max
 multimodal_llm: google/gemini-3.1-flash-lite-preview
 business_knowledge_oracle_model: google/gemini-3.1-flash-lite-preview
 openai_compatible_embedding_model: openai/text-embedding-3-small

--- a/scripts/replay_qwen_prompt_cache.py
+++ b/scripts/replay_qwen_prompt_cache.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from opentulpa.agent.model_pool import infer_stable_system_prefix_count
+from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _observations_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict) and isinstance(payload.get("body"), dict):
+        data = payload["body"].get("data")
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        return [item for item in payload["data"] if isinstance(item, dict)]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    return []
+
+
+def _fetch_langfuse_observations(trace_id: str, *, limit: int) -> list[dict[str, Any]]:
+    assert trace_id.strip(), "trace_id must not be empty"
+    assert limit > 0, "limit must be positive"
+    cmd = [
+        "npx",
+        "--yes",
+        "langfuse-cli",
+        "api",
+        "observations",
+        "list",
+        "--trace-id",
+        trace_id,
+        "--type",
+        "GENERATION",
+        "--fields",
+        "basic,time,io,model,usage",
+        "--limit",
+        str(limit),
+        "--json",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120)
+    return _observations_from_payload(json.loads(result.stdout))
+
+
+def _parse_langfuse_messages(observation: dict[str, Any]) -> list[dict[str, Any]] | None:
+    raw_input = observation.get("input")
+    if not isinstance(raw_input, str) or not raw_input.strip():
+        return None
+    try:
+        parsed = json.loads(raw_input)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, list):
+        return None
+    messages = [item for item in parsed if isinstance(item, dict) and isinstance(item.get("role"), str)]
+    return messages or None
+
+
+def _tool_from_trailing_schema(message: dict[str, Any]) -> dict[str, Any] | None:
+    if message.get("role") != "tool" or message.get("tool_call_id"):
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(content, dict):
+        return None
+    if content.get("type") == "function" and isinstance(content.get("function"), dict):
+        return content
+    return None
+
+
+def _split_messages_and_tools(raw_messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    messages = list(raw_messages)
+    tools: list[dict[str, Any]] = []
+    while messages:
+        tool = _tool_from_trailing_schema(messages[-1])
+        if tool is None:
+            break
+        tools.append(tool)
+        messages.pop()
+    tools.reverse()
+    return messages, tools
+
+
+def _lc_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    if not isinstance(tool_calls, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for index, call in enumerate(tool_calls):
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function") if isinstance(call.get("function"), dict) else {}
+        name = call.get("name") or function.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        args = call.get("args")
+        if args is None:
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                try:
+                    args = json.loads(arguments)
+                except json.JSONDecodeError:
+                    args = {"arguments": arguments}
+            else:
+                args = {}
+        normalized.append(
+            {
+                "id": str(call.get("id") or f"call_replay_{index}"),
+                "name": name,
+                "args": args if isinstance(args, dict) else {"value": args},
+            }
+        )
+    return normalized
+
+
+def _to_lc_messages(raw_messages: list[dict[str, Any]]) -> list[Any]:
+    converted: list[Any] = []
+    for raw in raw_messages:
+        role = str(raw.get("role") or "")
+        content = raw.get("content") or ""
+        if role == "system":
+            converted.append(SystemMessage(content=content))
+        elif role == "user":
+            converted.append(HumanMessage(content=content))
+        elif role == "assistant":
+            converted.append(AIMessage(content=content, tool_calls=_lc_tool_calls(raw.get("tool_calls"))))
+        elif role == "tool":
+            tool_call_id = str(raw.get("tool_call_id") or "call_replay_missing")
+            converted.append(ToolMessage(content=content, tool_call_id=tool_call_id))
+    return converted
+
+
+def _message_content_for_openai(content: Any) -> Any:
+    if isinstance(content, list):
+        return content
+    if content is None:
+        return ""
+    return content
+
+
+def _to_openai_messages(messages: Iterable[Any]) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    for message in messages:
+        if isinstance(message, SystemMessage):
+            converted.append({"role": "system", "content": _message_content_for_openai(message.content)})
+        elif isinstance(message, HumanMessage):
+            converted.append({"role": "user", "content": _message_content_for_openai(message.content)})
+        elif isinstance(message, AIMessage):
+            item: dict[str, Any] = {
+                "role": "assistant",
+                "content": _message_content_for_openai(message.content),
+            }
+            tool_calls = []
+            for call in getattr(message, "tool_calls", None) or []:
+                args = call.get("args") if isinstance(call, dict) else {}
+                tool_calls.append(
+                    {
+                        "id": str(call.get("id") or f"call_replay_{len(tool_calls)}"),
+                        "type": "function",
+                        "function": {
+                            "name": str(call.get("name") or ""),
+                            "arguments": json.dumps(args if isinstance(args, dict) else {"value": args}),
+                        },
+                    }
+                )
+            if tool_calls:
+                item["tool_calls"] = tool_calls
+            converted.append(item)
+        elif isinstance(message, ToolMessage):
+            converted.append(
+                {
+                    "role": "tool",
+                    "content": _message_content_for_openai(message.content),
+                    "tool_call_id": str(getattr(message, "tool_call_id", "") or "call_replay_missing"),
+                }
+            )
+    return converted
+
+
+def _cache_breakpoint_index(messages: list[dict[str, Any]]) -> int | None:
+    for index in range(len(messages) - 1, -1, -1):
+        content = messages[index].get("content")
+        if isinstance(content, list) and any(
+            isinstance(item, dict) and isinstance(item.get("cache_control"), dict) for item in content
+        ):
+            return index
+    return None
+
+
+def _usage_value(usage: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, int | float):
+            return int(value)
+    prompt_details = usage.get("prompt_tokens_details")
+    if isinstance(prompt_details, dict):
+        for key in keys:
+            value = prompt_details.get(key)
+            if isinstance(value, int | float):
+                return int(value)
+    return 0
+
+
+def _usage_cost(usage: dict[str, Any]) -> float:
+    value = usage.get("cost")
+    if isinstance(value, int | float):
+        return float(value)
+    details = usage.get("cost_details")
+    if isinstance(details, dict):
+        for key in ("total", "upstream_inference_cost"):
+            value = details.get(key)
+            if isinstance(value, int | float):
+                return float(value)
+    return 0.0
+
+
+def _openrouter_call(
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    max_tokens: int,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    assert api_key.strip(), "api key must not be empty"
+    assert messages, "messages must not be empty"
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "usage": {"include": True},
+    }
+    if tools:
+        payload["tools"] = tools
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Title": "OpenTulpa qwen cache replay",
+        "HTTP-Referer": "https://opentulpa.com",
+    }
+    with httpx.Client(timeout=timeout_seconds) as client:
+        response = client.post(f"{base_url.rstrip('/')}/chat/completions", headers=headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+def _select_observations(observations: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for observation in observations:
+        raw_messages = _parse_langfuse_messages(observation)
+        if raw_messages is None:
+            continue
+        messages, _ = _split_messages_and_tools(raw_messages)
+        if len(messages) < 2:
+            continue
+        first = messages[0]
+        if first.get("role") != "system" or "You are OpenTulpa" not in str(first.get("content") or ""):
+            continue
+        candidates.append(observation)
+    candidates.sort(key=lambda item: str(item.get("startTime") or item.get("createdAt") or ""))
+    if len(candidates) <= limit:
+        return candidates
+    best_start = 0
+    best_score = -1
+    for start in range(0, len(candidates) - limit + 1):
+        window = candidates[start : start + limit]
+        score = min(int(item.get("inputUsage") or item.get("totalUsage") or 0) for item in window)
+        if score > best_score:
+            best_score = score
+            best_start = start
+    return candidates[best_start : best_start + limit]
+
+
+def _build_replay_payload(
+    runtime: OpenTulpaLangGraphRuntime,
+    observation: dict[str, Any],
+    *,
+    model: str,
+) -> dict[str, Any]:
+    raw_messages = _parse_langfuse_messages(observation)
+    assert raw_messages is not None, "selected observation must have parseable messages"
+    raw_messages, tools = _split_messages_and_tools(raw_messages)
+    lc_messages = _to_lc_messages(raw_messages)
+    stable_prefix_count = infer_stable_system_prefix_count(lc_messages)
+    cacheable_prefix_count = max(stable_prefix_count, len(lc_messages) - 1)
+    prepared = runtime.prepare_messages_for_prompt_cache(
+        lc_messages,
+        model_name=model,
+        stable_prefix_count=stable_prefix_count,
+        cacheable_prefix_count=cacheable_prefix_count,
+    )
+    openai_messages = _to_openai_messages(prepared)
+    breakpoint_index = _cache_breakpoint_index(openai_messages)
+    assert breakpoint_index is not None, "cache breakpoint must be present"
+    assert breakpoint_index < len(openai_messages) - 1, "cache breakpoint must stay before live frontier"
+    return {
+        "messages": openai_messages,
+        "tools": tools,
+        "stable_prefix_count": stable_prefix_count,
+        "cacheable_prefix_count": cacheable_prefix_count,
+        "cache_breakpoint_index": breakpoint_index,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay Langfuse OpenTulpa generations against qwen prompt caching.")
+    parser.add_argument("--observations-file", type=Path)
+    parser.add_argument("--trace-id")
+    parser.add_argument("--limit", type=int, default=4)
+    parser.add_argument("--passes", type=int, default=2)
+    parser.add_argument("--model", default="qwen/qwen3.7-max")
+    parser.add_argument("--max-tokens", type=int, default=1)
+    parser.add_argument("--timeout-seconds", type=float, default=180.0)
+    parser.add_argument("--out", type=Path, default=Path(".tmp/qwen-cache-replay/latest.json"))
+    args = parser.parse_args()
+
+    if not args.observations_file and not args.trace_id:
+        raise SystemExit("Provide --observations-file or --trace-id")
+    if args.limit <= 0 or args.passes <= 0:
+        raise SystemExit("--limit and --passes must be positive")
+
+    if args.observations_file:
+        observations = _observations_from_payload(_load_json(args.observations_file))
+    else:
+        observations = _fetch_langfuse_observations(str(args.trace_id), limit=1000)
+    selected = _select_observations(observations, limit=args.limit)
+    if not selected:
+        raise SystemExit("No replayable OpenTulpa generation observations found")
+
+    api_key = os.environ.get("OPENAI_COMPATIBLE_API_KEY") or os.environ.get("OPENROUTER_API_KEY") or ""
+    base_url = os.environ.get("OPENAI_COMPATIBLE_BASE_URL") or os.environ.get("OPENROUTER_BASE_URL") or "https://openrouter.ai/api/v1"
+    runtime = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key=api_key or "missing",
+        openrouter_base_url=base_url,
+        model_name=args.model,
+        checkpoint_db_path=".opentulpa/qwen-cache-replay.sqlite",
+        prompt_caching_enabled=True,
+    )
+
+    started_at = datetime.now(tz=UTC).isoformat()
+    results: list[dict[str, Any]] = []
+    print("pass observation model prompt cached write cost breakpoint cacheable messages tools")
+    for pass_index in range(args.passes):
+        for observation in selected:
+            payload = _build_replay_payload(runtime, observation, model=args.model)
+            started = time.perf_counter()
+            response = _openrouter_call(
+                api_key=api_key,
+                base_url=base_url,
+                model=args.model,
+                messages=payload["messages"],
+                tools=payload["tools"],
+                max_tokens=args.max_tokens,
+                timeout_seconds=args.timeout_seconds,
+            )
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            usage = response.get("usage") if isinstance(response.get("usage"), dict) else {}
+            result = {
+                "pass": pass_index + 1,
+                "observation_id": observation.get("id"),
+                "trace_id": observation.get("traceId"),
+                "source_model": observation.get("model"),
+                "target_model": args.model,
+                "input_usage": observation.get("inputUsage"),
+                "prompt_tokens": _usage_value(usage, "prompt_tokens", "input_tokens"),
+                "completion_tokens": _usage_value(usage, "completion_tokens", "output_tokens"),
+                "cached_tokens": _usage_value(usage, "cached_tokens", "input_cache_read"),
+                "cache_write_tokens": _usage_value(usage, "cache_write_tokens", "input_cache_write"),
+                "cost_usd": _usage_cost(usage),
+                "elapsed_ms": elapsed_ms,
+                **payload,
+            }
+            result.pop("messages")
+            result.pop("tools")
+            results.append(result)
+            print(
+                f"{result['pass']} {result['observation_id']} {observation.get('model')} "
+                f"{result['prompt_tokens']} {result['cached_tokens']} {result['cache_write_tokens']} "
+                f"{result['cost_usd']:.8f} {result['cache_breakpoint_index']} "
+                f"{result['cacheable_prefix_count']} {len(payload['messages'])} {len(payload['tools'])}"
+            )
+
+    summary = {
+        "started_at": started_at,
+        "model": args.model,
+        "source": str(args.observations_file) if args.observations_file else {"trace_id": args.trace_id},
+        "selected_observation_ids": [item.get("id") for item in selected],
+        "results": results,
+        "totals": {
+            "cached_tokens": sum(int(item["cached_tokens"]) for item in results),
+            "cache_write_tokens": sum(int(item["cache_write_tokens"]) for item in results),
+            "cost_usd": sum(float(item["cost_usd"]) for item in results),
+        },
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -1277,6 +1277,8 @@ def build_runtime_graph(runtime: Any):
         dynamic_late_tokens = _message_tokens(dynamic_late_messages)
         older_history_tokens = _message_tokens(older_history_messages)
         latest_turn_tokens = _message_tokens(latest_turn_messages)
+        cacheable_prefix_count = len(prefix_messages) + len(older_history_messages)
+        cacheable_prefix_tokens = stable_prefix_tokens + older_history_tokens
         model_messages: list[AnyMessage] = [
             *prefix_messages,
             *older_history_messages,
@@ -1302,6 +1304,8 @@ def build_runtime_graph(runtime: Any):
             prompt_cache_top_level=bool(cache_profile.get("supports_top_level", False)),
             stable_prefix_count=stable_prefix_count,
             stable_prefix_tokens=stable_prefix_tokens,
+            cacheable_prefix_count=cacheable_prefix_count,
+            cacheable_prefix_tokens=cacheable_prefix_tokens,
             frozen_late_tokens=frozen_late_tokens,
             dynamic_late_tokens=dynamic_late_tokens,
             older_history_tokens=older_history_tokens,
@@ -1323,6 +1327,8 @@ def build_runtime_graph(runtime: Any):
             "prompt_sections": prompt_section_names,
             "stable_prefix_count": stable_prefix_count,
             "stable_prefix_tokens": stable_prefix_tokens,
+            "cacheable_prefix_count": cacheable_prefix_count,
+            "cacheable_prefix_tokens": cacheable_prefix_tokens,
             "frozen_late_tokens": frozen_late_tokens,
             "dynamic_late_tokens": dynamic_late_tokens,
             "older_history_tokens": older_history_tokens,
@@ -1342,6 +1348,7 @@ def build_runtime_graph(runtime: Any):
                 model_with_tools,
                 model_messages,
                 stable_prefix_count=stable_prefix_count,
+                cacheable_prefix_count=cacheable_prefix_count,
                 call_context=call_context,
                 stream_config=config,
             )
@@ -1350,6 +1357,7 @@ def build_runtime_graph(runtime: Any):
                 model_with_tools,
                 model_messages,
                 stable_prefix_count=stable_prefix_count,
+                cacheable_prefix_count=cacheable_prefix_count,
                 call_context=call_context,
             )
         else:

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -12,7 +12,7 @@ from langchain.chat_models import init_chat_model
 from langchain_openrouter import ChatOpenRouter
 from pydantic import BaseModel
 
-from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.utils import content_to_text as _content_to_text
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,15 @@ def provider_prompt_cache_profile(
         return {
             "enabled": True,
             "strategy": "breakpoint",
+            "supports_top_level": False,
+            "supports_breakpoints": True,
+            "cache_control": prompt_cache_control_payload(ttl_1h=ttl_1h),
+            "model_name": model_name,
+        }
+    if slug.startswith("qwen/") or "qwen" in slug:
+        return {
+            "enabled": True,
+            "strategy": "explicit_tail_breakpoint",
             "supports_top_level": False,
             "supports_breakpoints": True,
             "cache_control": prompt_cache_control_payload(ttl_1h=ttl_1h),
@@ -330,24 +339,41 @@ def prepare_messages_for_prompt_cache(
     *,
     model_name: str | None = None,
     stable_prefix_count: int = 0,
+    cacheable_prefix_count: int | None = None,
 ) -> list[Any]:
     profile = runtime.prompt_cache_profile(model_name=model_name)
-    if profile.get("strategy") != "breakpoint":
+    strategy = str(profile.get("strategy") or "")
+    if strategy not in {"breakpoint", "explicit_tail_breakpoint"}:
         return messages
     cache_control = dict(profile.get("cache_control") or {})
     if not cache_control:
         return messages
-    effective_stable_prefix_count = (
-        int(stable_prefix_count)
-        if int(stable_prefix_count) > 0
-        else infer_stable_system_prefix_count(messages)
-    )
-    if effective_stable_prefix_count <= 0:
+    if strategy == "explicit_tail_breakpoint":
+        effective_prefix_count = (
+            int(cacheable_prefix_count)
+            if cacheable_prefix_count is not None and int(cacheable_prefix_count) > 0
+            else int(stable_prefix_count)
+            if int(stable_prefix_count) > 0
+            else infer_stable_system_prefix_count(messages)
+        )
+    else:
+        effective_prefix_count = (
+            int(stable_prefix_count)
+            if int(stable_prefix_count) > 0
+            else infer_stable_system_prefix_count(messages)
+        )
+    if effective_prefix_count <= 0:
         return messages
     patched: list[Any] = list(messages)
     target_index: int | None = None
-    for idx in range(min(effective_stable_prefix_count, len(patched)) - 1, -1, -1):
-        if getattr(patched[idx], "content", None):
+    target_roles = (SystemMessage, HumanMessage, AIMessage, ToolMessage)
+    for idx in range(min(effective_prefix_count, len(patched)) - 1, -1, -1):
+        message = patched[idx]
+        if not isinstance(message, target_roles):
+            continue
+        if isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
+            continue
+        if getattr(message, "content", None):
             target_index = idx
             break
     if target_index is None:
@@ -413,6 +439,7 @@ async def ainvoke_model(
     *,
     model_name: str | None = None,
     stable_prefix_count: int = 0,
+    cacheable_prefix_count: int | None = None,
     call_context: dict[str, Any] | None = None,
 ) -> Any:
     resolved_model_name = runtime._resolve_model_name_for_runtime_call(
@@ -422,6 +449,7 @@ async def ainvoke_model(
         list(messages),
         model_name=resolved_model_name,
         stable_prefix_count=stable_prefix_count,
+        cacheable_prefix_count=cacheable_prefix_count,
     )
     base_invoke_extras = runtime.model_invoke_extras(model_name=resolved_model_name)
     attempts = runtime._model_request_attempts(model_name=resolved_model_name)
@@ -473,7 +501,10 @@ async def ainvoke_model(
                 stable_prefix_count=stable_prefix_count,
                 response=response,
                 error=error_text,
-                call_context=attempt_context,
+                call_context={
+                    **attempt_context,
+                    "cacheable_prefix_count": cacheable_prefix_count,
+                },
             )
     if last_exc is not None:
         raise last_exc
@@ -487,6 +518,7 @@ async def astream_model(
     *,
     model_name: str | None = None,
     stable_prefix_count: int = 0,
+    cacheable_prefix_count: int | None = None,
     call_context: dict[str, Any] | None = None,
     stream_config: Any | None = None,
 ) -> Any:
@@ -497,6 +529,7 @@ async def astream_model(
         list(messages),
         model_name=resolved_model_name,
         stable_prefix_count=stable_prefix_count,
+        cacheable_prefix_count=cacheable_prefix_count,
     )
     base_invoke_extras = runtime.model_invoke_extras(model_name=resolved_model_name)
     attempts = runtime._model_request_attempts(model_name=resolved_model_name)
@@ -522,6 +555,7 @@ async def astream_model(
                 messages,
                 model_name=resolved_model_name,
                 stable_prefix_count=stable_prefix_count,
+                cacheable_prefix_count=cacheable_prefix_count,
                 call_context=call_context,
             )
         response: Any | None = None
@@ -575,7 +609,10 @@ async def astream_model(
                 stable_prefix_count=stable_prefix_count,
                 response=response,
                 error=error_text,
-                call_context=attempt_context,
+                call_context={
+                    **attempt_context,
+                    "cacheable_prefix_count": cacheable_prefix_count,
+                },
             )
     if last_exc is not None:
         raise last_exc
@@ -590,6 +627,7 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
     schema: type[StructuredModelT],
     model_name: str | None = None,
     stable_prefix_count: int = 0,
+    cacheable_prefix_count: int | None = None,
     call_context: dict[str, Any] | None = None,
     clean_json_text_block: Any,
 ) -> tuple[StructuredModelT | None, str | None]:
@@ -601,6 +639,7 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
         list(messages),
         model_name=resolved_model_name,
         stable_prefix_count=stable_prefix_count,
+        cacheable_prefix_count=cacheable_prefix_count,
     )
     base_invoke_extras = runtime.model_invoke_extras(model_name=resolved_model_name)
     attempts = runtime._model_request_attempts(model_name=resolved_model_name)
@@ -694,7 +733,10 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
                         stable_prefix_count=stable_prefix_count,
                         response=payload,
                         error=None,
-                        call_context=attempt_context,
+                        call_context={
+                            **attempt_context,
+                            "cacheable_prefix_count": cacheable_prefix_count,
+                        },
                     )
                     trace_recorded = True
                     return payload, None
@@ -720,7 +762,10 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
                         stable_prefix_count=stable_prefix_count,
                         response=parsed,
                         error=None,
-                        call_context=attempt_context,
+                        call_context={
+                            **attempt_context,
+                            "cacheable_prefix_count": cacheable_prefix_count,
+                        },
                     )
                     trace_recorded = True
                     return parsed, None
@@ -752,7 +797,10 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
                         stable_prefix_count=stable_prefix_count,
                         response=payload,
                         error=error_text,
-                        call_context=attempt_context,
+                        call_context={
+                            **attempt_context,
+                            "cacheable_prefix_count": cacheable_prefix_count,
+                        },
                     )
         if error_text:
             last_error = error_text

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -505,6 +505,23 @@ def _prompt_cache_trace_fields(
         stable_messages = serialized_messages[:stable_count]
         fields["stable_prefix_hash"] = _hash_json(stable_messages)
         fields["stable_prefix_chars"] = sum(len(str(item.get("text", "") or "")) for item in stable_messages)
+    cache_breakpoint_indexes: list[int] = []
+    for index, message in enumerate(serialized_messages):
+        content = message.get("content")
+        if isinstance(content, list) and any(
+            isinstance(item, dict) and isinstance(item.get("cache_control"), dict)
+            for item in content
+        ):
+            cache_breakpoint_indexes.append(index)
+    if cache_breakpoint_indexes:
+        breakpoint_index = cache_breakpoint_indexes[-1]
+        cacheable_messages = serialized_messages[: breakpoint_index + 1]
+        fields["cache_breakpoint_index"] = breakpoint_index
+        fields["cache_breakpoint_count"] = len(cache_breakpoint_indexes)
+        fields["cache_breakpoint_prefix_hash"] = _hash_json(cacheable_messages)
+        fields["cache_breakpoint_prefix_chars"] = sum(
+            len(str(item.get("text", "") or "")) for item in cacheable_messages
+        )
 
     first_system = next(
         (item for item in serialized_messages if str(item.get("role", "") or "") == "system"),
@@ -1633,12 +1650,14 @@ class OpenTulpaLangGraphRuntime:
         *,
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        cacheable_prefix_count: int | None = None,
     ) -> list[Any]:
         return _model_pool.prepare_messages_for_prompt_cache(
             self,
             messages,
             model_name=model_name,
             stable_prefix_count=stable_prefix_count,
+            cacheable_prefix_count=cacheable_prefix_count,
         )
 
     async def ainvoke_model(
@@ -1648,6 +1667,7 @@ class OpenTulpaLangGraphRuntime:
         *,
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        cacheable_prefix_count: int | None = None,
         call_context: dict[str, Any] | None = None,
     ) -> Any:
         return await _model_pool.ainvoke_model(
@@ -1656,6 +1676,7 @@ class OpenTulpaLangGraphRuntime:
             messages,
             model_name=model_name,
             stable_prefix_count=stable_prefix_count,
+            cacheable_prefix_count=cacheable_prefix_count,
             call_context=call_context,
         )
 
@@ -1666,6 +1687,7 @@ class OpenTulpaLangGraphRuntime:
         *,
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        cacheable_prefix_count: int | None = None,
         call_context: dict[str, Any] | None = None,
         stream_config: Any | None = None,
     ) -> Any:
@@ -1675,6 +1697,7 @@ class OpenTulpaLangGraphRuntime:
             messages,
             model_name=model_name,
             stable_prefix_count=stable_prefix_count,
+            cacheable_prefix_count=cacheable_prefix_count,
             call_context=call_context,
             stream_config=stream_config,
         )
@@ -2032,6 +2055,7 @@ class OpenTulpaLangGraphRuntime:
         schema: type[StructuredModelT],
         model_name: str | None = None,
         stable_prefix_count: int = 0,
+        cacheable_prefix_count: int | None = None,
         call_context: dict[str, Any] | None = None,
     ) -> tuple[StructuredModelT | None, str | None]:
         return await _model_pool.invoke_structured_model(
@@ -2041,6 +2065,7 @@ class OpenTulpaLangGraphRuntime:
             schema=schema,
             model_name=model_name,
             stable_prefix_count=stable_prefix_count,
+            cacheable_prefix_count=cacheable_prefix_count,
             call_context=call_context,
             clean_json_text_block=_clean_json_text_block,
         )

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -192,10 +192,10 @@ class Settings(BaseSettings):
         ),
     )
     llm_model: str = Field(
-        default="z-ai/glm-5.1",
+        default="qwen/qwen3.7-max",
         description=(
             "Model identifier accepted by the configured provider. "
-            "Recommended default is the OpenRouter slug z-ai/glm-5.1 for main chat turns."
+            "Recommended default is the OpenRouter slug qwen/qwen3.7-max for main chat turns."
         ),
     )
     memory_llm_model: str = Field(
@@ -221,10 +221,10 @@ class Settings(BaseSettings):
         ),
     )
     wake_execution_model: str | None = Field(
-        default="z-ai/glm-5.1",
+        default="qwen/qwen3.7-max",
         description=(
             "Model used for wake/routine execution turns that need stronger reasoning "
-            "and tool use. Recommended default aligns this with the main chat model: z-ai/glm-5.1."
+            "and tool use. Recommended default aligns this with the main chat model: qwen/qwen3.7-max."
         ),
     )
     multimodal_llm: str = Field(
@@ -241,7 +241,7 @@ class Settings(BaseSettings):
         ),
     )
     workflow_setup_input_classifier_model: str = Field(
-        default="z-ai/glm-5.1",
+        default="qwen/qwen3.7-max",
         description=(
             "Model used to classify messages sent while workflow setup is already running "
             "as status nudges versus real setup edits."

--- a/tests/test_config_api_key_alias.py
+++ b/tests/test_config_api_key_alias.py
@@ -61,7 +61,7 @@ def test_settings_accepts_legacy_telegram_media_model_alias() -> None:
     assert settings.multimodal_llm == "google/gemini-3-flash-preview"
 
 
-def test_settings_default_agent_models_use_glm(monkeypatch, tmp_path: Path) -> None:
+def test_settings_default_agent_models_use_qwen(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("LLM_MODEL", raising=False)
     monkeypatch.delenv("WAKE_EXECUTION_MODEL", raising=False)
@@ -69,9 +69,9 @@ def test_settings_default_agent_models_use_glm(monkeypatch, tmp_path: Path) -> N
 
     settings = Settings()
 
-    assert settings.llm_model == "z-ai/glm-5.1"
-    assert settings.wake_execution_model == "z-ai/glm-5.1"
-    assert settings.workflow_setup_input_classifier_model == "z-ai/glm-5.1"
+    assert settings.llm_model == "qwen/qwen3.7-max"
+    assert settings.wake_execution_model == "qwen/qwen3.7-max"
+    assert settings.workflow_setup_input_classifier_model == "qwen/qwen3.7-max"
     assert settings.business_knowledge_oracle_model == "google/gemini-3.1-flash-lite-preview"
 
 

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -8,7 +8,7 @@ from opentulpa.agent.graph_builder import (
     _build_connected_composio_toolkits_context,
     _build_late_turn_control_text,
 )
-from opentulpa.agent.lc_messages import HumanMessage, SystemMessage
+from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.prompt_policy import build_system_prompt_message
 from opentulpa.agent.prompt_sections import PROMPT_DYNAMIC_BOUNDARY
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
@@ -196,6 +196,22 @@ def test_prompt_cache_profile_zai_glm_is_automatic() -> None:
     assert profile["supports_breakpoints"] is False
 
 
+def test_prompt_cache_profile_qwen_uses_explicit_tail_breakpoint() -> None:
+    rt = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="qwen/qwen3.7-max",
+        checkpoint_db_path=".opentulpa/test-prompt-cache.sqlite",
+        prompt_caching_enabled=True,
+    )
+
+    profile = rt.prompt_cache_profile()
+
+    assert profile["strategy"] == "explicit_tail_breakpoint"
+    assert profile["supports_top_level"] is False
+    assert profile["supports_breakpoints"] is True
+
+
 def test_prepare_messages_for_prompt_cache_wraps_stable_system_message_for_gemini_by_default() -> None:
     rt = OpenTulpaLangGraphRuntime(
         app_url="http://127.0.0.1:8000",
@@ -257,6 +273,73 @@ def test_prepare_messages_for_prompt_cache_prefers_stable_prefix_when_provided()
     assert stable_block["text"] == "Stable skills context"
     assert stable_block["cache_control"] == {"type": "ephemeral"}
     assert prepared[2].content == "Dynamic user question"
+
+
+def test_prepare_messages_for_qwen_wraps_latest_cacheable_history_before_current_turn() -> None:
+    rt = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="qwen/qwen3.7-max",
+        checkpoint_db_path=".opentulpa/test-prompt-cache.sqlite",
+        prompt_caching_enabled=True,
+    )
+    messages = [
+        SystemMessage(content="Stable system prompt"),
+        HumanMessage(content="OpenTulpa cache anchor v1"),
+        AIMessage(content="Prior assistant answer"),
+        ToolMessage(content='{"ok": true}', tool_call_id="call_1"),
+        HumanMessage(content="Prior user turn"),
+        HumanMessage(content="Current user turn"),
+    ]
+
+    prepared = rt.prepare_messages_for_prompt_cache(
+        messages,
+        stable_prefix_count=2,
+        cacheable_prefix_count=5,
+    )
+
+    assert prepared[0].content == "Stable system prompt"
+    assert prepared[1].content == "OpenTulpa cache anchor v1"
+    assert prepared[2].content == "Prior assistant answer"
+    assert prepared[3].content == '{"ok": true}'
+    assert isinstance(prepared[4].content, list)
+    cache_block = prepared[4].content[0]
+    assert cache_block["type"] == "text"
+    assert cache_block["text"] == "Prior user turn"
+    assert cache_block["cache_control"] == {"type": "ephemeral"}
+    assert prepared[5].content == "Current user turn"
+
+
+def test_prepare_messages_for_qwen_uses_tool_result_after_ai_tool_call() -> None:
+    rt = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="qwen/qwen3.7-max",
+        checkpoint_db_path=".opentulpa/test-prompt-cache.sqlite",
+        prompt_caching_enabled=True,
+    )
+    messages = [
+        SystemMessage(content="Stable system prompt"),
+        HumanMessage(content="OpenTulpa cache anchor v1"),
+        AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
+        ToolMessage(content='{"ok": true}', tool_call_id="call_1"),
+        HumanMessage(content="Current user turn"),
+    ]
+
+    prepared = rt.prepare_messages_for_prompt_cache(
+        messages,
+        stable_prefix_count=2,
+        cacheable_prefix_count=4,
+    )
+
+    assert prepared[0].content == "Stable system prompt"
+    assert prepared[1].content == "OpenTulpa cache anchor v1"
+    assert prepared[2].content == ""
+    assert isinstance(prepared[3].content, list)
+    cache_block = prepared[3].content[0]
+    assert cache_block["text"] == '{"ok": true}'
+    assert cache_block["cache_control"] == {"type": "ephemeral"}
+    assert prepared[4].content == "Current user turn"
 
 
 class _CaptureResponse:

--- a/tests/test_runtime_structured_model.py
+++ b/tests/test_runtime_structured_model.py
@@ -1145,8 +1145,10 @@ def test_prompt_cache_profile_uses_openrouter_standard_modes() -> None:
     gemini = runtime.prompt_cache_profile(model_name="google/gemini-3-flash-preview")
     auto = runtime.prompt_cache_profile(model_name="openai/gpt-4.1")
     zai = runtime.prompt_cache_profile(model_name="z-ai/glm-5.1")
+    qwen = runtime.prompt_cache_profile(model_name="qwen/qwen3.7-max")
 
     assert anth["strategy"] == "top_level"
     assert gemini["strategy"] == "breakpoint"
     assert auto["strategy"] == "automatic"
     assert zai["strategy"] == "automatic"
+    assert qwen["strategy"] == "explicit_tail_breakpoint"


### PR DESCRIPTION
## Summary

Switch OpenTulpa agent defaults from GLM 5.1 to `qwen/qwen3.7-max` and add provider-specific prompt cache breakpoint handling for Qwen on OpenRouter.

## What changed

- Adds Qwen prompt-cache profile using explicit tail breakpoints.
- Routes Qwen-on-OpenRouter through `ChatOpenRouter` instead of generic `ChatOpenAI`, because the generic path records `cache_control` in Langfuse but does not get provider cache reads.
- Passes `cacheable_prefix_count` from graph prompt assembly into model invocation so Qwen can cache stable prefix plus older committed history while excluding live/dynamic latest-turn context.
- Allows cache breakpoints on tool result messages, while still skipping assistant messages that contain tool calls.
- Adds prompt-cache trace fields for breakpoint index/count/hash/size.
- Switches main, wake execution, and workflow setup classifier defaults to `qwen/qwen3.7-max`.
- Adds `scripts/replay_qwen_prompt_cache.py` to replay Langfuse generations through the runtime cache-prep path and prove provider cache reads/writes.

## Why

Qwen supports prompt caching through explicit `cache_control`, but OpenTulpa previously classified it as unknown/automatic and did not place provider breakpoints. Initial replay proved caching worked but only cached about 60% of long tool-heavy histories because breakpoint selection skipped `ToolMessage`. The updated selection caches near the end of older committed history.

A later live trace showed `cache_control` present in Langfuse but `input_cache_read=0`; direct replay of the same prompt cached correctly. The difference was the runtime model adapter: Qwen was still using the generic OpenAI/LangChain path. This PR now uses the OpenRouter adapter for Qwen so `cache_control` reaches the provider.

## Validation

- `uv run pytest tests/test_config_api_key_alias.py tests/test_prompt_cache_split.py tests/test_runtime_structured_model.py::test_prompt_cache_profile_uses_openrouter_standard_modes -q` passed: 47 tests.
- `uv run pytest tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_deepseek_reasoning tests/test_prompt_cache_split.py tests/test_runtime_structured_model.py::test_prompt_cache_profile_uses_openrouter_standard_modes -q` passed: 29 tests.
- `uv run ruff check src/opentulpa/agent/model_pool.py tests/test_runtime_reasoning_effort.py` passed.
- Direct `ChatOpenRouter` probe using the exact live Langfuse prompt reported `cache_read=7447` for Qwen.