### PR TITLE
Use committed Qwen prompt cache prefixes

### DIFF
--- a/scripts/replay_qwen_prompt_cache.py
+++ b/scripts/replay_qwen_prompt_cache.py
@@ -12,6 +12,11 @@ from typing import Any
 
 import httpx
 
+from opentulpa.agent.graph_builder import (
+    CACHE_STICKY_ROUTING_ANCHOR,
+    _committed_history_message_count,
+    _message_tokens,
+)
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.model_pool import infer_stable_system_prefix_count
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
@@ -136,7 +141,7 @@ def _to_lc_messages(raw_messages: list[dict[str, Any]]) -> list[Any]:
     converted: list[Any] = []
     for raw in raw_messages:
         role = str(raw.get("role") or "")
-        content = raw.get("content") or ""
+        content = _strip_cache_control(raw.get("content") or "")
         if role == "system":
             converted.append(SystemMessage(content=content))
         elif role == "user":
@@ -155,6 +160,18 @@ def _message_content_for_openai(content: Any) -> Any:
     if content is None:
         return ""
     return content
+
+
+def _strip_cache_control(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_strip_cache_control(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _strip_cache_control(item)
+            for key, item in value.items()
+            if key != "cache_control"
+        }
+    return value
 
 
 def _to_openai_messages(messages: Iterable[Any]) -> list[dict[str, Any]]:
@@ -298,13 +315,27 @@ def _build_replay_payload(
     observation: dict[str, Any],
     *,
     model: str,
+    commit_token_step: int,
 ) -> dict[str, Any]:
     raw_messages = _parse_langfuse_messages(observation)
     assert raw_messages is not None, "selected observation must have parseable messages"
     raw_messages, tools = _split_messages_and_tools(raw_messages)
     lc_messages = _to_lc_messages(raw_messages)
     stable_prefix_count = infer_stable_system_prefix_count(lc_messages)
-    cacheable_prefix_count = max(stable_prefix_count, len(lc_messages) - 1)
+    if (
+        stable_prefix_count < len(lc_messages)
+        and isinstance(lc_messages[stable_prefix_count], HumanMessage)
+        and str(lc_messages[stable_prefix_count].content or "").startswith(
+            CACHE_STICKY_ROUTING_ANCHOR
+        )
+    ):
+        stable_prefix_count += 1
+    history_messages = lc_messages[stable_prefix_count:-1]
+    committed_history_count = _committed_history_message_count(
+        [_message_tokens([message]) for message in history_messages],
+        commit_token_step=commit_token_step,
+    )
+    cacheable_prefix_count = stable_prefix_count + committed_history_count
     prepared = runtime.prepare_messages_for_prompt_cache(
         lc_messages,
         model_name=model,
@@ -321,6 +352,7 @@ def _build_replay_payload(
         "stable_prefix_count": stable_prefix_count,
         "cacheable_prefix_count": cacheable_prefix_count,
         "cache_breakpoint_index": breakpoint_index,
+        "cache_policy": "committed",
     }
 
 
@@ -331,6 +363,7 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=4)
     parser.add_argument("--passes", type=int, default=2)
     parser.add_argument("--model", default="qwen/qwen3.7-max")
+    parser.add_argument("--commit-token-step", type=int, default=4000)
     parser.add_argument("--max-tokens", type=int, default=1)
     parser.add_argument("--timeout-seconds", type=float, default=180.0)
     parser.add_argument("--out", type=Path, default=Path(".tmp/qwen-cache-replay/latest.json"))
@@ -365,7 +398,12 @@ def main() -> None:
     print("pass observation model prompt cached write cost breakpoint cacheable messages tools")
     for pass_index in range(args.passes):
         for observation in selected:
-            payload = _build_replay_payload(runtime, observation, model=args.model)
+            payload = _build_replay_payload(
+                runtime,
+                observation,
+                model=args.model,
+                commit_token_step=int(args.commit_token_step),
+            )
             started = time.perf_counter()
             response = _openrouter_call(
                 api_key=api_key,
@@ -406,6 +444,8 @@ def main() -> None:
     summary = {
         "started_at": started_at,
         "model": args.model,
+        "cache_policy": "committed",
+        "commit_token_step": args.commit_token_step,
         "source": str(args.observations_file) if args.observations_file else {"trace_id": args.trace_id},
         "selected_observation_ids": [item.get("id") for item in selected],
         "results": results,

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -26,6 +26,9 @@ from opentulpa.agent.lc_messages import (
     SystemMessage,
     ToolMessage,
 )
+from opentulpa.agent.model_pool import (
+    prompt_cache_breakpoint_message_index as _prompt_cache_breakpoint_message_index,
+)
 from opentulpa.agent.models import AgentState
 from opentulpa.agent.prompt_policy import (
     build_system_prompt_message as _build_system_prompt_message,
@@ -160,6 +163,7 @@ def _prompt_cache_prefix_count_for_turn(
         return max(0, int(stable_prefix_count)), "stable_prefix_committed_only"
     safe_history_count = min(max(0, int(older_history_count)), committed_history_count)
     return max(0, int(stable_prefix_count)) + safe_history_count, "committed_older_history"
+
 
 def _build_workflow_setup_prompt_context(
     runtime: Any,
@@ -1324,7 +1328,7 @@ def build_runtime_graph(runtime: Any):
         dynamic_late_tokens = _message_tokens(dynamic_late_messages)
         older_history_tokens = _message_tokens(older_history_messages)
         latest_turn_tokens = _message_tokens(latest_turn_messages)
-        cacheable_prefix_count, cacheable_prefix_mode = _prompt_cache_prefix_count_for_turn(
+        requested_cacheable_prefix_count, cacheable_prefix_mode = _prompt_cache_prefix_count_for_turn(
             prompt_cache_strategy=str(cache_profile.get("strategy", "")),
             stable_prefix_count=stable_prefix_count,
             older_history_count=len(older_history_messages),
@@ -1333,23 +1337,23 @@ def build_runtime_graph(runtime: Any):
             ],
             latest_turn_messages=latest_turn_messages,
         )
-        cacheable_prefix_tokens = (
-            stable_prefix_tokens
-            + _message_tokens(
-                older_history_messages[
-                    : max(0, cacheable_prefix_count - stable_prefix_count)
-                ]
-            )
-            if cacheable_prefix_count > stable_prefix_count
-            else stable_prefix_tokens
-        )
         model_messages: list[AnyMessage] = [
             *prefix_messages,
             *older_history_messages,
-            *latest_turn_messages,
             *frozen_late_messages,
+            *latest_turn_messages,
             *dynamic_late_messages,
         ]
+        cacheable_prefix_count = requested_cacheable_prefix_count
+        cache_breakpoint_index: int | None = None
+        if bool(cache_profile.get("supports_breakpoints", False)):
+            cache_breakpoint_index = _prompt_cache_breakpoint_message_index(
+                model_messages,
+                effective_prefix_count=requested_cacheable_prefix_count,
+            )
+            if cache_breakpoint_index is not None:
+                cacheable_prefix_count = cache_breakpoint_index + 1
+        cacheable_prefix_tokens = _message_tokens(model_messages[:cacheable_prefix_count])
         _log(
             state,
             "graph.agent.prompt_ready",
@@ -1368,9 +1372,11 @@ def build_runtime_graph(runtime: Any):
             prompt_cache_top_level=bool(cache_profile.get("supports_top_level", False)),
             stable_prefix_count=stable_prefix_count,
             stable_prefix_tokens=stable_prefix_tokens,
+            requested_cacheable_prefix_count=requested_cacheable_prefix_count,
             cacheable_prefix_count=cacheable_prefix_count,
             cacheable_prefix_tokens=cacheable_prefix_tokens,
             cacheable_prefix_mode=cacheable_prefix_mode,
+            cache_breakpoint_index=cache_breakpoint_index,
             frozen_late_tokens=frozen_late_tokens,
             dynamic_late_tokens=dynamic_late_tokens,
             older_history_tokens=older_history_tokens,
@@ -1392,9 +1398,11 @@ def build_runtime_graph(runtime: Any):
             "prompt_sections": prompt_section_names,
             "stable_prefix_count": stable_prefix_count,
             "stable_prefix_tokens": stable_prefix_tokens,
+            "requested_cacheable_prefix_count": requested_cacheable_prefix_count,
             "cacheable_prefix_count": cacheable_prefix_count,
             "cacheable_prefix_tokens": cacheable_prefix_tokens,
             "cacheable_prefix_mode": cacheable_prefix_mode,
+            "cache_breakpoint_index": cache_breakpoint_index,
             "frozen_late_tokens": frozen_late_tokens,
             "dynamic_late_tokens": dynamic_late_tokens,
             "older_history_tokens": older_history_tokens,

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -112,6 +112,29 @@ LOOP_LIMIT_REPAIR_INSTRUCTION = (
 CACHE_STICKY_ROUTING_ANCHOR = (
     "OpenTulpa cache anchor v1. Real conversation messages follow; do not answer this marker."
 )
+QWEN_CACHE_HISTORY_COMMIT_TOKENS = 4000
+
+
+def _committed_history_message_count(
+    token_counts: list[int],
+    *,
+    commit_token_step: int = QWEN_CACHE_HISTORY_COMMIT_TOKENS,
+) -> int:
+    safe_step = max(1, int(commit_token_step))
+    safe_counts = [max(0, int(token_count)) for token_count in token_counts]
+    total_tokens = sum(safe_counts)
+    committed_tokens = (total_tokens // safe_step) * safe_step
+    if committed_tokens <= 0:
+        return 0
+    included = 0
+    included_tokens = 0
+    for token_count in safe_counts:
+        next_tokens = included_tokens + token_count
+        if next_tokens > committed_tokens and included > 0:
+            break
+        included += 1
+        included_tokens = next_tokens
+    return included
 
 
 def _prompt_cache_prefix_count_for_turn(
@@ -119,17 +142,24 @@ def _prompt_cache_prefix_count_for_turn(
     prompt_cache_strategy: str,
     stable_prefix_count: int,
     older_history_count: int,
+    older_history_token_counts: list[int] | None = None,
     latest_turn_messages: list[AnyMessage],
 ) -> tuple[int, str]:
     full_count = max(0, int(stable_prefix_count)) + max(0, int(older_history_count))
-    if str(prompt_cache_strategy or "") != "explicit_tail_breakpoint":
+    if str(prompt_cache_strategy or "") != "explicit_committed_breakpoint":
         return full_count, "full_older_history"
     is_fresh_user_turn = (
         len(latest_turn_messages) == 1 and isinstance(latest_turn_messages[0], HumanMessage)
     )
-    if is_fresh_user_turn:
+    if is_fresh_user_turn and older_history_count <= 0:
         return max(0, int(stable_prefix_count)), "stable_prefix_fresh_user_turn"
-    return full_count, "full_older_history"
+    if older_history_token_counts is None:
+        return full_count, "full_older_history"
+    committed_history_count = _committed_history_message_count(older_history_token_counts)
+    if committed_history_count <= 0:
+        return max(0, int(stable_prefix_count)), "stable_prefix_committed_only"
+    safe_history_count = min(max(0, int(older_history_count)), committed_history_count)
+    return max(0, int(stable_prefix_count)) + safe_history_count, "committed_older_history"
 
 
 def _build_workflow_setup_prompt_context(
@@ -1299,18 +1329,26 @@ def build_runtime_graph(runtime: Any):
             prompt_cache_strategy=str(cache_profile.get("strategy", "")),
             stable_prefix_count=stable_prefix_count,
             older_history_count=len(older_history_messages),
+            older_history_token_counts=[
+                _message_tokens([message]) for message in older_history_messages
+            ],
             latest_turn_messages=latest_turn_messages,
         )
         cacheable_prefix_tokens = (
-            stable_prefix_tokens + older_history_tokens
+            stable_prefix_tokens
+            + _message_tokens(
+                older_history_messages[
+                    : max(0, cacheable_prefix_count - stable_prefix_count)
+                ]
+            )
             if cacheable_prefix_count > stable_prefix_count
             else stable_prefix_tokens
         )
         model_messages: list[AnyMessage] = [
             *prefix_messages,
             *older_history_messages,
-            *frozen_late_messages,
             *latest_turn_messages,
+            *frozen_late_messages,
             *dynamic_late_messages,
         ]
         _log(

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -114,6 +114,24 @@ CACHE_STICKY_ROUTING_ANCHOR = (
 )
 
 
+def _prompt_cache_prefix_count_for_turn(
+    *,
+    prompt_cache_strategy: str,
+    stable_prefix_count: int,
+    older_history_count: int,
+    latest_turn_messages: list[AnyMessage],
+) -> tuple[int, str]:
+    full_count = max(0, int(stable_prefix_count)) + max(0, int(older_history_count))
+    if str(prompt_cache_strategy or "") != "explicit_tail_breakpoint":
+        return full_count, "full_older_history"
+    is_fresh_user_turn = (
+        len(latest_turn_messages) == 1 and isinstance(latest_turn_messages[0], HumanMessage)
+    )
+    if is_fresh_user_turn:
+        return max(0, int(stable_prefix_count)), "stable_prefix_fresh_user_turn"
+    return full_count, "full_older_history"
+
+
 def _build_workflow_setup_prompt_context(
     runtime: Any,
     *,
@@ -1277,8 +1295,17 @@ def build_runtime_graph(runtime: Any):
         dynamic_late_tokens = _message_tokens(dynamic_late_messages)
         older_history_tokens = _message_tokens(older_history_messages)
         latest_turn_tokens = _message_tokens(latest_turn_messages)
-        cacheable_prefix_count = len(prefix_messages) + len(older_history_messages)
-        cacheable_prefix_tokens = stable_prefix_tokens + older_history_tokens
+        cacheable_prefix_count, cacheable_prefix_mode = _prompt_cache_prefix_count_for_turn(
+            prompt_cache_strategy=str(cache_profile.get("strategy", "")),
+            stable_prefix_count=stable_prefix_count,
+            older_history_count=len(older_history_messages),
+            latest_turn_messages=latest_turn_messages,
+        )
+        cacheable_prefix_tokens = (
+            stable_prefix_tokens + older_history_tokens
+            if cacheable_prefix_count > stable_prefix_count
+            else stable_prefix_tokens
+        )
         model_messages: list[AnyMessage] = [
             *prefix_messages,
             *older_history_messages,
@@ -1306,6 +1333,7 @@ def build_runtime_graph(runtime: Any):
             stable_prefix_tokens=stable_prefix_tokens,
             cacheable_prefix_count=cacheable_prefix_count,
             cacheable_prefix_tokens=cacheable_prefix_tokens,
+            cacheable_prefix_mode=cacheable_prefix_mode,
             frozen_late_tokens=frozen_late_tokens,
             dynamic_late_tokens=dynamic_late_tokens,
             older_history_tokens=older_history_tokens,
@@ -1329,6 +1357,7 @@ def build_runtime_graph(runtime: Any):
             "stable_prefix_tokens": stable_prefix_tokens,
             "cacheable_prefix_count": cacheable_prefix_count,
             "cacheable_prefix_tokens": cacheable_prefix_tokens,
+            "cacheable_prefix_mode": cacheable_prefix_mode,
             "frozen_late_tokens": frozen_late_tokens,
             "dynamic_late_tokens": dynamic_late_tokens,
             "older_history_tokens": older_history_tokens,

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -345,6 +345,25 @@ def infer_stable_system_prefix_count(messages: list[Any]) -> int:
     return count
 
 
+def prompt_cache_breakpoint_message_index(
+    messages: list[Any],
+    *,
+    effective_prefix_count: int,
+) -> int | None:
+    if effective_prefix_count <= 0:
+        return None
+    target_roles = (SystemMessage, HumanMessage, AIMessage, ToolMessage)
+    for idx in range(min(effective_prefix_count, len(messages)) - 1, -1, -1):
+        message = messages[idx]
+        if not isinstance(message, target_roles):
+            continue
+        if isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
+            continue
+        if getattr(message, "content", None):
+            return idx
+    return None
+
+
 def prepare_messages_for_prompt_cache(
     runtime: Any,
     messages: list[Any],
@@ -377,17 +396,10 @@ def prepare_messages_for_prompt_cache(
     if effective_prefix_count <= 0:
         return messages
     patched: list[Any] = list(messages)
-    target_index: int | None = None
-    target_roles = (SystemMessage, HumanMessage, AIMessage, ToolMessage)
-    for idx in range(min(effective_prefix_count, len(patched)) - 1, -1, -1):
-        message = patched[idx]
-        if not isinstance(message, target_roles):
-            continue
-        if isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
-            continue
-        if getattr(message, "content", None):
-            target_index = idx
-            break
+    target_index = prompt_cache_breakpoint_message_index(
+        patched,
+        effective_prefix_count=effective_prefix_count,
+    )
     if target_index is None:
         return messages
     patched[target_index] = message_with_cache_breakpoint(

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -65,7 +65,7 @@ def provider_prompt_cache_profile(
     if slug.startswith("qwen/") or "qwen" in slug:
         return {
             "enabled": True,
-            "strategy": "explicit_tail_breakpoint",
+            "strategy": "explicit_committed_breakpoint",
             "supports_top_level": False,
             "supports_breakpoints": True,
             "cache_control": prompt_cache_control_payload(ttl_1h=ttl_1h),
@@ -355,12 +355,12 @@ def prepare_messages_for_prompt_cache(
 ) -> list[Any]:
     profile = runtime.prompt_cache_profile(model_name=model_name)
     strategy = str(profile.get("strategy") or "")
-    if strategy not in {"breakpoint", "explicit_tail_breakpoint"}:
+    if strategy not in {"breakpoint", "explicit_committed_breakpoint"}:
         return messages
     cache_control = dict(profile.get("cache_control") or {})
     if not cache_control:
         return messages
-    if strategy == "explicit_tail_breakpoint":
+    if strategy == "explicit_committed_breakpoint":
         effective_prefix_count = (
             int(cacheable_prefix_count)
             if cacheable_prefix_count is not None and int(cacheable_prefix_count) > 0

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -7,6 +7,7 @@ import pytest
 from opentulpa.agent.graph_builder import (
     _build_connected_composio_toolkits_context,
     _build_late_turn_control_text,
+    _committed_history_message_count,
     _prompt_cache_prefix_count_for_turn,
 )
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -197,7 +198,7 @@ def test_prompt_cache_profile_zai_glm_is_automatic() -> None:
     assert profile["supports_breakpoints"] is False
 
 
-def test_prompt_cache_profile_qwen_uses_explicit_tail_breakpoint() -> None:
+def test_prompt_cache_profile_qwen_uses_explicit_committed_breakpoint() -> None:
     rt = OpenTulpaLangGraphRuntime(
         app_url="http://127.0.0.1:8000",
         openrouter_api_key="k",
@@ -208,7 +209,7 @@ def test_prompt_cache_profile_qwen_uses_explicit_tail_breakpoint() -> None:
 
     profile = rt.prompt_cache_profile()
 
-    assert profile["strategy"] == "explicit_tail_breakpoint"
+    assert profile["strategy"] == "explicit_committed_breakpoint"
     assert profile["supports_top_level"] is False
     assert profile["supports_breakpoints"] is True
 
@@ -343,11 +344,11 @@ def test_prepare_messages_for_qwen_uses_tool_result_after_ai_tool_call() -> None
     assert prepared[4].content == "Current user turn"
 
 
-def test_qwen_cache_prefix_uses_stable_prefix_for_fresh_user_turn() -> None:
+def test_qwen_cache_prefix_uses_stable_prefix_for_first_user_turn() -> None:
     count, mode = _prompt_cache_prefix_count_for_turn(
-        prompt_cache_strategy="explicit_tail_breakpoint",
+        prompt_cache_strategy="explicit_committed_breakpoint",
         stable_prefix_count=2,
-        older_history_count=6,
+        older_history_count=0,
         latest_turn_messages=[HumanMessage(content="New user turn")],
     )
 
@@ -355,11 +356,38 @@ def test_qwen_cache_prefix_uses_stable_prefix_for_fresh_user_turn() -> None:
     assert mode == "stable_prefix_fresh_user_turn"
 
 
-def test_qwen_cache_prefix_uses_older_history_after_tool_loop_starts() -> None:
+def test_qwen_cache_prefix_keeps_older_history_on_later_fresh_turn() -> None:
     count, mode = _prompt_cache_prefix_count_for_turn(
-        prompt_cache_strategy="explicit_tail_breakpoint",
+        prompt_cache_strategy="explicit_committed_breakpoint",
         stable_prefix_count=2,
         older_history_count=6,
+        older_history_token_counts=[1000, 1000, 1000, 1000, 1000, 1000],
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 6
+    assert mode == "committed_older_history"
+
+
+def test_qwen_cache_prefix_waits_for_committed_history_bucket() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_committed_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=3,
+        older_history_token_counts=[900, 1000, 1200],
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 2
+    assert mode == "stable_prefix_committed_only"
+
+
+def test_qwen_cache_prefix_uses_older_history_after_tool_loop_starts() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_committed_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        older_history_token_counts=[1000, 1000, 1000, 1000, 1000, 1000],
         latest_turn_messages=[
             HumanMessage(content="New user turn"),
             AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
@@ -367,8 +395,15 @@ def test_qwen_cache_prefix_uses_older_history_after_tool_loop_starts() -> None:
         ],
     )
 
-    assert count == 8
-    assert mode == "full_older_history"
+    assert count == 6
+    assert mode == "committed_older_history"
+
+
+def test_qwen_committed_history_count_advances_in_token_buckets() -> None:
+    assert _committed_history_message_count([900, 1000, 1200]) == 0
+    assert _committed_history_message_count([1000, 1000, 1000, 1000, 1000]) == 4
+    assert _committed_history_message_count([5000, 1000]) == 1
+    assert _committed_history_message_count([2000, 2000, 2000, 2000]) == 4
 
 
 def test_non_qwen_cache_prefix_keeps_full_older_history() -> None:

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -7,6 +7,7 @@ import pytest
 from opentulpa.agent.graph_builder import (
     _build_connected_composio_toolkits_context,
     _build_late_turn_control_text,
+    _prompt_cache_prefix_count_for_turn,
 )
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.prompt_policy import build_system_prompt_message
@@ -340,6 +341,46 @@ def test_prepare_messages_for_qwen_uses_tool_result_after_ai_tool_call() -> None
     assert cache_block["text"] == '{"ok": true}'
     assert cache_block["cache_control"] == {"type": "ephemeral"}
     assert prepared[4].content == "Current user turn"
+
+
+def test_qwen_cache_prefix_uses_stable_prefix_for_fresh_user_turn() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_tail_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 2
+    assert mode == "stable_prefix_fresh_user_turn"
+
+
+def test_qwen_cache_prefix_uses_older_history_after_tool_loop_starts() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="explicit_tail_breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[
+            HumanMessage(content="New user turn"),
+            AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
+            ToolMessage(content='{"ok": true}', tool_call_id="call_1"),
+        ],
+    )
+
+    assert count == 8
+    assert mode == "full_older_history"
+
+
+def test_non_qwen_cache_prefix_keeps_full_older_history() -> None:
+    count, mode = _prompt_cache_prefix_count_for_turn(
+        prompt_cache_strategy="breakpoint",
+        stable_prefix_count=2,
+        older_history_count=6,
+        latest_turn_messages=[HumanMessage(content="New user turn")],
+    )
+
+    assert count == 8
+    assert mode == "full_older_history"
 
 
 class _CaptureResponse:

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -11,6 +11,7 @@ from opentulpa.agent.graph_builder import (
     _prompt_cache_prefix_count_for_turn,
 )
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from opentulpa.agent.model_pool import prompt_cache_breakpoint_message_index
 from opentulpa.agent.prompt_policy import build_system_prompt_message
 from opentulpa.agent.prompt_sections import PROMPT_DYNAMIC_BOUNDARY
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
@@ -342,6 +343,19 @@ def test_prepare_messages_for_qwen_uses_tool_result_after_ai_tool_call() -> None
     assert cache_block["text"] == '{"ok": true}'
     assert cache_block["cache_control"] == {"type": "ephemeral"}
     assert prepared[4].content == "Current user turn"
+
+
+def test_prompt_cache_breakpoint_index_matches_actual_cacheable_message() -> None:
+    messages = [
+        SystemMessage(content="Stable system prompt"),
+        HumanMessage(content="OpenTulpa cache anchor v1"),
+        AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
+        HumanMessage(content="Current user turn"),
+    ]
+
+    index = prompt_cache_breakpoint_message_index(messages, effective_prefix_count=3)
+
+    assert index == 1
 
 
 def test_qwen_cache_prefix_uses_stable_prefix_for_first_user_turn() -> None:

--- a/tests/test_runtime_structured_model.py
+++ b/tests/test_runtime_structured_model.py
@@ -1151,4 +1151,4 @@ def test_prompt_cache_profile_uses_openrouter_standard_modes() -> None:
     assert gemini["strategy"] == "breakpoint"
     assert auto["strategy"] == "automatic"
     assert zai["strategy"] == "automatic"
-    assert qwen["strategy"] == "explicit_tail_breakpoint"
+    assert qwen["strategy"] == "explicit_committed_breakpoint"


### PR DESCRIPTION
## Summary
- switch Qwen prompt caching from tail-chasing to committed prefix buckets
- move volatile late prompt cards after the current turn/history to keep cached prefixes stable
- update the Qwen replay helper to strip stale cache markers and replay the committed-prefix strategy

## Why
OpenRouter/Qwen explicit caching was repeatedly writing new prefixes as the conversation grew. That made many live turns look uncached or only cache the stable anchor. Committing older history in 4k-token buckets reduces cache-boundary churn while preserving the shared prompt path for interactive and workflow setup turns.

## Validation
- `.venv/bin/python -m pytest -q tests/test_prompt_cache_split.py tests/test_runtime_structured_model.py::test_prompt_cache_profile_uses_openrouter_standard_modes tests/test_runtime_reasoning_effort.py::test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache`
- `.venv/bin/python -m py_compile scripts/replay_qwen_prompt_cache.py`
- replayed sampled Qwen `interactive` and `workflow_setup` Langfuse observations with committed 4k cache prefixes
