### PR TITLE
Fix Qwen cache delivery through OpenRouter adapter

### DIFF
--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -176,6 +176,13 @@ def uses_openrouter_reasoning_adapter(*, model_name: str | None, base_url: str |
     )
 
 
+def uses_openrouter_chat_adapter(*, model_name: str | None, base_url: str | None) -> bool:
+    slug = str(model_name or "").strip().lower()
+    return looks_like_openrouter_base_url(base_url) and (
+        "deepseek" in slug or slug.startswith("qwen/") or "qwen" in slug
+    )
+
+
 def openrouter_reasoning_config(reasoning_effort: str | None) -> dict[str, Any]:
     effort = str(reasoning_effort or "").strip() or "none"
     return {"effort": effort, "exclude": False}
@@ -222,7 +229,11 @@ def init_runtime_chat_model(
     init_chat_model_func: Any = init_chat_model,
     chat_openrouter_cls: Any = ChatOpenRouter,
 ) -> Any:
-    if uses_openrouter_reasoning_adapter(model_name=model_name, base_url=openrouter_base_url):
+    if uses_openrouter_chat_adapter(model_name=model_name, base_url=openrouter_base_url):
+        uses_reasoning = uses_openrouter_reasoning_adapter(
+            model_name=model_name,
+            base_url=openrouter_base_url,
+        )
         app_headers = openrouter_app_headers(base_url=openrouter_base_url)
         adapter_kwargs: dict[str, Any] = {
             "model": model_name,
@@ -230,9 +241,10 @@ def init_runtime_chat_model(
             "base_url": openrouter_base_url or base_kwargs.get("base_url"),
             "temperature": base_kwargs.get("temperature"),
             "max_completion_tokens": base_kwargs.get("max_completion_tokens"),
-            "reasoning": openrouter_reasoning_config(reasoning_effort),
             "streaming": bool(base_kwargs.get("streaming", True)),
         }
+        if uses_reasoning:
+            adapter_kwargs["reasoning"] = openrouter_reasoning_config(reasoning_effort)
         if referer := app_headers.get("HTTP-Referer"):
             adapter_kwargs["app_url"] = referer
         if title := app_headers.get("X-OpenRouter-Title"):

--- a/tests/test_runtime_reasoning_effort.py
+++ b/tests/test_runtime_reasoning_effort.py
@@ -184,6 +184,46 @@ def test_runtime_uses_openrouter_adapter_for_deepseek_reasoning(monkeypatch) -> 
     assert all(call["model"] != "deepseek/deepseek-v4-pro" for call in init_calls)
 
 
+def test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache(monkeypatch) -> None:
+    init_calls: list[dict[str, Any]] = []
+    openrouter_calls: list[dict[str, Any]] = []
+
+    def _fake_init_chat_model(model: str | None = None, **kwargs: Any) -> object:
+        init_calls.append({"model": model, **kwargs})
+        return object()
+
+    class _FakeChatOpenRouter:
+        def __init__(self, **kwargs: Any) -> None:
+            openrouter_calls.append(kwargs)
+
+    monkeypatch.setattr(runtime_module, "init_chat_model", _fake_init_chat_model)
+    monkeypatch.setattr(runtime_module, "ChatOpenRouter", _FakeChatOpenRouter)
+    monkeypatch.delenv("OPENROUTER_APP_TITLE", raising=False)
+
+    runtime_module.OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="test-key",
+        openrouter_base_url="https://openrouter.ai/api/v1",
+        model_name="qwen/qwen3.7-max",
+        reasoning_effort="medium",
+        wake_classifier_model_name="google/gemini-3-flash-preview",
+        wake_execution_model_name="google/gemini-3-flash-preview",
+        telegram_media_model_name="google/gemini-3-flash-preview",
+        checkpoint_db_path=".opentulpa/test.sqlite",
+    )
+
+    assert openrouter_calls
+    qwen_call = openrouter_calls[0]
+    assert qwen_call["model"] == "qwen/qwen3.7-max"
+    assert qwen_call["api_key"] == "test-key"
+    assert qwen_call["base_url"] == "https://openrouter.ai/api/v1"
+    assert qwen_call["streaming"] is True
+    assert qwen_call["app_url"] == "https://github.com/kvyb/opentulpa"
+    assert qwen_call["app_title"] == "OpenTulpa"
+    assert "reasoning" not in qwen_call
+    assert all(call["model"] != "qwen/qwen3.7-max" for call in init_calls)
+
+
 def test_runtime_uses_openrouter_adapter_to_disable_deepseek_reasoning(monkeypatch) -> None:
     openrouter_calls: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary

Route Qwen OpenRouter models through `ChatOpenRouter` and make fresh user turns use a read-stable cache breakpoint.

## Why

Live Langfuse trace `36be2cea548376dcf8e94462d0042627` showed `cache_control` present in captured input but `input_cache_read=0` across repeated Qwen calls. The cache prefix was stable across calls, so the issue was not prompt churn.

Direct replay of the exact captured prompt to OpenRouter cached correctly:

- first converted direct request: `cache_write_tokens=7447`, `cached_tokens=0`
- second converted direct request: `cached_tokens=7447`, `cache_write_tokens=0`

A `ChatOpenRouter` probe with the same prompt also reported `input_token_details.cache_read=7447`. That points to the generic `ChatOpenAI` path not delivering Qwen `cache_control` to OpenRouter even though Langfuse sees it pre-send.

A later one-shot-turn trace showed a different problem: adapter caching worked, but the tail breakpoint moved with each fresh user turn, so adjacent one-shot turns had different prefix hashes and no cache read. Qwen appears to use the last breakpoint only, so dual read/write breakpoints did not solve this. This PR uses stable-prefix breakpoints for fresh user turns, then switches back to full older-history tail breakpoints once a tool loop starts.

## What changed

- Adds `uses_openrouter_chat_adapter(...)`.
- Routes Qwen on OpenRouter through `ChatOpenRouter`.
- Keeps OpenRouter reasoning payload DeepSeek-only so Qwen does not receive unrelated reasoning config.
- Adds a regression test to ensure Qwen does not fall back to generic `init_chat_model`.
- Adds `_prompt_cache_prefix_count_for_turn(...)` so fresh Qwen user turns use `stable_prefix_fresh_user_turn`, while tool-loop turns keep `full_older_history` for high cache reads.

## Validation

- `uv run pytest tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_deepseek_reasoning tests/test_prompt_cache_split.py tests/test_runtime_structured_model.py::test_prompt_cache_profile_uses_openrouter_standard_modes -q` passed: 32 tests.
- `uv run ruff check src/opentulpa/agent/graph_builder.py tests/test_prompt_cache_split.py src/opentulpa/agent/model_pool.py tests/test_runtime_reasoning_effort.py` passed.
- `ChatOpenRouter` probe using exact live Langfuse prompt reported `cache_read=7447`.
- Exact 13:39/13:40 one-shot prompts using stable-prefix breakpoint read `5559` and `5682` cached tokens instead of zero.