### PR TITLE
Add tool schema cache metadata to Langfuse callbacks

### DIFF
--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -3194,7 +3194,7 @@ class OpenTulpaLangGraphRuntime:
         )
         if callbacks:
             config["callbacks"] = callbacks
-            config["metadata"] = {
+            config_metadata = {
                 "langfuse_user_id": str(customer_id or "").strip(),
                 "langfuse_session_id": str(thread_id or "").strip(),
                 "langfuse_tags": [
@@ -3207,6 +3207,8 @@ class OpenTulpaLangGraphRuntime:
                 "turn_mode": str(turn_mode or "").strip(),
                 "prompt_mode": str(prompt_mode or "").strip(),
             }
+            config_metadata.update(_tool_schema_trace_fields(self, turn_mode))
+            config["metadata"] = config_metadata
             config["tags"] = list(config["metadata"]["langfuse_tags"])
             graph_langfuse_callback_attached = True
         else:
@@ -3251,6 +3253,7 @@ class OpenTulpaLangGraphRuntime:
             "model_name": str(model_name or "").strip(),
             "opentulpa_trace_id": str(trace_id or "").strip(),
         }
+        metadata.update(_tool_schema_trace_fields(self, str(turn_mode or "").strip()))
         return build_callbacks(
             user_id=str(customer_id or "").strip() or None,
             trace_id=str(trace_id or "").strip() or None,
@@ -3307,6 +3310,12 @@ class OpenTulpaLangGraphRuntime:
                 "call_site": str(context.get("call_site") or "").strip()
                 or "runtime_model_invoke",
             }
+            metadata.update(
+                _tool_schema_trace_fields(
+                    self,
+                    str(context.get("turn_mode") or "").strip(),
+                )
+            )
             configured_model = with_config(
                 {
                     "callbacks": callbacks,

--- a/tests/test_langfuse_logging.py
+++ b/tests/test_langfuse_logging.py
@@ -432,9 +432,8 @@ def test_tool_span_inherits_active_trace_context() -> None:
         trace_id="turn_1",
         user_id="cust_1",
         session_id="thread_1",
-    ):
-        with tracer.tool_span(trace_id="turn_1", tool_name="send_message"):
-            pass
+    ), tracer.tool_span(trace_id="turn_1", tool_name="send_message"):
+        pass
 
     root, tool = client.observations
     assert "trace_context" not in root.kwargs
@@ -524,6 +523,7 @@ async def test_prepare_turn_context_adds_langfuse_callbacks_to_graph_config() ->
     runtime = object.__new__(OpenTulpaLangGraphRuntime)
     runtime.recursion_limit = 8
     runtime._langfuse_tracer = _FakeCallbackTracer()
+    runtime._tools = {}
     runtime.register_links_from_text = lambda **kwargs: []  # type: ignore[assignment]
     runtime.expand_link_aliases = lambda **kwargs: str(kwargs.get("text", ""))  # type: ignore[assignment]
     runtime._build_pending_context_summary = lambda **kwargs: ("", None)  # type: ignore[assignment]
@@ -552,6 +552,8 @@ async def test_prepare_turn_context_adds_langfuse_callbacks_to_graph_config() ->
     assert runtime._langfuse_tracer.calls[0]["user_id"] == "telegram_test"
     assert runtime._langfuse_tracer.calls[0]["trace_id"] == "turn_test"
     assert runtime._langfuse_tracer.calls[0]["session_id"] == "chat_test"
+    assert len(prepared.config["metadata"]["bound_tool_schema_hash"]) == 64
+    assert len(runtime._langfuse_tracer.calls[0]["metadata"]["bound_tool_schema_hash"]) == 64
 
 
 @pytest.mark.asyncio
@@ -583,6 +585,8 @@ async def test_ainvoke_model_attaches_langfuse_callbacks_with_with_config(tmp_pa
     assert model.configs[0]["callbacks"] == ["langfuse-callback"]
     assert runtime._langfuse_tracer.calls[0]["trace_id"] == "turn_test"
     assert runtime._langfuse_tracer.calls[0]["metadata"]["call_site"] == "graph_agent"
+    assert len(runtime._langfuse_tracer.calls[0]["metadata"]["bound_tool_schema_hash"]) == 64
+    assert len(model.configs[0]["metadata"]["bound_tool_schema_hash"]) == 64
     assert runtime._langfuse_tracer.generations == []
 
 


### PR DESCRIPTION
## Summary
- include bound tool schema hash/count/size in Langfuse graph callback metadata
- include the same metadata on direct model callback configs
- assert the metadata is present in callback tests

## Verification
- .venv/bin/python -m pytest -q tests/test_langfuse_logging.py::test_prepare_turn_context_adds_langfuse_callbacks_to_graph_config tests/test_langfuse_logging.py::test_ainvoke_model_attaches_langfuse_callbacks_with_with_config tests/test_langfuse_logging.py::test_tool_span_inherits_active_trace_context tests/test_llm_call_tracing.py::test_ainvoke_model_writes_full_llm_call_trace
- .venv/bin/python -m ruff check src/opentulpa/agent/runtime.py tests/test_langfuse_logging.py
- git diff --check