### PR TITLE
Use stable Qwen cache breakpoint for fresh turns

### DIFF
--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -114,6 +114,24 @@ CACHE_STICKY_ROUTING_ANCHOR = (
 )
 
 
+def _prompt_cache_prefix_count_for_turn(
+    *,
+    prompt_cache_strategy: str,
+    stable_prefix_count: int,
+    older_history_count: int,
+    latest_turn_messages: list[AnyMessage],
+) -> tuple[int, str]:
+    full_count = max(0, int(stable_prefix_count)) + max(0, int(older_history_count))
+    if str(prompt_cache_strategy or "") != "explicit_tail_breakpoint":
+        return full_count, "full_older_history"
+    is_fresh_user_turn = (
+        len(latest_turn_messages) == 1 and isinstance(latest_turn_messages[0], HumanMessage)
+    )
+    if is_fresh_user_turn:
+        return max(0, int(stable_prefix_count)), "stable_prefix_fresh_user_turn"
+    return full_count, "full_older_history"
+
+
 def _build_workflow_setup_prompt_context(
     runtime: Any,
     *,
@@ -1277,8 +1295,17 @@ def build_runtime_graph(runtime: Any):
         dynamic_late_tokens = _message_tokens(dynamic_late_messages)
         older_history_tokens = _message_tokens(older_history_messages)
         latest_turn_tokens = _message_tokens(latest_turn_messages)
-        cacheable_prefix_count = len(prefix_messages) + len(older_history_messages)
-        cacheable_prefix_tokens = stable_prefix_tokens + older_history_tokens
+        cacheable_prefix_count, cacheable_prefix_mode = _prompt_cache_prefix_count_for_turn(
+            prompt_cache_strategy=str(cache_profile.get("strategy", "")),
+            stable_prefix_count=stable_prefix_count,
+            older_history_count=len(older_history_messages),
+            latest_turn_messages=latest_turn_messages,
+        )
+        cacheable_prefix_tokens = (
+            stable_prefix_tokens + older_history_tokens
+            if cacheable_prefix_count > stable_prefix_count
+            else stable_prefix_tokens
+        )
         model_messages: list[AnyMessage] = [
             *prefix_messages,
             *older_history_messages,
@@ -1306,6 +1333,7 @@ def build_runtime_graph(runtime: Any):
             stable_prefix_tokens=stable_prefix_tokens,
             cacheable_prefix_count=cacheable_prefix_count,
             cacheable_prefix_tokens=cacheable_prefix_tokens,
+            cacheable_prefix_mode=cacheable_prefix_mode,
             frozen_late_tokens=frozen_late_tokens,
             dynamic_late_tokens=dynamic_late_tokens,
             older_history_tokens=older_history_tokens,
@@ -1329,6 +1357,7 @@ def build_runtime_graph(runtime: Any):
             "stable_prefix_tokens": stable_prefix_tokens,
             "cacheable_prefix_count": cacheable_prefix_count,
             "cacheable_prefix_tokens": cacheable_prefix_tokens,
+            "cacheable_prefix_mode": cacheable_prefix_mode,
             "frozen_late_tokens": frozen_late_tokens,
             "dynamic_late_tokens": dynamic_late_tokens,
             "older_history_tokens": older_history_tokens,

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -7,6 +7,7 @@ import pytest
 from opentulpa.agent.graph_builder import (
     _build_connected_composio_toolkits_context,
     _build_late_turn_control_text,
+    _prompt_cache_prefix_count_for_turn,
 )
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.prompt_policy import build_system_prompt_message
@@ -340,6 +341,46 @@ def test_prepare_messages_for_qwen_uses_tool_result_after_ai_tool_call() -> None
     assert cache_block["text"] == '{"ok": true}'
     assert cache_block["cache_control"] == {"type": "ephemeral"}
     assert prepared[4].content == "Current user turn"
+
+
+def test_qwen_cache_prefix_uses_stable_prefix_for_fresh_user_turn() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_tail_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 2
+    assert mode == "stable_prefix_fresh_user_turn"
+
+
+def test_qwen_cache_prefix_uses_older_history_after_tool_loop_starts() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_tail_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[
+            HumanMessage(content="New user turn"),
+            AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
+            ToolMessage(content='{"ok": true}', tool_call_id="call_1"),
+        ],
+    )
+
+    assert count == 8
+    assert mode == "full_older_history"
+
+
+def test_non_qwen_cache_prefix_keeps_full_older_history() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 8
+    assert mode == "full_older_history"
 
 
 class _CaptureResponse:


### PR DESCRIPTION
## Summary
- keep Qwen fresh user-turn cache breakpoint on the stable prefix instead of moving it onto rolling older history
- keep full older-history breakpoint once a tool loop starts, where repeated graph calls can reuse the larger prefix
- add focused tests for fresh-turn, tool-loop, and non-Qwen prefix selection

## Proof
- 13:39/13:40 Langfuse calls had OpenRouter adapter active and cache_control present, but different moving tail hashes: 80414ea686cd vs 1e51e7c001bf, so provider cache_read stayed 0
- exact prompt replay with stable-prefix-only breakpoint cached 5559 and 5682 prompt tokens on those calls
- tool-loop traces still cache near-full prefixes under existing full older-history mode

## Tests
- uv run pytest tests/test_prompt_cache_split.py tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache -q
- uv run ruff check src/opentulpa/agent/graph_builder.py tests/test_prompt_cache_split.py