### PR TITLE
[codex] Combine OPE-149 through OPE-153 refactors

### DIFF
--- a/opentulpa.config.yaml
+++ b/opentulpa.config.yaml
@@ -26,11 +26,12 @@ agent_context_rollup_tokens: 2200
 agent_context_compaction_source_tokens: 12000
 
 # LLM/provider configuration
-llm_model: qwen/qwen3.7-max
+llm_model: deepseek/deepseek-v4-pro
 memory_llm_model: google/gemini-3-flash-preview
 llm_reasoning_effort: medium
 wake_classifier_model: null
-wake_execution_model: qwen/qwen3.7-max
+wake_execution_model: deepseek/deepseek-v4-pro
+workflow_setup_input_classifier_model: deepseek/deepseek-v4-pro
 multimodal_llm: google/gemini-3.1-flash-lite-preview
 business_knowledge_oracle_model: google/gemini-3.1-flash-lite-preview
 openai_compatible_embedding_model: openai/text-embedding-3-small

--- a/src/opentulpa/agent/file_analysis.py
+++ b/src/opentulpa/agent/file_analysis.py
@@ -107,7 +107,7 @@ def _spreadsheet_cell_to_text(value: Any) -> str:
 def extract_xlsx_text(raw_bytes: bytes, *, max_chars: int = 140000) -> str:
     """Return a bounded, retrieval-friendly workbook preview."""
     try:
-        from openpyxl import load_workbook
+        from openpyxl import load_workbook  # type: ignore[import-untyped]
     except Exception as exc:
         raise RuntimeError("XLSX parser unavailable. Install openpyxl.") from exc
     try:

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -8,7 +8,7 @@ import json
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command, RetryPolicy
@@ -185,8 +185,11 @@ def _latest_turn_frontier_start_index(
     if isinstance(last, ToolMessage):
         tool_call_id = str(getattr(last, "tool_call_id", "") or "").strip()
         previous_index = last_index - 1
-        if previous_index >= 0 and isinstance(latest_turn_messages[previous_index], AIMessage):
-            call_ids = set(ContextEngineer._tool_call_ids(latest_turn_messages[previous_index]))
+        if previous_index >= 0:
+            previous = latest_turn_messages[previous_index]
+            if not isinstance(previous, AIMessage):
+                return last_index
+            call_ids = set(ContextEngineer._tool_call_ids(previous))
             if not tool_call_id or tool_call_id in call_ids:
                 return previous_index
         return last_index
@@ -241,7 +244,11 @@ def _split_qwen_cacheable_history(
         _qwen_cacheable_history_message(stable_candidates[:stable_count])
     ]
     frontier_history = [*stable_candidates[stable_count:], *latest_turn_messages[frontier_start:]]
-    return cacheable_history, frontier_history, "committed_tail_sized_history"
+    return (
+        cast("list[AnyMessage]", cacheable_history),
+        cast("list[AnyMessage]", frontier_history),
+        "committed_tail_sized_history",
+    )
 
 
 def _qwen_message_role(message: AnyMessage) -> str:
@@ -1359,9 +1366,9 @@ def build_runtime_graph(runtime: Any):
                     title="Compressed older in-thread context.",
                     body=history_working_set.summary_text,
                 )
-            selected_summary_entries: list[tuple[str, SystemMessage]] = []
+            projected_summary_entries: list[tuple[str, SystemMessage]] = []
             if summary_entry is not None:
-                selected_summary_entries, _ = _select_optional_prompt_entries(
+                projected_summary_entries, _ = _select_optional_prompt_entries(
                     [summary_entry],
                     initial_used_tokens=used_optional_tokens,
                     optional_context_budget=optional_context_budget,
@@ -1369,18 +1376,18 @@ def build_runtime_graph(runtime: Any):
             prompt_messages = [
                 *prompt_messages_base,
                 *(message for _, message in selected_frozen_late_entries),
-                *(message for _, message in selected_summary_entries),
+                *(message for _, message in projected_summary_entries),
             ]
             prompt_overhead_tokens = _prompt_overhead_tokens(prompt_messages)
-            while selected_summary_entries and prompt_overhead_tokens > max_overhead_tokens:
-                selected_summary_entries.pop()
+            while projected_summary_entries and prompt_overhead_tokens > max_overhead_tokens:
+                projected_summary_entries.pop()
                 prompt_messages = [
                     *prompt_messages_base,
                     *(message for _, message in selected_frozen_late_entries),
-                    *(message for _, message in selected_summary_entries),
+                    *(message for _, message in projected_summary_entries),
                 ]
                 prompt_overhead_tokens = _prompt_overhead_tokens(prompt_messages)
-            if selected_summary_entries:
+            if projected_summary_entries:
                 history_budget = max(800, prompt_budget - prompt_overhead_tokens)
                 history_working_set = context_engineer.build_history_working_set(
                     sanitized_history,
@@ -1721,7 +1728,7 @@ def build_runtime_graph(runtime: Any):
         loop_limit_final_status_text=LOOP_LIMIT_FINAL_STATUS_TEXT,
     )
 
-    async def tools_node(state: AgentState) -> Command[Literal["agent", "__end__"]]:
+    async def tools_node(state: AgentState) -> Command[Literal["agent", "finalize_turn", "__end__"]]:
         messages = state.get("messages", [])
         if not messages:
             return Command(update={"turn_status": "running"}, goto="agent")
@@ -2032,7 +2039,7 @@ def build_runtime_graph(runtime: Any):
     )
     builder.add_node(
         "validate_tools",
-        validate_tool_calls_node,
+        cast(Any, validate_tool_calls_node),
         retry_policy=RetryPolicy(max_attempts=2),
         destinations=("tools", "agent"),
     )

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -281,8 +281,11 @@ async def _build_connected_composio_toolkits_context(runtime: Any, customer_id: 
     else:
         toolkits = []
         composio = getattr(runtime, "composio_service", None)
-        list_connected_accounts = getattr(composio, "list_connected_accounts", None)
-        if bool(getattr(composio, "enabled", False)) and callable(list_connected_accounts):
+        if not bool(getattr(composio, "enabled", False)):
+            list_connected_accounts = None
+        else:
+            list_connected_accounts = getattr(composio, "list_connected_accounts", None)
+        if callable(list_connected_accounts):
             try:
                 response = await asyncio.wait_for(
                     asyncio.to_thread(

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 import logging
 import time
-from datetime import datetime, timedelta
 from typing import Any, Literal
 
 from langgraph.graph import END, START, StateGraph
@@ -27,10 +25,16 @@ from opentulpa.agent.lc_messages import (
     SystemMessage,
     ToolMessage,
 )
-from opentulpa.agent.model_pool import (
-    prompt_cache_breakpoint_message_index as _prompt_cache_breakpoint_message_index,
-)
 from opentulpa.agent.models import AgentState
+from opentulpa.agent.prompt_cache_policy import (
+    CACHE_STICKY_ROUTING_ANCHOR,
+)
+from opentulpa.agent.prompt_cache_policy import (
+    build_prompt_cache_plan as _build_prompt_cache_plan,
+)
+from opentulpa.agent.prompt_cache_policy import (
+    message_tokens as _message_tokens,
+)
 from opentulpa.agent.prompt_policy import (
     build_system_prompt_message as _build_system_prompt_message,
 )
@@ -43,6 +47,7 @@ from opentulpa.agent.prompt_sections import (
 from opentulpa.agent.prompt_sections import (
     build_retrieved_context_message as _build_retrieved_context_message,
 )
+from opentulpa.agent.tool_execution_policy import ToolExecutionPolicy
 from opentulpa.agent.tool_message_protocol import (
     enforce_tool_message_protocol as _enforce_tool_message_protocol,
 )
@@ -53,9 +58,6 @@ from opentulpa.agent.turn_policy import (
     build_turn_mode_system_message as _build_turn_mode_system_message,
 )
 from opentulpa.agent.turn_policy import (
-    execution_origin_for_turn_mode as _execution_origin_for_turn_mode,
-)
-from opentulpa.agent.turn_policy import (
     normalize_turn_mode as _normalize_turn_mode,
 )
 from opentulpa.agent.utils import (
@@ -63,12 +65,6 @@ from opentulpa.agent.utils import (
 )
 from opentulpa.agent.utils import (
     content_to_text as _content_to_text,
-)
-from opentulpa.agent.utils import (
-    extract_relative_delay_minutes as _extract_relative_delay_minutes,
-)
-from opentulpa.agent.utils import (
-    is_cron_like_schedule as _is_cron_like_schedule,
 )
 from opentulpa.agent.utils import (
     latest_user_text as _latest_user_text,
@@ -113,196 +109,6 @@ LOOP_LIMIT_REPAIR_INSTRUCTION = (
     "Write a concise user-facing status update now with what is done, the current blocker, "
     "or the next exact step."
 )
-CACHE_STICKY_ROUTING_ANCHOR = (
-    "OpenTulpa cache anchor v1. Real conversation messages follow; do not answer this marker."
-)
-QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS = 300
-QWEN_CACHE_INITIAL_COMMIT_TOKENS = 1024
-QWEN_CACHE_HISTORY_COMMIT_TOKENS = 4000
-
-
-def _tail_sized_history_message_count(
-    token_counts: list[int],
-    *,
-    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
-) -> int:
-    safe_counts = [max(0, int(token_count)) for token_count in token_counts]
-    if not safe_counts:
-        return 0
-    included = 0
-    remaining_tokens = sum(safe_counts)
-    safe_target = max(0, int(target_tail_tokens))
-    for token_count in safe_counts:
-        if remaining_tokens <= safe_target:
-            break
-        included += 1
-        remaining_tokens -= token_count
-    return included
-
-
-def _committed_tail_sized_history_message_count(
-    token_counts: list[int],
-    *,
-    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
-    initial_commit_tokens: int = QWEN_CACHE_INITIAL_COMMIT_TOKENS,
-    commit_token_step: int = QWEN_CACHE_HISTORY_COMMIT_TOKENS,
-) -> int:
-    tail_sized_count = _tail_sized_history_message_count(
-        token_counts,
-        target_tail_tokens=target_tail_tokens,
-    )
-    if tail_sized_count <= 0:
-        return 0
-    safe_counts = [max(0, int(token_count)) for token_count in token_counts[:tail_sized_count]]
-    total_tokens = sum(safe_counts)
-    safe_initial = max(1, int(initial_commit_tokens))
-    if total_tokens < safe_initial:
-        return 0
-    safe_step = max(1, int(commit_token_step))
-    committed_tokens = safe_initial + ((total_tokens - safe_initial) // safe_step) * safe_step
-    included = 0
-    included_tokens = 0
-    for token_count in safe_counts:
-        next_tokens = included_tokens + token_count
-        if next_tokens > committed_tokens and included > 0:
-            break
-        included += 1
-        included_tokens = next_tokens
-    return included
-
-
-def _latest_turn_frontier_start_index(
-    latest_turn_messages: list[AnyMessage],
-) -> int:
-    if not latest_turn_messages:
-        return 0
-    last_index = len(latest_turn_messages) - 1
-    last = latest_turn_messages[last_index]
-    if isinstance(last, HumanMessage):
-        return last_index
-    if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
-        return last_index
-    if isinstance(last, ToolMessage):
-        tool_call_id = str(getattr(last, "tool_call_id", "") or "").strip()
-        previous_index = last_index - 1
-        if previous_index >= 0 and isinstance(latest_turn_messages[previous_index], AIMessage):
-            call_ids = set(ContextEngineer._tool_call_ids(latest_turn_messages[previous_index]))
-            if not tool_call_id or tool_call_id in call_ids:
-                return previous_index
-        return last_index
-    return len(latest_turn_messages)
-
-
-def _qwen_cache_safe_history_count(
-    messages: list[AnyMessage],
-    requested_count: int,
-) -> int:
-    safe_count = max(0, min(int(requested_count), len(messages)))
-    while safe_count > 0:
-        last = messages[safe_count - 1]
-        if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
-            safe_count -= 1
-            continue
-        if isinstance(last, ToolMessage):
-            tool_call_id = str(getattr(last, "tool_call_id", "") or "").strip()
-            for previous in reversed(messages[: safe_count - 1]):
-                if not isinstance(previous, AIMessage):
-                    continue
-                call_ids = set(ContextEngineer._tool_call_ids(previous))
-                if not call_ids:
-                    continue
-                if not tool_call_id or tool_call_id in call_ids:
-                    return safe_count
-                break
-            safe_count -= 1
-            continue
-        if _content_to_text(getattr(last, "content", "")).strip():
-            return safe_count
-        safe_count -= 1
-    return 0
-
-
-def _split_qwen_cacheable_history(
-    *,
-    older_history_messages: list[AnyMessage],
-    latest_turn_messages: list[AnyMessage],
-    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
-) -> tuple[list[AnyMessage], list[AnyMessage], str]:
-    frontier_start = _latest_turn_frontier_start_index(latest_turn_messages)
-    stable_candidates = [*older_history_messages, *latest_turn_messages[:frontier_start]]
-    stable_count = _committed_tail_sized_history_message_count(
-        [_message_tokens([message]) for message in stable_candidates],
-        target_tail_tokens=target_tail_tokens,
-    )
-    stable_count = _qwen_cache_safe_history_count(stable_candidates, stable_count)
-    if stable_count <= 0:
-        return [], [*stable_candidates, *latest_turn_messages[frontier_start:]], "stable_prefix_tail_only"
-    cacheable_history = [
-        _qwen_cacheable_history_message(stable_candidates[:stable_count])
-    ]
-    frontier_history = [*stable_candidates[stable_count:], *latest_turn_messages[frontier_start:]]
-    return cacheable_history, frontier_history, "committed_tail_sized_history"
-
-
-def _qwen_message_role(message: AnyMessage) -> str:
-    if isinstance(message, HumanMessage):
-        return "user"
-    if isinstance(message, AIMessage):
-        return "assistant"
-    if isinstance(message, ToolMessage):
-        return "tool"
-    if isinstance(message, SystemMessage):
-        return "system"
-    return type(message).__name__
-
-
-def _qwen_cacheable_history_item(message: AnyMessage) -> dict[str, Any]:
-    item: dict[str, Any] = {
-        "role": _qwen_message_role(message),
-        "content": _content_to_text(getattr(message, "content", "")).strip(),
-    }
-    if isinstance(message, HumanMessage):
-        text = item["content"]
-        if text.startswith("INTERNAL_ONBOARDING_SEED."):
-            item["role"] = "system"
-            item["note"] = "internal_onboarding_seed"
-    if isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
-        item["tool_calls"] = getattr(message, "tool_calls", []) or []
-    if isinstance(message, ToolMessage):
-        item["tool_call_id"] = str(getattr(message, "tool_call_id", "") or "").strip()
-    return item
-
-
-def _qwen_cacheable_history_message(messages: list[AnyMessage]) -> HumanMessage:
-    payload = [_qwen_cacheable_history_item(message) for message in messages]
-    return HumanMessage(
-        content=(
-            "QWEN_CACHEABLE_COMMITTED_HISTORY\n"
-            "Stable completed prior conversation/tool history. Use as context; live frontier follows later.\n"
-            f"{json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)}"
-        )
-    )
-
-
-def _qwen_volatile_history_message(messages: list[AnyMessage]) -> HumanMessage:
-    payload = [_qwen_cacheable_history_item(message) for message in messages]
-    return HumanMessage(
-        content=(
-            "QWEN_VOLATILE_RECENT_HISTORY\n"
-            "Recent uncommitted conversation/tool history. Use as context; current live frontier follows.\n"
-            f"{json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)}"
-        )
-    )
-
-
-def _compact_qwen_frontier_history(messages: list[AnyMessage]) -> list[AnyMessage]:
-    frontier_start = _latest_turn_frontier_start_index(messages)
-    if frontier_start <= 0:
-        return messages
-    return [
-        _qwen_volatile_history_message(messages[:frontier_start]),
-        *messages[frontier_start:],
-    ]
 
 
 def _build_workflow_setup_prompt_context(
@@ -519,10 +325,6 @@ def _prompt_overhead_tokens(messages: list[AnyMessage]) -> int:
         _approx_tokens(_content_to_text(getattr(msg, "content", "")))
         for msg in messages
     )
-
-
-def _message_tokens(messages: list[AnyMessage]) -> int:
-    return sum(max(0, _approx_tokens(_content_to_text(getattr(msg, "content", "")))) for msg in messages)
 
 
 def _select_optional_prompt_entries(
@@ -1481,7 +1283,6 @@ def build_runtime_graph(runtime: Any):
             except Exception:
                 cache_profile = {}
         stable_prefix_count = len(prefix_messages)
-        prompt_cache_strategy = str(cache_profile.get("strategy", ""))
         actual_history_messages = [*older_history_messages, *latest_turn_messages]
         raw_chat_history_count = sum(
             1 for msg in actual_history_messages if isinstance(msg, (HumanMessage, AIMessage))
@@ -1493,44 +1294,20 @@ def build_runtime_graph(runtime: Any):
         dynamic_late_tokens = _message_tokens(dynamic_late_messages)
         older_history_tokens = _message_tokens(older_history_messages)
         latest_turn_tokens = _message_tokens(latest_turn_messages)
-        cacheable_history_messages: list[AnyMessage] = older_history_messages
-        frontier_history_messages: list[AnyMessage] = latest_turn_messages
-        if prompt_cache_strategy == "explicit_committed_breakpoint":
-            cacheable_history_messages, frontier_history_messages, cacheable_prefix_mode = (
-                _split_qwen_cacheable_history(
-                    older_history_messages=older_history_messages,
-                    latest_turn_messages=latest_turn_messages,
-                )
-            )
-            frontier_history_messages = _compact_qwen_frontier_history(frontier_history_messages)
-            requested_cacheable_prefix_count = stable_prefix_count + len(cacheable_history_messages)
-            model_messages: list[AnyMessage] = [
-                *prefix_messages,
-                *cacheable_history_messages,
-                *frozen_late_messages,
-                *frontier_history_messages,
-                *dynamic_late_messages,
-            ]
-        else:
-            requested_cacheable_prefix_count = stable_prefix_count + len(older_history_messages)
-            cacheable_prefix_mode = "full_older_history"
-            model_messages = [
-                *prefix_messages,
-                *older_history_messages,
-                *frozen_late_messages,
-                *latest_turn_messages,
-                *dynamic_late_messages,
-            ]
-        cacheable_prefix_count = requested_cacheable_prefix_count
-        cache_breakpoint_index: int | None = None
-        if bool(cache_profile.get("supports_breakpoints", False)):
-            cache_breakpoint_index = _prompt_cache_breakpoint_message_index(
-                model_messages,
-                effective_prefix_count=requested_cacheable_prefix_count,
-            )
-            if cache_breakpoint_index is not None:
-                cacheable_prefix_count = cache_breakpoint_index + 1
-        cacheable_prefix_tokens = _message_tokens(model_messages[:cacheable_prefix_count])
+        cache_plan = _build_prompt_cache_plan(
+            prefix_messages=prefix_messages,
+            older_history_messages=older_history_messages,
+            frozen_late_messages=frozen_late_messages,
+            latest_turn_messages=latest_turn_messages,
+            dynamic_late_messages=dynamic_late_messages,
+            cache_profile=cache_profile,
+        )
+        model_messages = cache_plan.model_messages
+        requested_cacheable_prefix_count = cache_plan.requested_cacheable_prefix_count
+        cacheable_prefix_count = cache_plan.cacheable_prefix_count
+        cacheable_prefix_mode = cache_plan.cacheable_prefix_mode
+        cache_breakpoint_index = cache_plan.cache_breakpoint_index
+        cacheable_prefix_tokens = cache_plan.cacheable_prefix_tokens
         _log(
             state,
             "graph.agent.prompt_ready",
@@ -1556,8 +1333,8 @@ def build_runtime_graph(runtime: Any):
             cache_breakpoint_index=cache_breakpoint_index,
             frozen_late_tokens=frozen_late_tokens,
             dynamic_late_tokens=dynamic_late_tokens,
-            cacheable_history_tokens=_message_tokens(cacheable_history_messages),
-            frontier_history_tokens=_message_tokens(frontier_history_messages),
+            cacheable_history_tokens=cache_plan.cacheable_history_tokens,
+            frontier_history_tokens=cache_plan.frontier_history_tokens,
             older_history_tokens=older_history_tokens,
             latest_turn_tokens=latest_turn_tokens,
             turn_mode=turn_mode,
@@ -1584,8 +1361,8 @@ def build_runtime_graph(runtime: Any):
             "cache_breakpoint_index": cache_breakpoint_index,
             "frozen_late_tokens": frozen_late_tokens,
             "dynamic_late_tokens": dynamic_late_tokens,
-            "cacheable_history_tokens": _message_tokens(cacheable_history_messages),
-            "frontier_history_tokens": _message_tokens(frontier_history_messages),
+            "cacheable_history_tokens": cache_plan.cacheable_history_tokens,
+            "frontier_history_tokens": cache_plan.frontier_history_tokens,
             "older_history_tokens": older_history_tokens,
             "latest_turn_tokens": latest_turn_tokens,
             "prompt_overhead_tokens": prompt_overhead_tokens,
@@ -1729,10 +1506,11 @@ def build_runtime_graph(runtime: Any):
         if not isinstance(last, AIMessage) or not last.tool_calls:
             return Command(update={"turn_status": "running"}, goto="agent")
 
-        customer_id = state.get("customer_id", "")
-        thread_id = str(state.get("thread_id", "")).strip()
-        turn_mode = _normalize_turn_mode(state.get("turn_mode"))
-        execution_origin = _execution_origin_for_turn_mode(turn_mode, thread_id=thread_id)
+        tool_policy = ToolExecutionPolicy.from_runtime_state(runtime=runtime, state=state)
+        customer_id = tool_policy.customer_id
+        thread_id = tool_policy.thread_id
+        turn_mode = tool_policy.turn_mode
+        execution_origin = tool_policy.execution_origin
         _log(
             state,
             "graph.tools.start",
@@ -1756,17 +1534,6 @@ def build_runtime_graph(runtime: Any):
         invoked_skill_context = str(state.get("active_invoked_skill_context", "")).strip() or str(
             state.get("active_skill_context", "")
         ).strip()
-        allowed_tool_names: set[str] = set()
-        tools_for_turn_mode = getattr(runtime, "tools_for_turn_mode", None)
-        if callable(tools_for_turn_mode):
-            try:
-                allowed_tool_names = {
-                    str(getattr(tool, "name", "") or "").strip()
-                    for tool in tools_for_turn_mode(turn_mode)
-                    if str(getattr(tool, "name", "") or "").strip()
-                }
-            except Exception:
-                allowed_tool_names = set()
         for call in last.tool_calls:
             call_name = str(call.get("name", ""))
             call_id = str(call.get("id", ""))
@@ -1775,31 +1542,15 @@ def build_runtime_graph(runtime: Any):
                 tool_fn = runtime._tools.get(call_name)
                 if tool_fn is None:
                     raise ValueError(f"Unknown tool: {call_name}")
-                if allowed_tool_names and call_name not in allowed_tool_names:
-                    raise ValueError(
-                        f"{call_name} is not bound in this turn. Use tool_group_exec "
-                        "with the matching group and command instead."
-                    )
-                if call_name in customer_scoped_tools and not str(customer_id or "").strip():
-                    raise ValueError(f"{call_name} requires customer scope, but customer_id is missing")
-                if call_name in {"tulpa_run_terminal", "routine_create"}:
-                    args = {
-                        **args,
-                        "thread_id": thread_id,
-                        "execution_origin": execution_origin,
-                    }
-                if call_name == "routine_create":
-                    latest_user = _latest_user_text(messages)
-                    corrected_args = dict(args)
-                    delay_minutes = _extract_relative_delay_minutes(latest_user)
-                    if delay_minutes is not None and _is_cron_like_schedule(
-                        str(corrected_args.get("schedule", ""))
-                    ):
-                        run_at_local = datetime.now().astimezone() + timedelta(
-                            minutes=max(1, delay_minutes)
-                        )
-                        corrected_args["schedule"] = run_at_local.isoformat()
-                    args = corrected_args
+                tool_policy.validate_call(
+                    call_name=call_name,
+                    customer_scoped_tools=customer_scoped_tools,
+                )
+                args = tool_policy.prepare_args(
+                    call_name=call_name,
+                    args=args,
+                    messages=messages,
+                )
                 args = runtime.resolve_link_aliases_in_args(customer_id=customer_id, args=args)
                 scope_token = None
                 set_customer_scope = getattr(runtime, "set_active_customer_id", None)

--- a/src/opentulpa/agent/graph_builder.py
+++ b/src/opentulpa/agent/graph_builder.py
@@ -311,7 +311,7 @@ def _build_workflow_setup_prompt_context(
     customer_id: str,
     thread_id: str,
 ) -> str:
-    service = getattr(runtime, "_workflow_setup_service", None)
+    service = getattr(runtime, "workflow_setup_service", None)
     if service is None or not hasattr(service, "get_thread_session"):
         return ""
     try:
@@ -336,7 +336,7 @@ def _thread_has_active_workflow_setup(
     customer_id: str,
     thread_id: str,
 ) -> bool:
-    service = getattr(runtime, "_workflow_setup_service", None)
+    service = getattr(runtime, "workflow_setup_service", None)
     if service is None or not hasattr(service, "get_thread_session"):
         return False
     try:
@@ -474,7 +474,7 @@ async def _build_connected_composio_toolkits_context(runtime: Any, customer_id: 
         toolkits = [str(item) for item in cached[1] if str(item).strip()]
     else:
         toolkits = []
-        composio = getattr(runtime, "_composio_service", None)
+        composio = getattr(runtime, "composio_service", None)
         list_connected_accounts = getattr(composio, "list_connected_accounts", None)
         if bool(getattr(composio, "enabled", False)) and callable(list_connected_accounts):
             try:

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
@@ -19,6 +20,34 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_OPENROUTER_APP_REFERER = "https://github.com/kvyb/opentulpa"
 DEFAULT_OPENROUTER_APP_TITLE = "OpenTulpa"
+_RETRYABLE_MODEL_ERROR_MARKERS = (
+    "429",
+    "rate limit",
+    "ratelimit",
+    "too many requests",
+    "toomanyrequests",
+    "temporarily unavailable",
+    "provider returned error",
+)
+
+
+def _model_transient_retry_limit() -> int:
+    raw = str(os.getenv("OPENTULPA_MODEL_TRANSIENT_RETRIES", "2") or "2").strip()
+    try:
+        return max(0, min(5, int(raw)))
+    except ValueError:
+        return 2
+
+
+def _is_retryable_model_error(error_text: str) -> bool:
+    normalized = str(error_text or "").strip().lower()
+    if not normalized:
+        return False
+    return any(marker in normalized for marker in _RETRYABLE_MODEL_ERROR_MARKERS)
+
+
+def _model_transient_retry_delay_seconds(retry_index: int) -> float:
+    return float(min(6.0, 0.75 * (2 ** max(0, int(retry_index)))))
 
 
 def prompt_cache_control_payload(*, ttl_1h: bool) -> dict[str, Any]:
@@ -731,10 +760,42 @@ async def invoke_structured_model[StructuredModelT: BaseModel](
                         attempt_context.get("provider_attempt_name") or "default"
                     ),
                 )
-                if supports_ainvoke_kwargs(runner, invoke_extras):
-                    payload = await runner.ainvoke(prepared_messages, **invoke_extras)
-                else:
-                    payload = await runner.ainvoke(prepared_messages)
+                transient_retries = _model_transient_retry_limit()
+                provider_retry_index = 0
+                while True:
+                    try:
+                        if supports_ainvoke_kwargs(runner, invoke_extras):
+                            payload = await runner.ainvoke(prepared_messages, **invoke_extras)
+                        else:
+                            payload = await runner.ainvoke(prepared_messages)
+                        break
+                    except Exception as exc:
+                        retry_error_text = f"{type(exc).__name__}: {exc}"
+                        if (
+                            provider_retry_index >= transient_retries
+                            or not _is_retryable_model_error(retry_error_text)
+                        ):
+                            raise
+                        delay_seconds = _model_transient_retry_delay_seconds(provider_retry_index)
+                        provider_retry_index += 1
+                        runtime.log_behavior_event(
+                            event="llm.invoke.transient_retry",
+                            model_name=resolved_model_name,
+                            call_site=str(
+                                attempt_context.get("call_site") or "runtime_model_invoke"
+                            ),
+                            trace_id=str(attempt_context.get("trace_id") or ""),
+                            thread_id=str(attempt_context.get("thread_id") or ""),
+                            customer_id=str(attempt_context.get("customer_id") or ""),
+                            provider_attempt_name=str(
+                                attempt_context.get("provider_attempt_name") or "default"
+                            ),
+                            retry_index=provider_retry_index,
+                            retry_limit=transient_retries,
+                            delay_seconds=delay_seconds,
+                            error=retry_error_text,
+                        )
+                        await asyncio.sleep(delay_seconds)
                 provider_elapsed_ms = int((time.monotonic() - provider_started) * 1000)
                 if isinstance(payload, schema):
                     runtime.log_behavior_event(

--- a/src/opentulpa/agent/model_pool.py
+++ b/src/opentulpa/agent/model_pool.py
@@ -217,6 +217,15 @@ def openrouter_reasoning_config(reasoning_effort: str | None) -> dict[str, Any]:
     return {"effort": effort, "exclude": False}
 
 
+def openrouter_provider_routing(*, model_name: str | None, base_url: str | None) -> dict[str, Any] | None:
+    if not looks_like_openrouter_base_url(base_url):
+        return None
+    slug = str(model_name or "").strip().lower()
+    if slug in {"deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-pro-20260423"}:
+        return {"order": ["DeepSeek"], "allow_fallbacks": False}
+    return None
+
+
 def openrouter_app_headers(
     *,
     base_url: str | None,
@@ -274,6 +283,12 @@ def init_runtime_chat_model(
         }
         if uses_reasoning:
             adapter_kwargs["reasoning"] = openrouter_reasoning_config(reasoning_effort)
+        provider_routing = openrouter_provider_routing(
+            model_name=model_name,
+            base_url=openrouter_base_url,
+        )
+        if provider_routing is not None:
+            adapter_kwargs["openrouter_provider"] = provider_routing
         if referer := app_headers.get("HTTP-Referer"):
             adapter_kwargs["app_url"] = referer
         if title := app_headers.get("X-OpenRouter-Title"):

--- a/src/opentulpa/agent/prompt_cache_policy.py
+++ b/src/opentulpa/agent/prompt_cache_policy.py
@@ -1,0 +1,291 @@
+"""Prompt-cache policy helpers for runtime graph prompts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from opentulpa.agent.context_engineer import ContextEngineer
+from opentulpa.agent.lc_messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from opentulpa.agent.model_pool import prompt_cache_breakpoint_message_index
+from opentulpa.agent.utils import approx_tokens as _approx_tokens
+from opentulpa.agent.utils import content_to_text as _content_to_text
+
+CACHE_STICKY_ROUTING_ANCHOR = (
+    "OpenTulpa cache anchor v1. Real conversation messages follow; do not answer this marker."
+)
+QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS = 300
+QWEN_CACHE_INITIAL_COMMIT_TOKENS = 1024
+QWEN_CACHE_HISTORY_COMMIT_TOKENS = 4000
+
+
+@dataclass(frozen=True)
+class PromptCachePlan:
+    model_messages: list[Any]
+    requested_cacheable_prefix_count: int
+    cacheable_prefix_count: int
+    cacheable_prefix_mode: str
+    cache_breakpoint_index: int | None
+    cacheable_prefix_tokens: int
+    cacheable_history_messages: list[Any]
+    frontier_history_messages: list[Any]
+    cacheable_history_tokens: int
+    frontier_history_tokens: int
+
+
+def message_tokens(messages: Sequence[Any]) -> int:
+    return sum(max(0, _approx_tokens(_content_to_text(getattr(msg, "content", "")))) for msg in messages)
+
+
+def tail_sized_history_message_count(
+    token_counts: list[int],
+    *,
+    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
+) -> int:
+    safe_counts = [max(0, int(token_count)) for token_count in token_counts]
+    if not safe_counts:
+        return 0
+    included = 0
+    remaining_tokens = sum(safe_counts)
+    safe_target = max(0, int(target_tail_tokens))
+    for token_count in safe_counts:
+        if remaining_tokens <= safe_target:
+            break
+        included += 1
+        remaining_tokens -= token_count
+    return included
+
+
+def _committed_tail_sized_history_message_count(
+    token_counts: list[int],
+    *,
+    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
+    initial_commit_tokens: int = QWEN_CACHE_INITIAL_COMMIT_TOKENS,
+    commit_token_step: int = QWEN_CACHE_HISTORY_COMMIT_TOKENS,
+) -> int:
+    tail_sized_count = tail_sized_history_message_count(
+        token_counts,
+        target_tail_tokens=target_tail_tokens,
+    )
+    if tail_sized_count <= 0:
+        return 0
+    safe_counts = [max(0, int(token_count)) for token_count in token_counts[:tail_sized_count]]
+    total_tokens = sum(safe_counts)
+    safe_initial = max(1, int(initial_commit_tokens))
+    if total_tokens < safe_initial:
+        return 0
+    safe_step = max(1, int(commit_token_step))
+    committed_tokens = safe_initial + ((total_tokens - safe_initial) // safe_step) * safe_step
+    included = 0
+    included_tokens = 0
+    for token_count in safe_counts:
+        next_tokens = included_tokens + token_count
+        if next_tokens > committed_tokens and included > 0:
+            break
+        included += 1
+        included_tokens = next_tokens
+    return included
+
+
+def _latest_turn_frontier_start_index(
+    latest_turn_messages: Sequence[Any],
+) -> int:
+    if not latest_turn_messages:
+        return 0
+    last_index = len(latest_turn_messages) - 1
+    last = latest_turn_messages[last_index]
+    if isinstance(last, HumanMessage):
+        return last_index
+    if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
+        return last_index
+    if isinstance(last, ToolMessage):
+        tool_call_id = str(getattr(last, "tool_call_id", "") or "").strip()
+        previous_index = last_index - 1
+        if previous_index >= 0 and isinstance(latest_turn_messages[previous_index], AIMessage):
+            call_ids = set(ContextEngineer._tool_call_ids(latest_turn_messages[previous_index]))
+            if not tool_call_id or tool_call_id in call_ids:
+                return previous_index
+        return last_index
+    return len(latest_turn_messages)
+
+
+def qwen_cache_safe_history_count(
+    messages: Sequence[Any],
+    requested_count: int,
+) -> int:
+    safe_count = max(0, min(int(requested_count), len(messages)))
+    while safe_count > 0:
+        last = messages[safe_count - 1]
+        if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
+            safe_count -= 1
+            continue
+        if isinstance(last, ToolMessage):
+            tool_call_id = str(getattr(last, "tool_call_id", "") or "").strip()
+            for previous in reversed(messages[: safe_count - 1]):
+                if not isinstance(previous, AIMessage):
+                    continue
+                call_ids = set(ContextEngineer._tool_call_ids(previous))
+                if not call_ids:
+                    continue
+                if not tool_call_id or tool_call_id in call_ids:
+                    return safe_count
+                break
+            safe_count -= 1
+            continue
+        if _content_to_text(getattr(last, "content", "")).strip():
+            return safe_count
+        safe_count -= 1
+    return 0
+
+
+def split_qwen_cacheable_history(
+    *,
+    older_history_messages: Sequence[Any],
+    latest_turn_messages: Sequence[Any],
+    target_tail_tokens: int = QWEN_CACHE_VOLATILE_HISTORY_TAIL_TOKENS,
+) -> tuple[list[Any], list[Any], str]:
+    frontier_start = _latest_turn_frontier_start_index(latest_turn_messages)
+    stable_candidates = [*older_history_messages, *latest_turn_messages[:frontier_start]]
+    stable_count = _committed_tail_sized_history_message_count(
+        [message_tokens([message]) for message in stable_candidates],
+        target_tail_tokens=target_tail_tokens,
+    )
+    stable_count = qwen_cache_safe_history_count(stable_candidates, stable_count)
+    if stable_count <= 0:
+        return [], [*stable_candidates, *latest_turn_messages[frontier_start:]], "stable_prefix_tail_only"
+    cacheable_history = [
+        _qwen_cacheable_history_message(stable_candidates[:stable_count])
+    ]
+    frontier_history = [*stable_candidates[stable_count:], *latest_turn_messages[frontier_start:]]
+    return cacheable_history, frontier_history, "committed_tail_sized_history"
+
+
+def _qwen_message_role(message: AnyMessage) -> str:
+    if isinstance(message, HumanMessage):
+        return "user"
+    if isinstance(message, AIMessage):
+        return "assistant"
+    if isinstance(message, ToolMessage):
+        return "tool"
+    if isinstance(message, SystemMessage):
+        return "system"
+    return type(message).__name__
+
+
+def _qwen_cacheable_history_item(message: AnyMessage) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "role": _qwen_message_role(message),
+        "content": _content_to_text(getattr(message, "content", "")).strip(),
+    }
+    if isinstance(message, HumanMessage):
+        text = item["content"]
+        if text.startswith("INTERNAL_ONBOARDING_SEED."):
+            item["role"] = "system"
+            item["note"] = "internal_onboarding_seed"
+    if isinstance(message, AIMessage) and getattr(message, "tool_calls", None):
+        item["tool_calls"] = getattr(message, "tool_calls", []) or []
+    if isinstance(message, ToolMessage):
+        item["tool_call_id"] = str(getattr(message, "tool_call_id", "") or "").strip()
+    return item
+
+
+def _qwen_cacheable_history_message(messages: Sequence[Any]) -> HumanMessage:
+    payload = [_qwen_cacheable_history_item(message) for message in messages]
+    return HumanMessage(
+        content=(
+            "QWEN_CACHEABLE_COMMITTED_HISTORY\n"
+            "Stable completed prior conversation/tool history. Use as context; live frontier follows later.\n"
+            f"{json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)}"
+        )
+    )
+
+
+def _qwen_volatile_history_message(messages: Sequence[Any]) -> HumanMessage:
+    payload = [_qwen_cacheable_history_item(message) for message in messages]
+    return HumanMessage(
+        content=(
+            "QWEN_VOLATILE_RECENT_HISTORY\n"
+            "Recent uncommitted conversation/tool history. Use as context; current live frontier follows.\n"
+            f"{json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)}"
+        )
+    )
+
+
+def compact_qwen_frontier_history(messages: Sequence[Any]) -> list[Any]:
+    frontier_start = _latest_turn_frontier_start_index(messages)
+    if frontier_start <= 0:
+        return list(messages)
+    return [
+        _qwen_volatile_history_message(messages[:frontier_start]),
+        *messages[frontier_start:],
+    ]
+
+
+def build_prompt_cache_plan(
+    *,
+    prefix_messages: Sequence[Any],
+    older_history_messages: Sequence[Any],
+    frozen_late_messages: Sequence[Any],
+    latest_turn_messages: Sequence[Any],
+    dynamic_late_messages: Sequence[Any],
+    cache_profile: dict[str, Any],
+) -> PromptCachePlan:
+    stable_prefix_count = len(prefix_messages)
+    prompt_cache_strategy = str(cache_profile.get("strategy", ""))
+    cacheable_history_messages: list[Any] = list(older_history_messages)
+    frontier_history_messages: list[Any] = list(latest_turn_messages)
+    if prompt_cache_strategy == "explicit_committed_breakpoint":
+        cacheable_history_messages, frontier_history_messages, cacheable_prefix_mode = (
+            split_qwen_cacheable_history(
+                older_history_messages=older_history_messages,
+                latest_turn_messages=latest_turn_messages,
+            )
+        )
+        frontier_history_messages = compact_qwen_frontier_history(frontier_history_messages)
+        requested_cacheable_prefix_count = stable_prefix_count + len(cacheable_history_messages)
+        model_messages: list[Any] = [
+            *prefix_messages,
+            *cacheable_history_messages,
+            *frozen_late_messages,
+            *frontier_history_messages,
+            *dynamic_late_messages,
+        ]
+    else:
+        requested_cacheable_prefix_count = stable_prefix_count + len(older_history_messages)
+        cacheable_prefix_mode = "full_older_history"
+        model_messages = [
+            *prefix_messages,
+            *older_history_messages,
+            *frozen_late_messages,
+            *latest_turn_messages,
+            *dynamic_late_messages,
+        ]
+    cacheable_prefix_count = requested_cacheable_prefix_count
+    cache_breakpoint_index: int | None = None
+    if bool(cache_profile.get("supports_breakpoints", False)):
+        cache_breakpoint_index = prompt_cache_breakpoint_message_index(
+            model_messages,
+            effective_prefix_count=requested_cacheable_prefix_count,
+        )
+        if cache_breakpoint_index is not None:
+            cacheable_prefix_count = cache_breakpoint_index + 1
+    return PromptCachePlan(
+        model_messages=model_messages,
+        requested_cacheable_prefix_count=requested_cacheable_prefix_count,
+        cacheable_prefix_count=cacheable_prefix_count,
+        cacheable_prefix_mode=cacheable_prefix_mode,
+        cache_breakpoint_index=cache_breakpoint_index,
+        cacheable_prefix_tokens=message_tokens(model_messages[:cacheable_prefix_count]),
+        cacheable_history_messages=cacheable_history_messages,
+        frontier_history_messages=frontier_history_messages,
+        cacheable_history_tokens=message_tokens(cacheable_history_messages),
+        frontier_history_tokens=message_tokens(frontier_history_messages),
+    )

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -325,7 +325,11 @@ def _extract_response_usage_fields(response: Any) -> dict[str, Any]:
         completion_tokens = _maybe_int(usage.get("output_tokens"))
     total_tokens = _maybe_int(usage.get("total_tokens"))
     cached_tokens = _maybe_int(prompt_details.get("cached_tokens"))
+    if cached_tokens is None:
+        cached_tokens = _maybe_int(usage.get("prompt_cache_hit_tokens"))
     cache_write_tokens = _maybe_int(prompt_details.get("cache_write_tokens"))
+    if cache_write_tokens is None:
+        cache_write_tokens = _maybe_int(usage.get("prompt_cache_miss_tokens"))
     reasoning_tokens = _maybe_int(completion_details.get("reasoning_tokens"))
     cost = usage.get("cost")
     cost_details = _usage_object_to_dict(usage.get("cost_details"))

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -25,7 +25,7 @@ from contextlib import asynccontextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from langchain.chat_models import init_chat_model
@@ -1320,17 +1320,17 @@ class OpenTulpaLangGraphRuntime:
         self._max_completion_tokens = max(128, min(int(max_completion_tokens), 32768))
         self._max_user_reply_chars = max(500, min(int(max_user_reply_chars), 20000))
         self._wake_classifier_model_name = (
-            _normalize_model_name(wake_classifier_model_name)
+            _normalize_model_name(str(wake_classifier_model_name))
             if str(wake_classifier_model_name or "").strip()
             else self.model_name
         )
         self._wake_execution_model_name = (
-            _normalize_model_name(wake_execution_model_name)
+            _normalize_model_name(str(wake_execution_model_name))
             if str(wake_execution_model_name or "").strip()
             else self.model_name
         )
         self._telegram_media_model_name = (
-            _normalize_model_name(telegram_media_model_name)
+            _normalize_model_name(str(telegram_media_model_name))
             if str(telegram_media_model_name or "").strip()
             else "google/gemini-3.1-flash-lite-preview"
         )
@@ -2400,7 +2400,8 @@ class OpenTulpaLangGraphRuntime:
         kind = str(item.get("kind", "") or "").strip().lower()
         priority = int(MEMORY_KIND_PRIORITY.get(kind, 50))
         try:
-            score = float(item.get("score"))
+            raw_score = item.get("score")
+            score = float(raw_score) if raw_score is not None else 0.0
         except (TypeError, ValueError):
             score = 0.0
         return priority, -score
@@ -2752,7 +2753,7 @@ class OpenTulpaLangGraphRuntime:
             "server_time_utc_iso": now_utc.isoformat(),
             "server_utc_offset": server_offset_text,
             "user_time_local_iso": user_local.isoformat(),
-            "user_utc_offset": user_offset_text,
+            "user_utc_offset": str(user_offset_text or server_offset_text),
             "user_time_source": source,
         }
 
@@ -3189,8 +3190,9 @@ class OpenTulpaLangGraphRuntime:
                 skill_state = await self._pre_resolve_skill_state(
                     customer_id=customer_id,
                     user_text=user_text,
+                    prompt_mode=prompt_mode,
                 )
-        config = {
+        config: dict[str, Any] = {
             "configurable": {"thread_id": thread_id},
             "recursion_limit": self._effective_recursion_limit(recursion_limit_override),
         }
@@ -3218,7 +3220,7 @@ class OpenTulpaLangGraphRuntime:
             }
             config_metadata.update(_tool_schema_trace_fields(self, turn_mode))
             config["metadata"] = config_metadata
-            config["tags"] = list(config["metadata"]["langfuse_tags"])
+            config["tags"] = list(config_metadata["langfuse_tags"])
             graph_langfuse_callback_attached = True
         else:
             graph_langfuse_callback_attached = False
@@ -3263,12 +3265,19 @@ class OpenTulpaLangGraphRuntime:
             "opentulpa_trace_id": str(trace_id or "").strip(),
         }
         metadata.update(_tool_schema_trace_fields(self, str(turn_mode or "").strip()))
-        return build_callbacks(
-            user_id=str(customer_id or "").strip() or None,
-            trace_id=str(trace_id or "").strip() or None,
-            session_id=str(thread_id or "").strip() or None,
-            metadata=metadata,
-            tags=[item for item in (str(turn_mode or "").strip(), str(prompt_mode or "").strip()) if item],
+        return cast(
+            "list[Any]",
+            build_callbacks(
+                user_id=str(customer_id or "").strip() or None,
+                trace_id=str(trace_id or "").strip() or None,
+                session_id=str(thread_id or "").strip() or None,
+                metadata=metadata,
+                tags=[
+                    item
+                    for item in (str(turn_mode or "").strip(), str(prompt_mode or "").strip())
+                    if item
+                ],
+            ),
         )
 
     def _model_with_callbacks(
@@ -4807,7 +4816,7 @@ class OpenTulpaLangGraphRuntime:
             raw_token, previous = token
             previous = str(previous or "").strip()
         try:
-            ctx.reset(raw_token)
+            ctx.reset(cast("contextvars.Token[str]", raw_token))
         except ValueError:
             ctx.set(previous)
         self._active_customer_id = str(ctx.get() or "").strip()
@@ -4839,7 +4848,7 @@ class OpenTulpaLangGraphRuntime:
             raw_token, previous = token
             previous = str(previous or "").strip()
         try:
-            ctx.reset(raw_token)
+            ctx.reset(cast("contextvars.Token[str]", raw_token))
         except ValueError:
             ctx.set(previous)
         self._active_thread_id = str(ctx.get() or "").strip()
@@ -4871,7 +4880,7 @@ class OpenTulpaLangGraphRuntime:
             raw_token, previous = token
             previous = str(previous or "").strip() or "interactive"
         try:
-            ctx.reset(raw_token)
+            ctx.reset(cast("contextvars.Token[str]", raw_token))
         except ValueError:
             ctx.set(previous)
         self._active_turn_mode = _normalize_turn_mode(str(ctx.get() or "interactive"))

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1353,6 +1353,7 @@ class OpenTulpaLangGraphRuntime:
         self._customer_profile_service = customer_profile_service
         self._thread_rollup_service = thread_rollup_service
         self._link_alias_service = link_alias_service
+        self._composio_service: Any | None = None
         self._workflow_setup_service: Any | None = None
         self._context_token_limit = max(6000, min(30000, int(context_token_limit)))
         self._context_short_term_high_tokens = self._context_token_limit
@@ -1572,6 +1573,34 @@ class OpenTulpaLangGraphRuntime:
         self._wake_execution_model_with_tools = None
         self._thread_inputs = ThreadInputCoordinator(debounce_seconds=self._input_debounce_seconds)
         self._internal_api = InternalApiClient(base_url=self.app_url)
+
+    @property
+    def link_alias_service(self) -> LinkAliasService | None:
+        return self._link_alias_service
+
+    @property
+    def composio_service(self) -> Any | None:
+        return self._composio_service
+
+    @property
+    def workflow_setup_service(self) -> Any | None:
+        return self._workflow_setup_service
+
+    def configure_api_services(
+        self,
+        *,
+        link_alias_service: LinkAliasService | None = None,
+        composio_service: Any | None = None,
+        workflow_setup_service: Any | None = None,
+    ) -> None:
+        assert composio_service is None or hasattr(composio_service, "status")
+        assert workflow_setup_service is None or hasattr(workflow_setup_service, "get_thread_session")
+        if link_alias_service is not None and self._link_alias_service is None:
+            self._link_alias_service = link_alias_service
+        if composio_service is not None:
+            self._composio_service = composio_service
+        if workflow_setup_service is not None:
+            self._workflow_setup_service = workflow_setup_service
 
     def prompt_cache_profile(self, *, model_name: str | None = None) -> dict[str, Any]:
         target_model_name = str(model_name or getattr(self, "model_name", "") or "").strip()

--- a/src/opentulpa/agent/runtime.py
+++ b/src/opentulpa/agent/runtime.py
@@ -1192,11 +1192,13 @@ def _build_intake_workflow_context_prompt(
 
 def _build_intake_workflow_state_prompt(
     *,
+    workflow: dict[str, Any],
     conversation: dict[str, Any],
     active_booking: dict[str, Any] | None,
     recent_completed_booking: dict[str, Any] | None,
     execution_feedback: list[dict[str, Any]] | None = None,
 ) -> str:
+    compact_workflow = _compact_workflow_for_prompt(workflow)
     compact_conversation = _compact_conversation_for_prompt(conversation)
     compact_active_booking = _compact_booking_for_prompt(active_booking)
     compact_recent_booking = _compact_booking_for_prompt(recent_completed_booking)
@@ -1204,6 +1206,7 @@ def _build_intake_workflow_state_prompt(
     return (
         "INTAKE_CONVERSATION_STATE\n"
         "Volatile conversation state for the current inbound message.\n"
+        f"workflow={json.dumps(compact_workflow, ensure_ascii=False)}\n"
         f"conversation={json.dumps(compact_conversation, ensure_ascii=False)}\n"
         f"active_booking={json.dumps(compact_active_booking, ensure_ascii=False)}\n"
         f"recent_completed_booking={json.dumps(compact_recent_booking, ensure_ascii=False)}\n"
@@ -3216,10 +3219,10 @@ class OpenTulpaLangGraphRuntime:
                     prompt_mode=prompt_mode,
                 )
             except TypeError:
-                skill_state = await self._pre_resolve_skill_state(
+                resolver = cast(Any, self._pre_resolve_skill_state)
+                skill_state = await resolver(
                     customer_id=customer_id,
                     user_text=user_text,
-                    prompt_mode=prompt_mode,
                 )
         config: dict[str, Any] = {
             "configurable": {"thread_id": thread_id},
@@ -4670,15 +4673,19 @@ class OpenTulpaLangGraphRuntime:
                     model=model,
                     schema=_IntakeWorkflowDecision,
                     messages=[
-                        SystemMessage(content=_build_intake_workflow_system_prompt()),
                         SystemMessage(
-                            content=_build_intake_workflow_context_prompt(
-                                customer_id=customer_id,
-                                workflow=workflow,
+                            content=(
+                                _build_intake_workflow_system_prompt()
+                                + "\n\n"
+                                + _build_intake_workflow_context_prompt(
+                                    customer_id=customer_id,
+                                    workflow=workflow,
+                                )
                             )
                         ),
                         HumanMessage(
                             content=_build_intake_workflow_state_prompt(
+                                workflow=workflow,
                                 conversation=conversation,
                                 active_booking=active_booking,
                                 recent_completed_booking=recent_completed_booking,
@@ -4686,7 +4693,7 @@ class OpenTulpaLangGraphRuntime:
                             )
                         ),
                     ],
-                    stable_prefix_count=2,
+                    stable_prefix_count=1,
                     call_context={
                         "call_site": "intake_workflow_decision",
                         "trace_id": structured_trace_id,

--- a/src/opentulpa/agent/tool_execution_policy.py
+++ b/src/opentulpa/agent/tool_execution_policy.py
@@ -1,0 +1,84 @@
+"""Tool execution policy for the runtime graph tools node."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from opentulpa.agent.lc_messages import AnyMessage
+from opentulpa.agent.turn_policy import execution_origin_for_turn_mode, normalize_turn_mode
+from opentulpa.agent.utils import (
+    extract_relative_delay_minutes,
+    is_cron_like_schedule,
+    latest_user_text,
+)
+
+
+@dataclass(frozen=True)
+class ToolExecutionPolicy:
+    customer_id: str
+    thread_id: str
+    turn_mode: str
+    execution_origin: str
+    allowed_tool_names: set[str]
+
+    @classmethod
+    def from_runtime_state(cls, *, runtime: Any, state: Any) -> ToolExecutionPolicy:
+        customer_id = str(state.get("customer_id", "") or "")
+        thread_id = str(state.get("thread_id", "") or "").strip()
+        turn_mode = normalize_turn_mode(state.get("turn_mode"))
+        allowed_tool_names: set[str] = set()
+        tools_for_turn_mode = getattr(runtime, "tools_for_turn_mode", None)
+        if callable(tools_for_turn_mode):
+            try:
+                allowed_tool_names = {
+                    str(getattr(tool, "name", "") or "").strip()
+                    for tool in tools_for_turn_mode(turn_mode)
+                    if str(getattr(tool, "name", "") or "").strip()
+                }
+            except Exception:
+                allowed_tool_names = set()
+        return cls(
+            customer_id=customer_id,
+            thread_id=thread_id,
+            turn_mode=turn_mode,
+            execution_origin=execution_origin_for_turn_mode(turn_mode, thread_id=thread_id),
+            allowed_tool_names=allowed_tool_names,
+        )
+
+    def validate_call(self, *, call_name: str, customer_scoped_tools: set[str]) -> None:
+        assert call_name
+        if self.allowed_tool_names and call_name not in self.allowed_tool_names:
+            raise ValueError(
+                f"{call_name} is not bound in this turn. Use tool_group_exec "
+                "with the matching group and command instead."
+            )
+        if call_name in customer_scoped_tools and not self.customer_id.strip():
+            raise ValueError(f"{call_name} requires customer scope, but customer_id is missing")
+
+    def prepare_args(
+        self,
+        *,
+        call_name: str,
+        args: dict[str, Any],
+        messages: list[AnyMessage],
+    ) -> dict[str, Any]:
+        prepared = dict(args)
+        if call_name in {"tulpa_run_terminal", "routine_create"}:
+            prepared = {
+                **prepared,
+                "thread_id": self.thread_id,
+                "execution_origin": self.execution_origin,
+            }
+        if call_name == "routine_create":
+            latest_user = latest_user_text(messages)
+            delay_minutes = extract_relative_delay_minutes(latest_user)
+            if delay_minutes is not None and is_cron_like_schedule(
+                str(prepared.get("schedule", ""))
+            ):
+                run_at_local = datetime.now().astimezone() + timedelta(
+                    minutes=max(1, delay_minutes)
+                )
+                prepared["schedule"] = run_at_local.isoformat()
+        return prepared

--- a/src/opentulpa/agent/tools/composio_tools.py
+++ b/src/opentulpa/agent/tools/composio_tools.py
@@ -7,6 +7,10 @@ from typing import Any
 from langchain.tools import tool
 
 from opentulpa.agent.tools.common import require_customer_id
+from opentulpa.agent.tools.internal_http import (
+    RETRYABLE_INTERNAL_STATUS_CODES,
+    InternalToolHTTPClient,
+)
 
 
 def _toolkit_from_slug(tool_slug: str) -> str:
@@ -43,27 +47,28 @@ def _composio_failure_payload(
 
 
 def _is_retryable_internal_status(status_code: int) -> bool:
-    return int(status_code or 0) in {408, 429, 500, 502, 503, 504}
+    return int(status_code or 0) in RETRYABLE_INTERNAL_STATUS_CODES
 
 
 def register_composio_tools(runtime: Any) -> dict[str, Any]:
+    http = InternalToolHTTPClient(runtime)
+
     @tool
     async def composio_status() -> Any:
         """Check whether Composio is configured before trying auth or external tool execution."""
-        r = await runtime._request_with_backoff(
+        return await http.request(
+            "composio_status",
             "GET",
             "/internal/composio/status",
             timeout=8.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_status failed: {r.text}"}
-        return r.json()
 
     @tool
     async def composio_authorize_toolkit(toolkit: str, callback_url: str = "") -> Any:
         """Create a Composio auth link for the active user. Share redirect_url with the user so they can finish OAuth."""
         customer_id = require_customer_id(runtime)
-        r = await runtime._request_with_backoff(
+        payload = await http.request(
+            "composio_authorize_toolkit",
             "POST",
             "/internal/composio/authorize",
             json_body={
@@ -73,9 +78,8 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_authorize_toolkit failed: {r.text}"}
-        payload = r.json()
+        if payload.get("error"):
+            return payload
         redirect_url = str(payload.get("redirect_url", "") or "").strip()
         if redirect_url:
             payload["message"] = (
@@ -89,9 +93,12 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
         timeout_seconds: float = 60.0,
     ) -> Any:
         """Wait for a Composio connection to become active after the user finishes OAuth."""
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_wait_for_connection",
             "POST",
             "/internal/composio/wait_for_connection",
+            "connection",
+            default={},
             json_body={
                 "connection_id": connection_id,
                 "timeout_seconds": max(1.0, min(float(timeout_seconds), 600.0)),
@@ -99,9 +106,6 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             timeout=max(10.0, min(float(timeout_seconds) + 5.0, 605.0)),
             retries=0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_wait_for_connection failed: {r.text}"}
-        return r.json().get("connection", {})
 
     @tool
     async def composio_toolkits(
@@ -120,15 +124,15 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
         }
         if str(is_connected or "").strip():
             params["is_connected"] = str(is_connected).strip()
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_toolkits",
             "GET",
             "/internal/composio/toolkits",
+            "items",
+            default=[],
             params=params,
             timeout=15.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_toolkits failed: {r.text}"}
-        return r.json().get("items", [])
 
     @tool
     async def composio_connected_accounts(
@@ -138,9 +142,12 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
     ) -> Any:
         """List Composio connected accounts for the active user."""
         customer_id = require_customer_id(runtime)
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_connected_accounts",
             "GET",
             "/internal/composio/connected_accounts",
+            "items",
+            default=[],
             params={
                 "customer_id": customer_id,
                 "toolkits": ",".join(toolkits or []),
@@ -149,35 +156,32 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=15.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_connected_accounts failed: {r.text}"}
-        return r.json().get("items", [])
 
     @tool
     async def composio_disable_connected_account(connected_account_id: str) -> Any:
         """Disable a Composio connected account so OpenTulpa stops using it."""
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_disable_connected_account",
             "POST",
             "/internal/composio/connected_accounts/disable",
+            "connected_account",
+            default={},
             json_body={"connected_account_id": str(connected_account_id or "").strip()},
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_disable_connected_account failed: {r.text}"}
-        return r.json().get("connected_account", {})
 
     @tool
     async def composio_delete_connected_account(connected_account_id: str) -> Any:
         """Delete a Composio connected account permanently."""
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_delete_connected_account",
             "POST",
             "/internal/composio/connected_accounts/delete",
+            "connected_account",
+            default={},
             json_body={"connected_account_id": str(connected_account_id or "").strip()},
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_delete_connected_account failed: {r.text}"}
-        return r.json().get("connected_account", {})
 
     @tool
     async def composio_tool_search(
@@ -186,9 +190,12 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
         limit: int = 20,
     ) -> Any:
         """Search Composio tools and return candidate tool slugs, descriptions, and input schemas."""
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_tool_search",
             "GET",
             "/internal/composio/tools/search",
+            "items",
+            default=[],
             params={
                 "query": str(query or "").strip(),
                 "toolkits": ",".join(toolkits or []),
@@ -196,21 +203,18 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_tool_search failed: {r.text}"}
-        return r.json().get("items", [])
 
     @tool
     async def composio_tool_schema(tool_slug: str) -> Any:
         """Get the input schema for a single Composio tool slug."""
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "composio_tool_schema",
             "GET",
             f"/internal/composio/tools/{tool_slug}/schema",
+            "tool",
+            default={},
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_tool_schema failed: {r.text}"}
-        return r.json().get("tool", {})
 
     @tool
     async def composio_instagram_reply_precheck(
@@ -221,7 +225,8 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
     ) -> Any:
         """Verify the exact Instagram thread for a recipient and capture the latest inbound timestamp before attempting a DM send."""
         customer_id = require_customer_id(runtime)
-        r = await runtime._request_with_backoff(
+        return await http.request(
+            "composio_instagram_reply_precheck",
             "POST",
             "/internal/composio/instagram/reply_precheck",
             json_body={
@@ -233,9 +238,6 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=60.0,
         )
-        if r.status_code != 200:
-            return {"error": f"composio_instagram_reply_precheck failed: {r.text}"}
-        return r.json()
 
     @tool
     async def composio_tool_execute(
@@ -295,7 +297,7 @@ def register_composio_tools(runtime: Any) -> dict[str, Any]:
             retries=0,
         )
         if r.status_code != 200:
-            retryable = r.status_code in {408, 429, 500, 502, 503, 504}
+            retryable = r.status_code in RETRYABLE_INTERNAL_STATUS_CODES
             return _composio_failure_payload(
                 operation="composio_tool_execute",
                 status_code=r.status_code,

--- a/src/opentulpa/agent/tools/core_tools.py
+++ b/src/opentulpa/agent/tools/core_tools.py
@@ -74,8 +74,16 @@ def _trim_tool_text(value: Any, *, limit: int = 160) -> str:
     return text[: max(0, limit - 15)].rstrip() + " ...[truncated]"
 
 
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _list_or_empty(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
 def _compact_file_record_for_tool(raw: Any) -> dict[str, Any]:
-    record = raw if isinstance(raw, dict) else {}
+    record = _dict_or_empty(raw)
     summary = str(record.get("summary", "") or "").strip()
     if " | content_preview=" in summary:
         summary = summary.split(" | content_preview=", 1)[0].strip()
@@ -89,8 +97,8 @@ def _compact_file_record_for_tool(raw: Any) -> dict[str, Any]:
 
 
 def _compact_row_view(raw: Any, *, value_limit: int = 120, max_values: int = 8) -> dict[str, Any]:
-    row = raw if isinstance(raw, dict) else {}
-    values = row.get("values") if isinstance(row.get("values"), list) else []
+    row = _dict_or_empty(raw)
+    values = _list_or_empty(row.get("values"))
     return {
         key: value
         for key, value in {
@@ -105,21 +113,17 @@ def _compact_row_view(raw: Any, *, value_limit: int = 120, max_values: int = 8) 
 def _compact_uploaded_file_inspection(payload: Any) -> Any:
     if not isinstance(payload, dict):
         return payload
-    inspection = payload.get("inspection") if isinstance(payload.get("inspection"), dict) else {}
-    structure = inspection.get("structure") if isinstance(inspection.get("structure"), dict) else {}
-    raw_sheets = structure.get("sheets") if isinstance(structure.get("sheets"), list) else []
+    inspection = _dict_or_empty(payload.get("inspection"))
+    structure = _dict_or_empty(inspection.get("structure"))
+    raw_sheets = _list_or_empty(structure.get("sheets"))
     sheet_inventory: list[dict[str, Any]] = []
     relevant_sheets: list[dict[str, Any]] = []
     for raw_sheet in raw_sheets:
         if not isinstance(raw_sheet, dict):
             continue
-        matches = raw_sheet.get("matches") if isinstance(raw_sheet.get("matches"), list) else []
-        sample_rows = raw_sheet.get("sample_rows") if isinstance(raw_sheet.get("sample_rows"), list) else []
-        table_candidates = (
-            raw_sheet.get("table_candidates")
-            if isinstance(raw_sheet.get("table_candidates"), list)
-            else []
-        )
+        matches = _list_or_empty(raw_sheet.get("matches"))
+        sample_rows = _list_or_empty(raw_sheet.get("sample_rows"))
+        table_candidates = _list_or_empty(raw_sheet.get("table_candidates"))
         compact_sheet = {
             "index": raw_sheet.get("index"),
             "name": str(raw_sheet.get("name", "") or "").strip(),
@@ -144,7 +148,7 @@ def _compact_uploaded_file_inspection(payload: Any) -> Any:
                         "sample_rows": [
                             _compact_row_view(row, value_limit=80, max_values=6)
                             for row in (
-                                item.get("sample_rows") if isinstance(item, dict) and isinstance(item.get("sample_rows"), list) else []
+                                _list_or_empty(item.get("sample_rows")) if isinstance(item, dict) else []
                             )[:1]
                         ],
                     }.items()

--- a/src/opentulpa/agent/tools/intake_workflow_tools.py
+++ b/src/opentulpa/agent/tools/intake_workflow_tools.py
@@ -7,6 +7,7 @@ from typing import Any
 from langchain.tools import tool
 
 from opentulpa.agent.tools.common import require_customer_id
+from opentulpa.agent.tools.internal_http import InternalToolHTTPClient
 
 
 def _unique_string_list(values: list[str] | None) -> list[str]:
@@ -81,6 +82,8 @@ def _active_thread_id(runtime: Any, explicit_thread_id: str | None) -> str:
 
 
 def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
+    http = InternalToolHTTPClient(runtime)
+
     @tool
     async def intake_workflow_upsert(
         name: str,
@@ -226,9 +229,12 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         if sink_error:
             return {"error": f"intake_workflow_upsert failed: {sink_error}"}
 
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "intake_workflow_upsert",
             "POST",
             "/internal/intake/workflows/upsert",
+            "workflow",
+            default={},
             json_body={
                 "customer_id": safe_customer,
                 "workflow_id": safe_workflow_id or None,
@@ -251,40 +257,35 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=20.0,
         )
-        if r.status_code != 200:
-            return {"error": f"intake_workflow_upsert failed: {r.text}"}
-        return r.json().get("workflow", {})
 
     @tool
     async def telegram_business_status() -> Any:
         """Check whether Telegram Business is connected for the active user and inspect available business connections."""
         customer_id = require_customer_id(runtime)
-        r = await runtime._request_with_backoff(
+        return await http.request(
+            "telegram_business_status",
             "POST",
             "/internal/telegram/business/status",
             json_body={"customer_id": customer_id},
             timeout=10.0,
         )
-        if r.status_code != 200:
-            return {"error": f"telegram_business_status failed: {r.text}"}
-        return r.json()
 
     @tool
     async def intake_workflow_list(include_disabled: bool = False) -> Any:
         """List saved intake workflows for inbound DM automation and booking flows."""
         customer_id = require_customer_id(runtime)
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "intake_workflow_list",
             "POST",
             "/internal/intake/workflows/list",
+            "workflows",
+            default=[],
             json_body={
                 "customer_id": customer_id,
                 "include_disabled": bool(include_disabled),
             },
             timeout=10.0,
         )
-        if r.status_code != 200:
-            return {"error": f"intake_workflow_list failed: {r.text}"}
-        return r.json().get("workflows", [])
 
     @tool
     async def intake_workflow_get(workflow_id: str) -> Any:
@@ -293,18 +294,18 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         safe_workflow_id = str(workflow_id or "").strip()
         if not safe_workflow_id:
             return {"error": "intake_workflow_get failed: workflow_id is required"}
-        r = await runtime._request_with_backoff(
+        return await http.request_item(
+            "intake_workflow_get",
             "POST",
             "/internal/intake/workflows/get",
+            "workflow",
+            default={},
             json_body={
                 "customer_id": customer_id,
                 "workflow_id": safe_workflow_id,
             },
             timeout=10.0,
         )
-        if r.status_code != 200:
-            return {"error": f"intake_workflow_get failed: {r.text}"}
-        return r.json().get("workflow", {})
 
     @tool
     async def intake_workflow_delete(workflow_id: str) -> Any:
@@ -313,7 +314,8 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         safe_workflow_id = str(workflow_id or "").strip()
         if not safe_workflow_id:
             return {"error": "intake_workflow_delete failed: workflow_id is required"}
-        r = await runtime._request_with_backoff(
+        return await http.request(
+            "intake_workflow_delete",
             "POST",
             "/internal/intake/workflows/delete",
             json_body={
@@ -322,9 +324,6 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=10.0,
         )
-        if r.status_code != 200:
-            return {"error": f"intake_workflow_delete failed: {r.text}"}
-        return r.json()
 
     @tool
     async def intake_workflow_run(workflow_id: str, force: bool = False) -> Any:
@@ -333,7 +332,8 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
         safe_workflow_id = str(workflow_id or "").strip()
         if not safe_workflow_id:
             return {"error": "intake_workflow_run failed: workflow_id is required"}
-        r = await runtime._request_with_backoff(
+        return await http.request(
+            "intake_workflow_run",
             "POST",
             "/internal/intake/workflows/run",
             json_body={
@@ -344,9 +344,6 @@ def register_intake_workflow_tools(runtime: Any) -> dict[str, Any]:
             },
             timeout=60.0,
         )
-        if r.status_code != 200:
-            return {"error": f"intake_workflow_run failed: {r.text}"}
-        return r.json()
 
     return {
         "intake_workflow_upsert": intake_workflow_upsert,

--- a/src/opentulpa/agent/tools/internal_http.py
+++ b/src/opentulpa/agent/tools/internal_http.py
@@ -1,0 +1,78 @@
+"""Shared internal HTTP helpers for agent tool handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+RETRYABLE_INTERNAL_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+
+class InternalToolHTTPClient:
+    """Normalizes internal HTTP response parsing for tool handlers."""
+
+    def __init__(self, runtime: Any) -> None:
+        self.runtime = runtime
+
+    async def request(
+        self,
+        tool_name: str,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        timeout: float = 20.0,
+        retries: int | None = None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"timeout": timeout}
+        if json_body is not None:
+            kwargs["json_body"] = json_body
+        if params is not None:
+            kwargs["params"] = params
+        if retries is not None:
+            kwargs["retries"] = retries
+        response = await self.runtime._request_with_backoff(method, path, **kwargs)
+        if int(response.status_code) != 200:
+            return failure_payload(tool_name=tool_name, response=response)
+        try:
+            payload = response.json()
+        except Exception:
+            return {"error": f"{tool_name} failed: invalid JSON response", "response": response.text}
+        if not isinstance(payload, dict):
+            return {"error": f"{tool_name} failed: JSON response was not an object", "response": payload}
+        return payload
+
+    async def request_item(
+        self,
+        tool_name: str,
+        method: str,
+        path: str,
+        item_key: str,
+        *,
+        default: Any,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        timeout: float = 20.0,
+        retries: int | None = None,
+    ) -> Any:
+        payload = await self.request(
+            tool_name,
+            method,
+            path,
+            json_body=json_body,
+            params=params,
+            timeout=timeout,
+            retries=retries,
+        )
+        if isinstance(payload, dict) and payload.get("error"):
+            return payload
+        return payload.get(item_key, default) if isinstance(payload, dict) else default
+
+
+def failure_payload(*, tool_name: str, response: Any) -> dict[str, Any]:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    return {
+        "error": f"{tool_name} failed: {getattr(response, 'text', '')}",
+        "status_code": status_code,
+        "retryable": status_code in RETRYABLE_INTERNAL_STATUS_CODES,
+    }

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -102,6 +102,25 @@ def _load_composio_service_class() -> type[Any]:
     return ComposioService
 
 
+def _configure_runtime_api_services(
+    runtime: Any | None,
+    *,
+    link_alias_service: LinkAliasService,
+    composio_service: Any,
+    workflow_setup_service: WorkflowSetupService,
+) -> None:
+    if runtime is None:
+        return
+    configure = getattr(runtime, "configure_api_services", None)
+    if not callable(configure):
+        return
+    configure(
+        link_alias_service=link_alias_service,
+        composio_service=composio_service,
+        workflow_setup_service=workflow_setup_service,
+    )
+
+
 def _is_trusted_server_client(host: str) -> bool:
     value = str(host or "").strip().lower()
     if not value:
@@ -282,10 +301,6 @@ def create_app(
     else:
         composio = _DisabledComposioService()
     skill_service.ensure_default_skill()
-    if runtime is not None and getattr(runtime, "_link_alias_service", None) is None:
-        runtime._link_alias_service = alias_service  # type: ignore[attr-defined]
-    if runtime is not None:
-        runtime._composio_service = composio  # type: ignore[attr-defined]
 
     telegram_client = (
         TelegramClient(settings.telegram_bot_token) if settings.telegram_bot_token else None
@@ -465,8 +480,12 @@ def create_app(
         intake_workflows=intake_service,
         knowledge_service=knowledge,
     )
-    if runtime is not None:
-        runtime._workflow_setup_service = workflow_setup_service  # type: ignore[attr-defined]
+    _configure_runtime_api_services(
+        runtime,
+        link_alias_service=alias_service,
+        composio_service=composio,
+        workflow_setup_service=workflow_setup_service,
+    )
     workflow_setup_orchestrator = WorkflowSetupOrchestrator(
         setup_service=workflow_setup_service,
     )

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from opentulpa.integrations.composio import ComposioService
 
 
-def _require(value: Any, name: str) -> Any:
+def _require[T](value: T | None, name: str) -> T:
     if value is None:
         raise RuntimeError(f"{name} not initialized")
     return value

--- a/src/opentulpa/api/routes/file_use_cases.py
+++ b/src/opentulpa/api/routes/file_use_cases.py
@@ -1,0 +1,333 @@
+"""Use-case helpers for internal file-vault HTTP routes."""
+
+from __future__ import annotations
+
+import mimetypes
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+from opentulpa.agent.knowledge_prep import inspect_uploaded_file_structure
+from opentulpa.api.customer_ids import resolve_body_customer_id
+from opentulpa.api.file_helpers import (
+    download_image_from_web_url,
+    sanitize_uploaded_file_record,
+)
+from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
+
+MAX_LOCAL_SEND_BYTES = 45_000_000
+
+
+def _telegram_delivery_payload(**fields: Any) -> dict[str, Any]:
+    payload = {
+        "ok": True,
+        "delivered_to_chat": True,
+        "model_instruction": (
+            "DELIVERED_TO_CHAT: The file has been sent to Telegram. "
+            "Do not call the file-send tool again for this file. "
+            "Continue with a short final confirmation only."
+        ),
+    }
+    payload.update(fields)
+    return payload
+
+
+def _chat_delivery_payload(**fields: Any) -> dict[str, Any]:
+    payload = {
+        "ok": True,
+        "delivered_to_chat": True,
+        "model_instruction": (
+            "DELIVERED_TO_CHAT: The file has been sent to the current chat. "
+            "Do not call the file-send tool again for this file. "
+            "Continue with a short final confirmation only."
+        ),
+    }
+    payload.update(fields)
+    return payload
+
+
+@dataclass(frozen=True)
+class FileRouteUseCases:
+    get_file_vault: Callable[[], Any]
+    get_telegram_chat: Callable[[], Any]
+    get_telegram_client: Callable[[], Any]
+    get_agent_runtime: Callable[[], Any]
+    telegram_enabled: bool
+    resolve_customer_id: Callable[[str], str] | None = None
+    tulpa_stuff_dir: Path = TULPA_STUFF_DIR
+    download_image: Callable[..., Any] = download_image_from_web_url
+
+    def _customer_id(self, body: dict[str, Any]) -> str:
+        return resolve_body_customer_id(body, self.resolve_customer_id)
+
+    def _chat_id_for_customer(self, customer_id: str) -> Any | None:
+        slots = self.get_telegram_chat().find_session_slots(customer_id)
+        return slots[0].get("chat_id") if slots else None
+
+    async def search(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        query = str(body.get("query", "")).strip()
+        limit = int(body.get("limit", 5))
+        results = [
+            sanitize_uploaded_file_record(r, include_excerpt=False)
+            for r in vault.search(customer_id, query=query, limit=limit)
+        ]
+        return {"ok": True, "results": results}
+
+    async def get(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        file_id = str(body.get("file_id", "")).strip()
+        max_excerpt_chars = max(500, min(int(body.get("max_excerpt_chars", 16000)), 60000))
+        record = vault.get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        return {
+            "ok": True,
+            "file": sanitize_uploaded_file_record(
+                record,
+                include_excerpt=True,
+                max_excerpt_chars=max_excerpt_chars,
+            ),
+        }
+
+    async def send(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        file_id = str(body.get("file_id", "")).strip()
+        caption = _optional_caption(body)
+        if not self.telegram_enabled:
+            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
+        if not customer_id or not file_id:
+            return JSONResponse(
+                status_code=400, content={"detail": "customer_id and file_id are required"}
+            )
+        record = vault.get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+
+        chat_id = record.get("chat_id")
+        if chat_id is None:
+            chat_id = self._chat_id_for_customer(customer_id)
+        if chat_id is None:
+            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
+
+        raw_bytes = vault.read_file_bytes(customer_id, file_id)
+        if raw_bytes is None:
+            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
+
+        sent = await self.get_telegram_client().send_file(
+            chat_id=chat_id,
+            filename=str(record.get("original_filename", "file.bin")),
+            raw_bytes=raw_bytes,
+            kind=str(record.get("kind", "document")),
+            mime_type=str(record.get("mime_type", "")).strip() or None,
+            caption=caption,
+            parse_mode="HTML",
+        )
+        if not sent:
+            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
+        return _telegram_delivery_payload(file_id=file_id, chat_id=chat_id)
+
+    async def send_local(self, body: dict[str, Any]) -> Any:
+        customer_id = self._customer_id(body)
+        local_path = str(body.get("path", "")).strip()
+        caption = _optional_caption(body)
+        if not self.telegram_enabled:
+            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
+        if not customer_id or not local_path:
+            return JSONResponse(
+                status_code=400, content={"detail": "customer_id and path are required"}
+            )
+        try:
+            target = (self.tulpa_stuff_dir.parent / local_path).resolve()
+        except Exception:
+            return JSONResponse(status_code=400, content={"detail": "invalid path"})
+        if not is_within(target, self.tulpa_stuff_dir):
+            return JSONResponse(status_code=400, content={"detail": "path must be under tulpa_stuff/"})
+        if not target.exists():
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        if target.is_dir():
+            return JSONResponse(status_code=400, content={"detail": "path is a directory"})
+        try:
+            file_size = int(target.stat().st_size)
+        except Exception:
+            return JSONResponse(status_code=502, content={"detail": "failed to stat local file"})
+        if file_size > MAX_LOCAL_SEND_BYTES:
+            return JSONResponse(
+                status_code=413,
+                content={
+                    "detail": f"file too large ({file_size} bytes > {MAX_LOCAL_SEND_BYTES} bytes)"
+                },
+            )
+
+        chat_id = self._chat_id_for_customer(customer_id)
+        if chat_id is None:
+            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
+        try:
+            raw_bytes = target.read_bytes()
+        except Exception:
+            return JSONResponse(status_code=502, content={"detail": "failed to read local file"})
+        guessed_mime, _ = mimetypes.guess_type(str(target.name))
+        sent = await self.get_telegram_client().send_file(
+            chat_id=chat_id,
+            filename=str(target.name),
+            raw_bytes=raw_bytes,
+            kind="document",
+            mime_type=str(guessed_mime).strip() if guessed_mime else None,
+            caption=caption,
+            parse_mode="HTML",
+        )
+        if not sent:
+            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
+        return _telegram_delivery_payload(path=local_path, chat_id=chat_id)
+
+    async def send_web_image(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        image_url = str(body.get("url", "")).strip()
+        caption = _optional_caption(body)
+        max_bytes = int(body.get("max_bytes", 10_000_000))
+
+        if not customer_id or not image_url:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "customer_id and url are required"},
+            )
+
+        chat_id = self._chat_id_for_customer(customer_id) if self.telegram_enabled else None
+        try:
+            downloaded = await self.download_image(image_url, max_bytes=max_bytes)
+        except ValueError as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        except Exception as exc:
+            return JSONResponse(status_code=502, content={"detail": f"image fetch failed: {exc}"})
+
+        if chat_id is None:
+            record = vault.ingest_file(
+                customer_id=customer_id,
+                chat_id=None,
+                kind=_downloaded_image_kind(downloaded),
+                telegram_file_id=None,
+                original_filename=str(downloaded["filename"]),
+                mime_type=str(downloaded["content_type"]),
+                caption=caption,
+                raw_bytes=downloaded["raw_bytes"],
+            )
+            emitter = getattr(self.get_agent_runtime(), "emit_interactive_file", None)
+            if not callable(emitter):
+                return JSONResponse(status_code=501, content={"detail": "file delivery unavailable"})
+            emitted = await emitter(file=sanitize_uploaded_file_record(record))
+            if not isinstance(emitted, dict) or not emitted.get("sent"):
+                reason = str((emitted or {}).get("reason") or "file delivery unavailable")
+                return JSONResponse(status_code=501, content={"detail": reason})
+            return _chat_delivery_payload(file_id=record.get("id"))
+
+        sent = await self.get_telegram_client().send_file(
+            chat_id=chat_id,
+            filename=str(downloaded["filename"]),
+            raw_bytes=downloaded["raw_bytes"],
+            kind=_downloaded_image_kind(downloaded),
+            mime_type=str(downloaded["content_type"]),
+            caption=caption,
+            parse_mode="HTML",
+        )
+        if not sent:
+            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
+        return _telegram_delivery_payload(
+            chat_id=chat_id,
+            url=str(downloaded["final_url"]),
+            mime_type=str(downloaded["content_type"]),
+            size_bytes=int(downloaded["size_bytes"]),
+        )
+
+    async def analyze(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        file_id = str(body.get("file_id", "")).strip()
+        question = _optional_question(body)
+        if not customer_id or not file_id:
+            return JSONResponse(
+                status_code=400, content={"detail": "customer_id and file_id are required"}
+            )
+        agent_runtime = self.get_agent_runtime()
+        if agent_runtime is None or not hasattr(agent_runtime, "analyze_uploaded_file"):
+            return JSONResponse(
+                status_code=501,
+                content={"detail": "agent runtime unavailable for file analysis"},
+            )
+        record = vault.get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        raw_bytes = vault.read_file_bytes(customer_id, file_id)
+        if raw_bytes is None:
+            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
+        try:
+            analysis_result = await agent_runtime.analyze_uploaded_file(
+                record=record,
+                raw_bytes=raw_bytes,
+                question=question,
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=500, content={"detail": f"file analysis failed: {exc}"})
+
+        if not question:
+            analysis_text = str(analysis_result.get("analysis", "")).strip()
+            if analysis_text:
+                updated = vault.set_ai_summary(customer_id, file_id, analysis_text)
+                if isinstance(updated, dict):
+                    record = updated
+        return {
+            "ok": True,
+            "analysis": str(analysis_result.get("analysis", "")).strip(),
+            "file": sanitize_uploaded_file_record(
+                record, include_excerpt=True, max_excerpt_chars=16000
+            ),
+        }
+
+    async def inspect_structure(self, body: dict[str, Any]) -> Any:
+        vault = self.get_file_vault()
+        customer_id = self._customer_id(body)
+        file_id = str(body.get("file_id", "")).strip()
+        if not customer_id or not file_id:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "customer_id and file_id are required"},
+            )
+        record = vault.get_file(customer_id, file_id)
+        if not record:
+            return JSONResponse(status_code=404, content={"detail": "file not found"})
+        raw_bytes = vault.read_file_bytes(customer_id, file_id)
+        if raw_bytes is None:
+            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
+        inspected = inspect_uploaded_file_structure(
+            raw_bytes=raw_bytes,
+            filename=str(record.get("original_filename", "") or "file.bin"),
+            mime_type=str(record.get("mime_type", "") or ""),
+            search_terms=body.get("search_terms"),
+        )
+        return {
+            "ok": True,
+            "file": sanitize_uploaded_file_record(record, include_excerpt=False),
+            "inspection": inspected,
+        }
+
+
+def _optional_caption(body: dict[str, Any]) -> str | None:
+    caption_raw = body.get("caption")
+    caption = str(caption_raw).strip() if caption_raw is not None else None
+    return caption or None
+
+
+def _optional_question(body: dict[str, Any]) -> str | None:
+    question_raw = body.get("question")
+    question = str(question_raw).strip() if question_raw is not None else None
+    return question or None
+
+
+def _downloaded_image_kind(downloaded: dict[str, Any]) -> str:
+    return "animation" if str(downloaded["content_type"]).strip().lower() == "image/gif" else "photo"

--- a/src/opentulpa/api/routes/files.py
+++ b/src/opentulpa/api/routes/files.py
@@ -2,50 +2,16 @@
 
 from __future__ import annotations
 
-import mimetypes
 from collections.abc import Callable
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 
-from opentulpa.agent.knowledge_prep import inspect_uploaded_file_structure
-from opentulpa.api.customer_ids import resolve_body_customer_id
-from opentulpa.api.file_helpers import (
-    download_image_from_web_url,
-    sanitize_uploaded_file_record,
+from opentulpa.api.routes.file_use_cases import TULPA_STUFF_DIR as TULPA_STUFF_DIR
+from opentulpa.api.routes.file_use_cases import FileRouteUseCases
+from opentulpa.api.routes.file_use_cases import (
+    download_image_from_web_url as download_image_from_web_url,
 )
-from opentulpa.tasks.sandbox import TULPA_STUFF_DIR, is_within
-
-MAX_LOCAL_SEND_BYTES = 45_000_000
-
-
-def _telegram_delivery_payload(**fields: Any) -> dict[str, Any]:
-    payload = {
-        "ok": True,
-        "delivered_to_chat": True,
-        "model_instruction": (
-            "DELIVERED_TO_CHAT: The file has been sent to Telegram. "
-            "Do not call the file-send tool again for this file. "
-            "Continue with a short final confirmation only."
-        ),
-    }
-    payload.update(fields)
-    return payload
-
-
-def _chat_delivery_payload(**fields: Any) -> dict[str, Any]:
-    payload = {
-        "ok": True,
-        "delivered_to_chat": True,
-        "model_instruction": (
-            "DELIVERED_TO_CHAT: The file has been sent to the current chat. "
-            "Do not call the file-send tool again for this file. "
-            "Continue with a short final confirmation only."
-        ),
-    }
-    payload.update(fields)
-    return payload
 
 
 def register_file_routes(
@@ -59,292 +25,41 @@ def register_file_routes(
     resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register uploaded-file search/get/send/analyze endpoints."""
+    use_cases = FileRouteUseCases(
+        get_file_vault=get_file_vault,
+        get_telegram_chat=get_telegram_chat,
+        get_telegram_client=get_telegram_client,
+        get_agent_runtime=get_agent_runtime,
+        telegram_enabled=telegram_enabled,
+        resolve_customer_id=resolve_customer_id,
+        tulpa_stuff_dir=TULPA_STUFF_DIR,
+        download_image=download_image_from_web_url,
+    )
 
     @app.post("/internal/files/search")
     async def internal_files_search(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        query = str(body.get("query", "")).strip()
-        limit = int(body.get("limit", 5))
-        results = [
-            sanitize_uploaded_file_record(r, include_excerpt=False)
-            for r in vault.search(customer_id, query=query, limit=limit)
-        ]
-        return {"ok": True, "results": results}
+        return await use_cases.search(await request.json())
 
     @app.post("/internal/files/get")
     async def internal_files_get(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        file_id = str(body.get("file_id", "")).strip()
-        max_excerpt_chars = max(500, min(int(body.get("max_excerpt_chars", 16000)), 60000))
-        record = vault.get_file(customer_id, file_id)
-        if not record:
-            return JSONResponse(status_code=404, content={"detail": "file not found"})
-        return {
-            "ok": True,
-            "file": sanitize_uploaded_file_record(
-                record,
-                include_excerpt=True,
-                max_excerpt_chars=max_excerpt_chars,
-            ),
-        }
+        return await use_cases.get(await request.json())
 
     @app.post("/internal/files/send")
     async def internal_files_send(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        file_id = str(body.get("file_id", "")).strip()
-        caption_raw = body.get("caption")
-        caption = str(caption_raw).strip() if caption_raw is not None else None
-        caption = caption or None
-        if not telegram_enabled:
-            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
-        if not customer_id or not file_id:
-            return JSONResponse(
-                status_code=400, content={"detail": "customer_id and file_id are required"}
-            )
-        record = vault.get_file(customer_id, file_id)
-        if not record:
-            return JSONResponse(status_code=404, content={"detail": "file not found"})
-
-        chat_id = record.get("chat_id")
-        if chat_id is None:
-            slots = get_telegram_chat().find_session_slots(customer_id)
-            if slots:
-                chat_id = slots[0].get("chat_id")
-        if chat_id is None:
-            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
-
-        raw_bytes = vault.read_file_bytes(customer_id, file_id)
-        if raw_bytes is None:
-            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
-
-        sent = await get_telegram_client().send_file(
-            chat_id=chat_id,
-            filename=str(record.get("original_filename", "file.bin")),
-            raw_bytes=raw_bytes,
-            kind=str(record.get("kind", "document")),
-            mime_type=str(record.get("mime_type", "")).strip() or None,
-            caption=caption,
-            parse_mode="HTML",
-        )
-        if not sent:
-            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return _telegram_delivery_payload(file_id=file_id, chat_id=chat_id)
+        return await use_cases.send(await request.json())
 
     @app.post("/internal/files/send_local")
     async def internal_files_send_local(request: Request) -> Any:
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        local_path = str(body.get("path", "")).strip()
-        caption_raw = body.get("caption")
-        caption = str(caption_raw).strip() if caption_raw is not None else None
-        caption = caption or None
-        if not telegram_enabled:
-            return JSONResponse(status_code=501, content={"detail": "Telegram not configured"})
-        if not customer_id or not local_path:
-            return JSONResponse(
-                status_code=400, content={"detail": "customer_id and path are required"}
-            )
-        try:
-            target = (TULPA_STUFF_DIR.parent / local_path).resolve()
-        except Exception:
-            return JSONResponse(status_code=400, content={"detail": "invalid path"})
-        if not is_within(target, TULPA_STUFF_DIR):
-            return JSONResponse(status_code=400, content={"detail": "path must be under tulpa_stuff/"})
-        if not target.exists():
-            return JSONResponse(status_code=404, content={"detail": "file not found"})
-        if target.is_dir():
-            return JSONResponse(status_code=400, content={"detail": "path is a directory"})
-        try:
-            file_size = int(target.stat().st_size)
-        except Exception:
-            return JSONResponse(status_code=502, content={"detail": "failed to stat local file"})
-        if file_size > MAX_LOCAL_SEND_BYTES:
-            return JSONResponse(
-                status_code=413,
-                content={
-                    "detail": (
-                        f"file too large ({file_size} bytes > {MAX_LOCAL_SEND_BYTES} bytes)"
-                    )
-                },
-            )
-
-        chat_id: Any = None
-        slots = get_telegram_chat().find_session_slots(customer_id)
-        if slots:
-            chat_id = slots[0].get("chat_id")
-        if chat_id is None:
-            return JSONResponse(status_code=404, content={"detail": "no chat found for customer"})
-        try:
-            raw_bytes = target.read_bytes()
-        except Exception:
-            return JSONResponse(status_code=502, content={"detail": "failed to read local file"})
-        guessed_mime, _ = mimetypes.guess_type(str(target.name))
-        sent = await get_telegram_client().send_file(
-            chat_id=chat_id,
-            filename=str(target.name),
-            raw_bytes=raw_bytes,
-            kind="document",
-            mime_type=str(guessed_mime).strip() if guessed_mime else None,
-            caption=caption,
-            parse_mode="HTML",
-        )
-        if not sent:
-            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return _telegram_delivery_payload(path=local_path, chat_id=chat_id)
+        return await use_cases.send_local(await request.json())
 
     @app.post("/internal/files/send_web_image")
     async def internal_files_send_web_image(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        image_url = str(body.get("url", "")).strip()
-        caption_raw = body.get("caption")
-        caption = str(caption_raw).strip() if caption_raw is not None else None
-        caption = caption or None
-        max_bytes = int(body.get("max_bytes", 10_000_000))
-
-        if not customer_id or not image_url:
-            return JSONResponse(
-                status_code=400,
-                content={"detail": "customer_id and url are required"},
-            )
-
-        chat_id: Any = None
-        if telegram_enabled:
-            slots = get_telegram_chat().find_session_slots(customer_id)
-            if slots:
-                chat_id = slots[0].get("chat_id")
-
-        try:
-            downloaded = await download_image_from_web_url(image_url, max_bytes=max_bytes)
-        except ValueError as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
-        except Exception as exc:
-            return JSONResponse(status_code=502, content={"detail": f"image fetch failed: {exc}"})
-
-        if chat_id is None:
-            record = vault.ingest_file(
-                customer_id=customer_id,
-                chat_id=None,
-                kind=(
-                    "animation"
-                    if str(downloaded["content_type"]).strip().lower() == "image/gif"
-                    else "photo"
-                ),
-                telegram_file_id=None,
-                original_filename=str(downloaded["filename"]),
-                mime_type=str(downloaded["content_type"]),
-                caption=caption,
-                raw_bytes=downloaded["raw_bytes"],
-            )
-            emitter = getattr(get_agent_runtime(), "emit_interactive_file", None)
-            if not callable(emitter):
-                return JSONResponse(status_code=501, content={"detail": "file delivery unavailable"})
-            emitted = await emitter(file=sanitize_uploaded_file_record(record))
-            if not isinstance(emitted, dict) or not emitted.get("sent"):
-                reason = str((emitted or {}).get("reason") or "file delivery unavailable")
-                return JSONResponse(status_code=501, content={"detail": reason})
-            return _chat_delivery_payload(file_id=record.get("id"))
-
-        sent = await get_telegram_client().send_file(
-            chat_id=chat_id,
-            filename=str(downloaded["filename"]),
-            raw_bytes=downloaded["raw_bytes"],
-            kind=(
-                "animation"
-                if str(downloaded["content_type"]).strip().lower() == "image/gif"
-                else "photo"
-            ),
-            mime_type=str(downloaded["content_type"]),
-            caption=caption,
-            parse_mode="HTML",
-        )
-        if not sent:
-            return JSONResponse(status_code=502, content={"detail": "telegram send failed"})
-        return _telegram_delivery_payload(
-            chat_id=chat_id,
-            url=str(downloaded["final_url"]),
-            mime_type=str(downloaded["content_type"]),
-            size_bytes=int(downloaded["size_bytes"]),
-        )
+        return await use_cases.send_web_image(await request.json())
 
     @app.post("/internal/files/analyze")
     async def internal_files_analyze(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        file_id = str(body.get("file_id", "")).strip()
-        question_raw = body.get("question")
-        question = str(question_raw).strip() if question_raw is not None else None
-        question = question or None
-        if not customer_id or not file_id:
-            return JSONResponse(
-                status_code=400, content={"detail": "customer_id and file_id are required"}
-            )
-        agent_runtime = get_agent_runtime()
-        if agent_runtime is None or not hasattr(agent_runtime, "analyze_uploaded_file"):
-            return JSONResponse(
-                status_code=501,
-                content={"detail": "agent runtime unavailable for file analysis"},
-            )
-        record = vault.get_file(customer_id, file_id)
-        if not record:
-            return JSONResponse(status_code=404, content={"detail": "file not found"})
-        raw_bytes = vault.read_file_bytes(customer_id, file_id)
-        if raw_bytes is None:
-            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
-        try:
-            analysis_result = await agent_runtime.analyze_uploaded_file(
-                record=record,
-                raw_bytes=raw_bytes,
-                question=question,
-            )
-        except Exception as exc:
-            return JSONResponse(status_code=500, content={"detail": f"file analysis failed: {exc}"})
-
-        if not question:
-            analysis_text = str(analysis_result.get("analysis", "")).strip()
-            if analysis_text:
-                updated = vault.set_ai_summary(customer_id, file_id, analysis_text)
-                if isinstance(updated, dict):
-                    record = updated
-        return {
-            "ok": True,
-            "analysis": str(analysis_result.get("analysis", "")).strip(),
-            "file": sanitize_uploaded_file_record(record, include_excerpt=True, max_excerpt_chars=16000),
-        }
+        return await use_cases.analyze(await request.json())
 
     @app.post("/internal/files/inspect_structure")
     async def internal_files_inspect_structure(request: Request) -> Any:
-        vault = get_file_vault()
-        body = await request.json()
-        customer_id = resolve_body_customer_id(body, resolve_customer_id)
-        file_id = str(body.get("file_id", "")).strip()
-        if not customer_id or not file_id:
-            return JSONResponse(
-                status_code=400,
-                content={"detail": "customer_id and file_id are required"},
-            )
-        record = vault.get_file(customer_id, file_id)
-        if not record:
-            return JSONResponse(status_code=404, content={"detail": "file not found"})
-        raw_bytes = vault.read_file_bytes(customer_id, file_id)
-        if raw_bytes is None:
-            return JSONResponse(status_code=404, content={"detail": "stored file bytes not found"})
-        inspected = inspect_uploaded_file_structure(
-            raw_bytes=raw_bytes,
-            filename=str(record.get("original_filename", "") or "file.bin"),
-            mime_type=str(record.get("mime_type", "") or ""),
-            search_terms=body.get("search_terms"),
-        )
-        return {
-            "ok": True,
-            "file": sanitize_uploaded_file_record(record, include_excerpt=False),
-            "inspection": inspected,
-        }
+        return await use_cases.inspect_structure(await request.json())

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -421,7 +421,7 @@ async def _stream_turn(
                         thread_id=thread_id,
                         sender=_send_file,
                     )
-            if turn_context_entered:
+            if turn_context_entered and turn_context is not None:
                 await turn_context.__aexit__(None, None, None)
             await queue.put(("done", {}))
 

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import hmac
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import quote
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from opentulpa.api.customer_ids import resolve_body_customer_id
-from opentulpa.api.file_helpers import sanitize_uploaded_file_record
+from opentulpa.api.routes.intake_use_cases import (
+    workflow_upsert_kwargs,
+    workflow_with_knowledge_files,
+)
 
 
 def register_intake_workflow_routes(
@@ -37,42 +39,11 @@ def register_intake_workflow_routes(
         raw = str(request.query_params.get("customer_id", "") or "").strip()
         return resolve_body_customer_id({"customer_id": raw}, resolve_customer_id)
 
-    def _workflow_with_knowledge_files(workflow: dict[str, Any]) -> dict[str, Any]:
-        item = dict(workflow)
-        file_vault = get_file_vault() if get_file_vault is not None else None
-        customer_id = str(item.get("customer_id", "") or "").strip()
-        file_ids = [
-            str(file_id or "").strip()
-            for file_id in item.get("knowledge_file_ids", [])
-            if str(file_id or "").strip()
-        ]
-        knowledge_files: list[dict[str, Any]] = []
-        if file_vault is not None and customer_id and file_ids:
-            for record in file_vault.get_many(customer_id, file_ids):
-                clean = sanitize_uploaded_file_record(record, include_excerpt=False)
-                file_id = str(clean.get("id") or "").strip()
-                if not file_id:
-                    continue
-                knowledge_files.append(
-                    {
-                        "id": file_id,
-                        "kind": clean.get("kind"),
-                        "original_filename": clean.get("original_filename"),
-                        "mime_type": clean.get("mime_type"),
-                        "size_bytes": clean.get("size_bytes"),
-                        "caption": clean.get("caption"),
-                        "summary": clean.get("summary"),
-                        "created_at": clean.get("created_at"),
-                        "content_path": (
-                            f"/web/files/{quote(file_id)}/content?customer_id={quote(customer_id, safe='')}"
-                        ),
-                        "metadata_path": (
-                            f"/web/files/{quote(file_id)}/metadata?customer_id={quote(customer_id, safe='')}"
-                        ),
-                    }
-                )
-        item["knowledge_files"] = knowledge_files
-        return item
+    def _file_vault_or_none() -> Any | None:
+        return get_file_vault() if get_file_vault is not None else None
+
+    def _workflow_response(workflow: dict[str, Any]) -> dict[str, Any]:
+        return workflow_with_knowledge_files(workflow, file_vault=_file_vault_or_none())
 
     @app.post("/internal/intake/workflows/upsert")
     async def internal_intake_workflows_upsert(request: Request) -> Any:
@@ -81,24 +52,7 @@ def register_intake_workflow_routes(
         customer_id = resolve_body_customer_id(body, resolve_customer_id)
         try:
             workflow = service.upsert_workflow(
-                customer_id=customer_id,
-                workflow_id=str(body.get("workflow_id", "")).strip() or None,
-                name=str(body.get("name", "")).strip(),
-                channel=str(body.get("channel", "instagram_dm")).strip() or "instagram_dm",
-                provider=str(body.get("provider", "composio")).strip() or "composio",
-                source_config=body.get("source_config") if isinstance(body.get("source_config"), dict) else None,
-                intent_description=str(body.get("intent_description", "")).strip(),
-                required_fields=body.get("required_fields") if isinstance(body.get("required_fields"), list) else [],
-                field_guidance=body.get("field_guidance") if isinstance(body.get("field_guidance"), dict) else None,
-                assistant_instructions=str(body.get("assistant_instructions", "")).strip(),
-                business_facts=body.get("business_facts") if isinstance(body.get("business_facts"), dict) else None,
-                knowledge_file_ids=body.get("knowledge_file_ids") if isinstance(body.get("knowledge_file_ids"), list) else None,
-                sink_type=str(body.get("sink_type", "")).strip(),
-                sink_config=body.get("sink_config") if isinstance(body.get("sink_config"), dict) else None,
-                schedule=str(body.get("schedule", "*/2 * * * *")).strip() or "*/2 * * * *",
-                notify_user=bool(body.get("notify_user", True)),
-                enabled=bool(body.get("enabled", True)),
-                reply_mode=str(body.get("reply_mode", "auto")).strip() or "auto",
+                **workflow_upsert_kwargs(body, customer_id=customer_id)
             )
         except Exception as exc:
             return JSONResponse(status_code=400, content={"detail": str(exc)})
@@ -171,7 +125,7 @@ def register_intake_workflow_routes(
         )
         return {
             "ok": True,
-            "workflows": [_workflow_with_knowledge_files(workflow) for workflow in workflows],
+            "workflows": [_workflow_response(workflow) for workflow in workflows],
         }
 
     @app.get("/web/intake/workflows/{workflow_id}")
@@ -187,7 +141,7 @@ def register_intake_workflow_routes(
         )
         if workflow is None:
             return JSONResponse(status_code=404, content={"detail": "workflow not found"})
-        return {"ok": True, "workflow": _workflow_with_knowledge_files(workflow)}
+        return {"ok": True, "workflow": _workflow_response(workflow)}
 
     @app.put("/web/intake/workflows/{workflow_id}")
     async def web_intake_workflows_put(workflow_id: str, request: Request) -> Any:
@@ -203,28 +157,16 @@ def register_intake_workflow_routes(
         payload["workflow_id"] = str(workflow_id or "").strip()
         try:
             workflow = get_intake_workflows().upsert_workflow(
-                customer_id=customer_id,
-                workflow_id=payload["workflow_id"],
-                name=str(payload.get("name", "")).strip(),
-                channel=str(payload.get("channel", "instagram_dm")).strip() or "instagram_dm",
-                provider=str(payload.get("provider", "composio")).strip() or "composio",
-                source_config=payload.get("source_config") if isinstance(payload.get("source_config"), dict) else None,
-                intent_description=str(payload.get("intent_description", "")).strip(),
-                required_fields=payload.get("required_fields") if isinstance(payload.get("required_fields"), list) else [],
-                field_guidance=payload.get("field_guidance") if isinstance(payload.get("field_guidance"), dict) else None,
-                assistant_instructions=str(payload.get("assistant_instructions", "")).strip(),
-                business_facts=payload.get("business_facts") if isinstance(payload.get("business_facts"), dict) else None,
-                knowledge_file_ids=payload.get("knowledge_file_ids") if isinstance(payload.get("knowledge_file_ids"), list) else None,
-                sink_type=str(payload.get("sink_type", "")).strip(),
-                sink_config=payload.get("sink_config") if isinstance(payload.get("sink_config"), dict) else None,
-                schedule=str(payload.get("schedule") or "*/2 * * * *").strip() or "*/2 * * * *",
-                notify_user=bool(payload.get("notify_user", True)),
-                enabled=bool(payload.get("enabled", True)),
-                reply_mode=str(payload.get("reply_mode", "auto")).strip() or "auto",
+                **workflow_upsert_kwargs(
+                    payload,
+                    customer_id=customer_id,
+                    workflow_id=payload["workflow_id"],
+                    default_schedule_on_falsey=True,
+                )
             )
         except Exception as exc:
             return JSONResponse(status_code=400, content={"detail": str(exc)})
-        return {"ok": True, "workflow": _workflow_with_knowledge_files(workflow)}
+        return {"ok": True, "workflow": _workflow_response(workflow)}
 
     @app.delete("/web/intake/workflows/{workflow_id}")
     async def web_intake_workflows_delete(workflow_id: str, request: Request) -> Any:

--- a/src/opentulpa/api/routes/intake_use_cases.py
+++ b/src/opentulpa/api/routes/intake_use_cases.py
@@ -1,0 +1,95 @@
+"""Use-case helpers for intake workflow HTTP routes."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from opentulpa.api.file_helpers import sanitize_uploaded_file_record
+
+
+def workflow_upsert_kwargs(
+    body: dict[str, Any],
+    *,
+    customer_id: str,
+    workflow_id: str | None = None,
+    default_schedule_on_falsey: bool = False,
+) -> dict[str, Any]:
+    schedule_value = body.get("schedule", "*/2 * * * *")
+    if default_schedule_on_falsey:
+        schedule_value = body.get("schedule") or "*/2 * * * *"
+    return {
+        "customer_id": customer_id,
+        "workflow_id": workflow_id
+        if workflow_id is not None
+        else str(body.get("workflow_id", "")).strip() or None,
+        "name": str(body.get("name", "")).strip(),
+        "channel": str(body.get("channel", "instagram_dm")).strip() or "instagram_dm",
+        "provider": str(body.get("provider", "composio")).strip() or "composio",
+        "source_config": body.get("source_config")
+        if isinstance(body.get("source_config"), dict)
+        else None,
+        "intent_description": str(body.get("intent_description", "")).strip(),
+        "required_fields": body.get("required_fields")
+        if isinstance(body.get("required_fields"), list)
+        else [],
+        "field_guidance": body.get("field_guidance")
+        if isinstance(body.get("field_guidance"), dict)
+        else None,
+        "assistant_instructions": str(body.get("assistant_instructions", "")).strip(),
+        "business_facts": body.get("business_facts")
+        if isinstance(body.get("business_facts"), dict)
+        else None,
+        "knowledge_file_ids": body.get("knowledge_file_ids")
+        if isinstance(body.get("knowledge_file_ids"), list)
+        else None,
+        "sink_type": str(body.get("sink_type", "")).strip(),
+        "sink_config": body.get("sink_config") if isinstance(body.get("sink_config"), dict) else None,
+        "schedule": str(schedule_value).strip() or "*/2 * * * *",
+        "notify_user": bool(body.get("notify_user", True)),
+        "enabled": bool(body.get("enabled", True)),
+        "reply_mode": str(body.get("reply_mode", "auto")).strip() or "auto",
+    }
+
+
+def workflow_with_knowledge_files(
+    workflow: dict[str, Any],
+    *,
+    file_vault: Any | None,
+) -> dict[str, Any]:
+    item = dict(workflow)
+    customer_id = str(item.get("customer_id", "") or "").strip()
+    file_ids = [
+        str(file_id or "").strip()
+        for file_id in item.get("knowledge_file_ids", [])
+        if str(file_id or "").strip()
+    ]
+    knowledge_files: list[dict[str, Any]] = []
+    if file_vault is not None and customer_id and file_ids:
+        for record in file_vault.get_many(customer_id, file_ids):
+            clean = sanitize_uploaded_file_record(record, include_excerpt=False)
+            file_id = str(clean.get("id") or "").strip()
+            if not file_id:
+                continue
+            knowledge_files.append(
+                {
+                    "id": file_id,
+                    "kind": clean.get("kind"),
+                    "original_filename": clean.get("original_filename"),
+                    "mime_type": clean.get("mime_type"),
+                    "size_bytes": clean.get("size_bytes"),
+                    "caption": clean.get("caption"),
+                    "summary": clean.get("summary"),
+                    "created_at": clean.get("created_at"),
+                    "content_path": (
+                        f"/web/files/{quote(file_id)}/content"
+                        f"?customer_id={quote(customer_id, safe='')}"
+                    ),
+                    "metadata_path": (
+                        f"/web/files/{quote(file_id)}/metadata"
+                        f"?customer_id={quote(customer_id, safe='')}"
+                    ),
+                }
+            )
+    item["knowledge_files"] = knowledge_files
+    return item

--- a/src/opentulpa/api/routes/user_context.py
+++ b/src/opentulpa/api/routes/user_context.py
@@ -14,14 +14,12 @@ with uploaded files, the agent prompt policy is responsible for asking the user.
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 
-from opentulpa.api.customer_ids import resolve_body_customer_id
+from opentulpa.api.routes.user_context_use_cases import UserContextRouteUseCases
 
 
 def register_user_context_routes(
@@ -33,275 +31,37 @@ def register_user_context_routes(
     resolve_customer_id: Callable[[str], str] | None = None,
 ) -> None:
     """Register internal user-context endpoints."""
-
-    def _record_user_context_event(event: str, **fields: Any) -> None:
-        runtime = get_agent_runtime()
-        if runtime is None:
-            return
-        recorder = getattr(runtime, "record_observability_event", None)
-        if callable(recorder):
-            recorder(event=event, **fields)
-            return
-        logger = getattr(runtime, "log_behavior_event", None)
-        if callable(logger):
-            logger(event=event, **fields)
-
-    def _warning_count(payload: Any) -> int:
-        if not isinstance(payload, dict):
-            return 0
-        warnings = payload.get("warnings")
-        if isinstance(warnings, list):
-            return len(warnings)
-        indexed = payload.get("indexed")
-        if isinstance(indexed, dict):
-            return sum(
-                len(source.get("warnings") or [])
-                for source in indexed.get("sources", [])
-                if isinstance(source, dict)
-            )
-        return 0
-
-    def _source_count(payload: Any) -> int:
-        if not isinstance(payload, dict):
-            return 0
-        sources = payload.get("sources")
-        if isinstance(sources, list):
-            return len(sources)
-        indexed = payload.get("indexed")
-        if isinstance(indexed, dict):
-            index = indexed.get("index")
-            if isinstance(index, dict):
-                return int(index.get("source_count") or 0)
-        return 0
-
-    async def _prepare_user_context_files(customer_id: str, file_ids: list[Any]) -> dict[str, Any]:
-        runtime = get_agent_runtime()
-        if runtime is None or not hasattr(runtime, "summarize_uploaded_blob"):
-            return {"prepared_count": 0, "failed_count": 0}
-        vault = get_file_vault()
-        prepared_count = 0
-        failed_count = 0
-        for raw_file_id in file_ids[:50]:
-            file_id = str(raw_file_id or "").strip()
-            if not file_id:
-                continue
-            record = vault.get_file(customer_id, file_id)
-            if not isinstance(record, dict) or not record:
-                continue
-            filename = str(record.get("original_filename", "") or "").strip()
-            mime_type = str(record.get("mime_type", "") or "").strip().lower()
-            kind = str(record.get("kind", "") or "").strip().lower()
-            lower_name = filename.lower()
-            needs_model_processing = (
-                kind in {"photo", "video", "video_note", "audio", "voice"}
-                or mime_type.startswith(("image/", "video/", "audio/"))
-                or mime_type == "application/pdf"
-                or lower_name.endswith(".pdf")
-            )
-            if not needs_model_processing:
-                continue
-            raw_bytes = vault.read_file_bytes(customer_id, file_id)
-            if raw_bytes is None:
-                continue
-            try:
-                analysis = await runtime.summarize_uploaded_blob(
-                    filename=filename or None,
-                    mime_type=mime_type or None,
-                    kind=kind or None,
-                    raw_bytes=raw_bytes,
-                    caption=str(record.get("caption", "") or "").strip() or None,
-                    question=(
-                        "Prepare this file for durable user_context retrieval. Extract transcript-like "
-                        "speech, visible text, visual facts, document layout facts, hooks, offers, claims, "
-                        "style cues, and concrete details. Return concise source-grounding notes only."
-                    ),
-                )
-            except Exception as exc:
-                failed_count += 1
-                _record_user_context_event(
-                    "user_context.media_prepare_failed",
-                    customer_id=customer_id,
-                    file_id=file_id,
-                    filename=filename,
-                    mime_type=mime_type,
-                    kind=kind,
-                    error=f"{type(exc).__name__}: {exc}"[:500],
-                )
-                continue
-            if str(analysis or "").strip():
-                vault.set_ai_summary(customer_id, file_id, str(analysis).strip())
-                prepared_count += 1
-                _record_user_context_event(
-                    "user_context.media_prepare_succeeded",
-                    customer_id=customer_id,
-                    file_id=file_id,
-                    filename=filename,
-                    mime_type=mime_type,
-                    kind=kind,
-                    analysis_chars=len(str(analysis or "")),
-                )
-            else:
-                failed_count += 1
-        return {"prepared_count": prepared_count, "failed_count": failed_count}
+    use_cases = UserContextRouteUseCases(
+        get_user_context_service=get_user_context_service,
+        get_file_vault=get_file_vault,
+        get_agent_runtime=get_agent_runtime,
+        resolve_customer_id=resolve_customer_id,
+    )
 
     @app.post("/internal/user_context/add_files")
     async def internal_user_context_add_files(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            started = time.monotonic()
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
-            prep = await _prepare_user_context_files(
-                customer_id=customer_id,
-                file_ids=file_ids,
-            )
-            result = service.add_files(
-                customer_id=customer_id,
-                file_ids=file_ids,
-            )
-            _record_user_context_event(
-                "user_context.add_files",
-                customer_id=customer_id,
-                file_count=len(file_ids),
-                source_count=_source_count(result),
-                warning_count=_warning_count(result),
-                prepared_count=int(prep.get("prepared_count") or 0),
-                failed_count=int(prep.get("failed_count") or 0),
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.add_files(await request.json())
 
     @app.post("/internal/user_context/list_sources")
     async def internal_user_context_list_sources(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            return service.list_sources(
-                customer_id=customer_id,
-                include_archived=bool(body.get("include_archived", False)),
-            )
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.list_sources(await request.json())
 
     @app.post("/internal/user_context/find_sources")
     async def internal_user_context_find_sources(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            return service.find_sources(
-                customer_id=customer_id,
-                query=str(body.get("query", "")).strip(),
-                limit=int(body.get("limit", 10) or 10),
-            )
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.find_sources(await request.json())
 
     @app.post("/internal/user_context/query")
     async def internal_user_context_query(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            started = time.monotonic()
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            result = service.query(
-                customer_id=customer_id,
-                query=str(body.get("query", "")).strip(),
-                max_extract_chars=int(body.get("max_extract_chars", 3000) or 3000),
-            )
-            _record_user_context_event(
-                "user_context.query",
-                customer_id=customer_id,
-                ok=bool(result.get("ok")) if isinstance(result, dict) else False,
-                source_count=int(result.get("source_count") or 0) if isinstance(result, dict) else 0,
-                section_count=int(result.get("section_count") or 0) if isinstance(result, dict) else 0,
-                warning_count=_warning_count(result),
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.query(await request.json())
 
     @app.post("/internal/user_context/reindex")
     async def internal_user_context_reindex(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            started = time.monotonic()
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else None
-            prep = {"prepared_count": 0, "failed_count": 0}
-            if file_ids:
-                prep = await _prepare_user_context_files(
-                    customer_id=customer_id,
-                    file_ids=file_ids,
-                )
-            result = service.reindex(
-                customer_id=customer_id,
-                file_ids=file_ids,
-            )
-            _record_user_context_event(
-                "user_context.reindex",
-                customer_id=customer_id,
-                file_count=len(file_ids or []),
-                source_count=_source_count(result),
-                warning_count=_warning_count(result),
-                prepared_count=int(prep.get("prepared_count") or 0),
-                failed_count=int(prep.get("failed_count") or 0),
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.reindex(await request.json())
 
     @app.post("/internal/user_context/archive_sources")
     async def internal_user_context_archive_sources(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            started = time.monotonic()
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
-            result = service.archive_sources(
-                customer_id=customer_id,
-                file_ids=file_ids,
-            )
-            _record_user_context_event(
-                "user_context.archive_sources",
-                customer_id=customer_id,
-                file_count=len(file_ids),
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.archive_sources(await request.json())
 
     @app.post("/internal/user_context/promote_to_intake")
     async def internal_user_context_promote_to_intake(request: Request) -> Any:
-        service = get_user_context_service()
-        body = await request.json()
-        try:
-            started = time.monotonic()
-            customer_id = resolve_body_customer_id(body, resolve_customer_id)
-            file_ids = body.get("file_ids") if isinstance(body.get("file_ids"), list) else []
-            result = service.promote_to_intake(
-                customer_id=customer_id,
-                workflow_id=str(body.get("workflow_id", "")).strip(),
-                file_ids=file_ids,
-            )
-            _record_user_context_event(
-                "user_context.promote_to_intake",
-                customer_id=customer_id,
-                workflow_id=str(body.get("workflow_id", "")).strip(),
-                file_count=len(file_ids),
-                source_count=_source_count(result),
-                warning_count=_warning_count(result),
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
-        except Exception as exc:
-            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await use_cases.promote_to_intake(await request.json())

--- a/src/opentulpa/api/routes/user_context_use_cases.py
+++ b/src/opentulpa/api/routes/user_context_use_cases.py
@@ -1,0 +1,308 @@
+"""Use-case helpers for internal user-context HTTP routes."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+from opentulpa.api.customer_ids import resolve_body_customer_id
+
+
+@dataclass(frozen=True)
+class UserContextRouteUseCases:
+    get_user_context_service: Callable[[], Any]
+    get_file_vault: Callable[[], Any]
+    get_agent_runtime: Callable[[], Any]
+    resolve_customer_id: Callable[[str], str] | None = None
+
+    def _customer_id(self, body: dict[str, Any]) -> str:
+        return resolve_body_customer_id(body, self.resolve_customer_id)
+
+    def _record_event(self, event: str, **fields: Any) -> None:
+        runtime = self.get_agent_runtime()
+        if runtime is None:
+            return
+        recorder = getattr(runtime, "record_observability_event", None)
+        if callable(recorder):
+            recorder(event=event, **fields)
+            return
+        logger = getattr(runtime, "log_behavior_event", None)
+        if callable(logger):
+            logger(event=event, **fields)
+
+    async def add_files(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            started = time.monotonic()
+            customer_id = self._customer_id(body)
+            file_ids: list[Any] = _list_body_value(body, "file_ids")
+            prep = await self.prepare_files(customer_id=customer_id, file_ids=file_ids)
+            result = service.add_files(customer_id=customer_id, file_ids=file_ids)
+            self._record_event(
+                "user_context.add_files",
+                customer_id=customer_id,
+                file_count=len(file_ids),
+                source_count=source_count(result),
+                warning_count=warning_count(result),
+                prepared_count=int(prep.get("prepared_count") or 0),
+                failed_count=int(prep.get("failed_count") or 0),
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+            return result
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def list_sources(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            return service.list_sources(
+                customer_id=self._customer_id(body),
+                include_archived=bool(body.get("include_archived", False)),
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def find_sources(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            return service.find_sources(
+                customer_id=self._customer_id(body),
+                query=str(body.get("query", "")).strip(),
+                limit=int(body.get("limit", 10) or 10),
+            )
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def query(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            started = time.monotonic()
+            customer_id = self._customer_id(body)
+            result = service.query(
+                customer_id=customer_id,
+                query=str(body.get("query", "")).strip(),
+                max_extract_chars=int(body.get("max_extract_chars", 3000) or 3000),
+            )
+            self._record_event(
+                "user_context.query",
+                customer_id=customer_id,
+                ok=bool(result.get("ok")) if isinstance(result, dict) else False,
+                source_count=int(result.get("source_count") or 0) if isinstance(result, dict) else 0,
+                section_count=int(result.get("section_count") or 0)
+                if isinstance(result, dict)
+                else 0,
+                warning_count=warning_count(result),
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+            return result
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def reindex(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            started = time.monotonic()
+            customer_id = self._customer_id(body)
+            raw_file_ids = body.get("file_ids")
+            file_ids = raw_file_ids if isinstance(raw_file_ids, list) else None
+            prep = {"prepared_count": 0, "failed_count": 0}
+            if file_ids:
+                prep = await self.prepare_files(customer_id=customer_id, file_ids=file_ids)
+            result = service.reindex(customer_id=customer_id, file_ids=file_ids)
+            self._record_event(
+                "user_context.reindex",
+                customer_id=customer_id,
+                file_count=len(file_ids or []),
+                source_count=source_count(result),
+                warning_count=warning_count(result),
+                prepared_count=int(prep.get("prepared_count") or 0),
+                failed_count=int(prep.get("failed_count") or 0),
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+            return result
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def archive_sources(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            started = time.monotonic()
+            customer_id = self._customer_id(body)
+            file_ids = _list_body_value(body, "file_ids")
+            result = service.archive_sources(customer_id=customer_id, file_ids=file_ids)
+            self._record_event(
+                "user_context.archive_sources",
+                customer_id=customer_id,
+                file_count=len(file_ids),
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+            return result
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def promote_to_intake(self, body: dict[str, Any]) -> Any:
+        service = self.get_user_context_service()
+        try:
+            started = time.monotonic()
+            customer_id = self._customer_id(body)
+            file_ids = _list_body_value(body, "file_ids")
+            workflow_id = str(body.get("workflow_id", "")).strip()
+            result = service.promote_to_intake(
+                customer_id=customer_id,
+                workflow_id=workflow_id,
+                file_ids=file_ids,
+            )
+            self._record_event(
+                "user_context.promote_to_intake",
+                customer_id=customer_id,
+                workflow_id=workflow_id,
+                file_count=len(file_ids),
+                source_count=source_count(result),
+                warning_count=warning_count(result),
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+            )
+            return result
+        except Exception as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    async def prepare_files(self, *, customer_id: str, file_ids: list[Any]) -> dict[str, Any]:
+        runtime = self.get_agent_runtime()
+        if runtime is None or not hasattr(runtime, "summarize_uploaded_blob"):
+            return {"prepared_count": 0, "failed_count": 0}
+        vault = self.get_file_vault()
+        prepared_count = 0
+        failed_count = 0
+        for raw_file_id in file_ids[:50]:
+            file_id = str(raw_file_id or "").strip()
+            if not file_id:
+                continue
+            record = vault.get_file(customer_id, file_id)
+            if not isinstance(record, dict) or not record:
+                continue
+            if not needs_model_processing(record):
+                continue
+            raw_bytes = vault.read_file_bytes(customer_id, file_id)
+            if raw_bytes is None:
+                continue
+            try:
+                analysis = await runtime.summarize_uploaded_blob(
+                    filename=str(record.get("original_filename", "") or "").strip() or None,
+                    mime_type=str(record.get("mime_type", "") or "").strip().lower() or None,
+                    kind=str(record.get("kind", "") or "").strip().lower() or None,
+                    raw_bytes=raw_bytes,
+                    caption=str(record.get("caption", "") or "").strip() or None,
+                    question=(
+                        "Prepare this file for durable user_context retrieval. Extract transcript-like "
+                        "speech, visible text, visual facts, document layout facts, hooks, offers, claims, "
+                        "style cues, and concrete details. Return concise source-grounding notes only."
+                    ),
+                )
+            except Exception as exc:
+                failed_count += 1
+                self._record_prepare_failure(
+                    customer_id=customer_id,
+                    file_id=file_id,
+                    record=record,
+                    error=f"{type(exc).__name__}: {exc}"[:500],
+                )
+                continue
+            if str(analysis or "").strip():
+                vault.set_ai_summary(customer_id, file_id, str(analysis).strip())
+                prepared_count += 1
+                self._record_prepare_success(
+                    customer_id=customer_id,
+                    file_id=file_id,
+                    record=record,
+                    analysis=str(analysis or ""),
+                )
+            else:
+                failed_count += 1
+        return {"prepared_count": prepared_count, "failed_count": failed_count}
+
+    def _record_prepare_failure(
+        self,
+        *,
+        customer_id: str,
+        file_id: str,
+        record: dict[str, Any],
+        error: str,
+    ) -> None:
+        self._record_event(
+            "user_context.media_prepare_failed",
+            customer_id=customer_id,
+            file_id=file_id,
+            filename=str(record.get("original_filename", "") or "").strip(),
+            mime_type=str(record.get("mime_type", "") or "").strip().lower(),
+            kind=str(record.get("kind", "") or "").strip().lower(),
+            error=error,
+        )
+
+    def _record_prepare_success(
+        self,
+        *,
+        customer_id: str,
+        file_id: str,
+        record: dict[str, Any],
+        analysis: str,
+    ) -> None:
+        self._record_event(
+            "user_context.media_prepare_succeeded",
+            customer_id=customer_id,
+            file_id=file_id,
+            filename=str(record.get("original_filename", "") or "").strip(),
+            mime_type=str(record.get("mime_type", "") or "").strip().lower(),
+            kind=str(record.get("kind", "") or "").strip().lower(),
+            analysis_chars=len(analysis),
+        )
+
+
+def warning_count(payload: Any) -> int:
+    if not isinstance(payload, dict):
+        return 0
+    warnings = payload.get("warnings")
+    if isinstance(warnings, list):
+        return len(warnings)
+    indexed = payload.get("indexed")
+    if isinstance(indexed, dict):
+        return sum(
+            len(source.get("warnings") or [])
+            for source in indexed.get("sources", [])
+            if isinstance(source, dict)
+        )
+    return 0
+
+
+def source_count(payload: Any) -> int:
+    if not isinstance(payload, dict):
+        return 0
+    sources = payload.get("sources")
+    if isinstance(sources, list):
+        return len(sources)
+    indexed = payload.get("indexed")
+    if isinstance(indexed, dict):
+        index = indexed.get("index")
+        if isinstance(index, dict):
+            return int(index.get("source_count") or 0)
+    return 0
+
+
+def needs_model_processing(record: dict[str, Any]) -> bool:
+    filename = str(record.get("original_filename", "") or "").strip()
+    mime_type = str(record.get("mime_type", "") or "").strip().lower()
+    kind = str(record.get("kind", "") or "").strip().lower()
+    lower_name = filename.lower()
+    return (
+        kind in {"photo", "video", "video_note", "audio", "voice"}
+        or mime_type.startswith(("image/", "video/", "audio/"))
+        or mime_type == "application/pdf"
+        or lower_name.endswith(".pdf")
+    )
+
+
+def _list_body_value(body: dict[str, Any], key: str) -> list[Any]:
+    value = body.get(key)
+    return value if isinstance(value, list) else []

--- a/src/opentulpa/api/tulpa_loader.py
+++ b/src/opentulpa/api/tulpa_loader.py
@@ -113,16 +113,14 @@ class TulpaRouterLoader:
                 continue
             try:
                 module = self._import_module(module_name)
-                router = getattr(module, "router", None)
-                has_internal = isinstance(router, APIRouter)
-                if not has_internal:
+                router_obj = getattr(module, "router", None)
+                if not isinstance(router_obj, APIRouter):
                     raise TypeError("missing APIRouter 'router' export")
-                if has_internal:
-                    self.mount_router.include_router(
-                        router,
-                        prefix=f"/{module_name}",
-                        tags=["tulpa"],
-                    )
+                self.mount_router.include_router(
+                    router_obj,
+                    prefix=f"/{module_name}",
+                    tags=["tulpa"],
+                )
                 loaded.append(module_name)
             except ModuleNotFoundError as exc:  # pragma: no cover - runtime guard
                 missing = str(getattr(exc, "name", "")).strip() or str(exc)
@@ -171,9 +169,7 @@ def _is_safe_module_level_statement(stmt: ast.stmt) -> bool:
         return _is_router_assignment(stmt) or _is_safe_constant_assignment(stmt)
     if isinstance(stmt, ast.AnnAssign):
         return _is_safe_literal(stmt.value)
-    if isinstance(stmt, ast.If) and _is_main_guard(stmt.test):
-        return True
-    return False
+    return isinstance(stmt, ast.If) and _is_main_guard(stmt.test)
 
 
 def _is_safe_constant_assignment(stmt: ast.Assign) -> bool:

--- a/src/opentulpa/application/wake_orchestrator.py
+++ b/src/opentulpa/application/wake_orchestrator.py
@@ -136,67 +136,48 @@ class WakeOrchestrator:
             return
         await self._handle_routine_event(body)
 
-    async def _handle_task_event(self, body: dict[str, Any]) -> None:
-        customer_id = self._customer_id(body.get("customer_id", ""))
-        event_type = str(body.get("event_type", "")).strip()
-        payload = self._payload(body.get("payload"))
-        if not customer_id or event_type not in {"done", "failed", "needs_input", "worker_stopped"}:
-            return
+    def _backlog_task_event(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        self._backlog(
+            customer_id=customer_id,
+            source="task",
+            event_type=event_type,
+            payload=payload,
+        )
 
-        runtime = self._get_agent_runtime()
-        should_notify = event_type == "needs_input"
-        if not should_notify and runtime and hasattr(runtime, "classify_wake_event"):
-            decision = await runtime.classify_wake_event(
-                customer_id=customer_id,
-                event_label=f"task/{event_type}",
-                payload={
-                    "task_id": str(body.get("task_id", "")),
-                    "payload": payload,
-                },
-            )
-            should_notify = bool(decision.get("notify_user", False))
+    async def _task_event_should_notify(
+        self,
+        *,
+        runtime: Any,
+        customer_id: str,
+        task_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> bool:
+        if event_type == "needs_input":
+            return True
+        if not runtime or not hasattr(runtime, "classify_wake_event"):
+            return False
+        decision = await runtime.classify_wake_event(
+            customer_id=customer_id,
+            event_label=f"task/{event_type}",
+            payload={"task_id": task_id, "payload": payload},
+        )
+        return bool(decision.get("notify_user", False))
 
-        backlog_payload = {"task_id": str(body.get("task_id", "")), **payload}
-        if not should_notify:
-            self._backlog(
-                customer_id=customer_id,
-                source="task",
-                event_type=event_type,
-                payload=backlog_payload,
-            )
-            return
-        if not self._settings.telegram_bot_token:
-            self._backlog(
-                customer_id=customer_id,
-                source="task",
-                event_type=event_type,
-                payload=backlog_payload,
-            )
-            return
-        try:
-            replies = await self._get_telegram_chat().relay_task_event(
-                customer_id=customer_id,
-                task_id=str(body.get("task_id", "")),
-                event_type=event_type,
-                payload=payload,
-                agent_runtime=runtime,
-            )
-        except Exception:
-            self._backlog(
-                customer_id=customer_id,
-                source="task",
-                event_type=event_type,
-                payload=backlog_payload,
-            )
-            return
-        if not replies:
-            self._backlog(
-                customer_id=customer_id,
-                source="task",
-                event_type=event_type,
-                payload=backlog_payload,
-            )
-            return
+    async def _send_task_event_replies(
+        self,
+        *,
+        customer_id: str,
+        task_id: str,
+        event_type: str,
+        replies: list[dict[str, Any]],
+    ) -> None:
         for item in replies:
             sent = await self._get_telegram_client().send_message(
                 chat_id=item["chat_id"],
@@ -206,139 +187,209 @@ class WakeOrchestrator:
             if sent:
                 append_web_event(
                     customer_id=customer_id,
-                    thread_id=str(body.get("task_id", "") or "").strip(),
+                    thread_id=task_id,
                     source="task",
                     kind="proactive_message",
                     text=str(item.get("text", "") or ""),
                     metadata_json=json.dumps({"event_type": event_type}, ensure_ascii=False),
                 )
 
-    async def _handle_routine_event(self, body: dict[str, Any]) -> None:
+    async def _handle_task_event(self, body: dict[str, Any]) -> None:
+        customer_id = self._customer_id(body.get("customer_id", ""))
+        event_type = str(body.get("event_type", "")).strip()
         payload = self._payload(body.get("payload"))
-        customer_id = self._customer_id(body.get("customer_id") or payload.get("customer_id") or "")
-        if not customer_id:
+        if not customer_id or event_type not in {"done", "failed", "needs_input", "worker_stopped"}:
             return
-        event_type = str(body.get("event_type") or payload.get("event_type") or "scheduled").strip()
-        notify_raw = body.get("notify_user", payload.get("notify_user", True))
-        notify_user = not (
-            notify_raw is False or str(notify_raw).strip().lower() in {"0", "false", "no", "off"}
-        )
-        routine_id = str(body.get("routine_id") or payload.get("routine_id") or "").strip()
-        routine_name = str(body.get("routine_name") or payload.get("routine_name") or "").strip()
-        queue_payload = {
-            "routine_id": routine_id,
-            "routine_name": routine_name,
-            "event_type": event_type,
-            "notify_user": bool(notify_user),
-            "payload": payload,
-        }
 
         runtime = self._get_agent_runtime()
-        if runtime is None:
-            self._backlog(
+        task_id = str(body.get("task_id", ""))
+        backlog_payload = {"task_id": str(body.get("task_id", "")), **payload}
+        if not await self._task_event_should_notify(
+            runtime=runtime,
+            customer_id=customer_id,
+            task_id=task_id,
+            event_type=event_type,
+            payload=payload,
+        ):
+            self._backlog_task_event(
                 customer_id=customer_id,
-                source="routine",
                 event_type=event_type,
-                payload=queue_payload,
+                payload=backlog_payload,
             )
             return
+        if not self._settings.telegram_bot_token:
+            self._backlog_task_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=backlog_payload,
+            )
+            return
+        try:
+            replies = await self._get_telegram_chat().relay_task_event(
+                customer_id=customer_id,
+                task_id=task_id,
+                event_type=event_type,
+                payload=payload,
+                agent_runtime=runtime,
+            )
+        except Exception:
+            self._backlog_task_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=backlog_payload,
+            )
+            return
+        if not replies:
+            self._backlog_task_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=backlog_payload,
+            )
+            return
+        await self._send_task_event_replies(
+            customer_id=customer_id,
+            task_id=task_id,
+            event_type=event_type,
+            replies=replies,
+        )
 
-        if str(payload.get("workflow_type", "")).strip() == "intake_workflow":
-            workflow_id = str(payload.get("workflow_id", "")).strip()
-            if not workflow_id or self._get_intake_workflows is None:
-                queue_payload["execution_status"] = "invalid"
-                queue_payload["execution_error"] = "intake workflow payload missing workflow_id"
-                self._backlog(
-                    customer_id=customer_id,
-                    source="routine",
-                    event_type=event_type,
-                    payload=queue_payload,
-                )
-                return
-            try:
-                result = await self._get_intake_workflows().run_workflow(
-                    customer_id=customer_id,
-                    workflow_id=workflow_id,
-                    event_type=event_type,
-                )
-            except Exception as exc:
-                queue_payload["execution_status"] = "failed"
-                queue_payload["execution_error"] = str(exc)[:500]
-                self._backlog(
-                    customer_id=customer_id,
-                    source="routine",
-                    event_type=event_type,
-                    payload=queue_payload,
-                )
-                return
-            execution_summary = str(result.get("summary", "") or "").strip() or NO_NOTIFY_TOKEN
-            queue_payload["execution_status"] = "executed" if bool(result.get("ok", False)) else "failed"
-            queue_payload["execution_summary"] = execution_summary[:2000]
-            queue_payload["execution_result"] = result
-            if queue_payload["execution_status"] != "executed":
-                queue_payload["execution_error"] = (
-                    " | ".join(str(item) for item in _safe_error_list(result.get("errors")))[:500]
-                    or "workflow execution failed"
-                )
-            if not notify_user or not self._settings.telegram_bot_token or execution_summary == NO_NOTIFY_TOKEN:
-                self._record_routine_execution(
-                    customer_id=customer_id,
-                    event_type=event_type,
-                    payload=queue_payload,
-                    notification_status="skipped",
-                    notification_error=(
-                        "notify_user=false"
-                        if not notify_user
-                        else "telegram_bot_token_missing"
-                        if not self._settings.telegram_bot_token
-                        else "no_notify_token"
-                    ),
-                )
-                return
-            delivery_slots: list[dict[str, Any]] = []
-            with suppress(Exception):
-                delivery_slots = self._get_telegram_chat().find_session_slots(customer_id)
-            delivery_slots = self._direct_owner_slots(delivery_slots)
-            if not delivery_slots:
-                self._record_routine_execution(
-                    customer_id=customer_id,
-                    event_type=event_type,
-                    payload=queue_payload,
-                    notification_status="backlogged",
-                    notification_error="no_telegram_session_slots",
-                )
-                return
-            notified_owner_chat_ids: list[int] = []
-            for slot in delivery_slots:
-                chat_id = int(slot["chat_id"])
-                await self._get_telegram_client().send_message(
-                    chat_id=chat_id,
-                    text=execution_summary,
-                    parse_mode="HTML",
-                )
-                with suppress(Exception):
-                    self._get_telegram_chat().touch_assistant_message(chat_id)
-                notified_owner_chat_ids.append(chat_id)
+    def _backlog_routine_event(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        self._backlog(
+            customer_id=customer_id,
+            source="routine",
+            event_type=event_type,
+            payload=payload,
+        )
+
+    def _record_invalid_routine_event(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        error: str,
+    ) -> None:
+        payload["execution_status"] = "invalid"
+        payload["execution_error"] = error
+        self._backlog_routine_event(
+            customer_id=customer_id,
+            event_type=event_type,
+            payload=payload,
+        )
+
+    async def _record_routine_notification_result(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        notify_user: bool,
+        execution_summary: str,
+    ) -> None:
+        if not notify_user or not self._settings.telegram_bot_token or execution_summary == NO_NOTIFY_TOKEN:
             self._record_routine_execution(
                 customer_id=customer_id,
                 event_type=event_type,
-                payload=queue_payload,
-                notification_status="sent",
-                notified_chat_ids=notified_owner_chat_ids,
+                payload=payload,
+                notification_status="skipped",
+                notification_error=(
+                    "notify_user=false"
+                    if not notify_user
+                    else "telegram_bot_token_missing"
+                    if not self._settings.telegram_bot_token
+                    else "no_notify_token"
+                ),
             )
             return
-
-        routine_instruction = str(payload.get("instruction", "")).strip()
-        if not routine_instruction:
-            queue_payload["execution_status"] = "invalid"
-            queue_payload["execution_error"] = "routine payload missing required instruction"
-            self._backlog(
+        notified_chat_ids = await self._notify_routine_owner_slots(
+            customer_id=customer_id,
+            text=execution_summary,
+        )
+        if not notified_chat_ids:
+            self._record_routine_execution(
                 customer_id=customer_id,
-                source="routine",
+                event_type=event_type,
+                payload=payload,
+                notification_status="backlogged",
+                notification_error="no_telegram_session_slots",
+            )
+            return
+        self._record_routine_execution(
+            customer_id=customer_id,
+            event_type=event_type,
+            payload=payload,
+            notification_status="sent",
+            notified_chat_ids=notified_chat_ids,
+        )
+
+    async def _handle_intake_workflow_routine_event(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        workflow_id: str,
+        notify_user: bool,
+        queue_payload: dict[str, Any],
+    ) -> None:
+        if not workflow_id or self._get_intake_workflows is None:
+            self._record_invalid_routine_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=queue_payload,
+                error="intake workflow payload missing workflow_id",
+            )
+            return
+        try:
+            result = await self._get_intake_workflows().run_workflow(
+                customer_id=customer_id,
+                workflow_id=workflow_id,
+                event_type=event_type,
+            )
+        except Exception as exc:
+            queue_payload["execution_status"] = "failed"
+            queue_payload["execution_error"] = str(exc)[:500]
+            self._backlog_routine_event(
+                customer_id=customer_id,
                 event_type=event_type,
                 payload=queue_payload,
             )
             return
+        execution_summary = str(result.get("summary", "") or "").strip() or NO_NOTIFY_TOKEN
+        queue_payload["execution_status"] = "executed" if bool(result.get("ok", False)) else "failed"
+        queue_payload["execution_summary"] = execution_summary[:2000]
+        queue_payload["execution_result"] = result
+        if queue_payload["execution_status"] != "executed":
+            queue_payload["execution_error"] = (
+                " | ".join(str(item) for item in _safe_error_list(result.get("errors")))[:500]
+                or "workflow execution failed"
+            )
+        await self._record_routine_notification_result(
+            customer_id=customer_id,
+            event_type=event_type,
+            payload=queue_payload,
+            notify_user=notify_user,
+            execution_summary=execution_summary,
+        )
+
+    async def _handle_agent_routine_event(
+        self,
+        *,
+        customer_id: str,
+        event_type: str,
+        routine_id: str,
+        routine_name: str,
+        routine_instruction: str,
+        notify_user: bool,
+        payload: dict[str, Any],
+        queue_payload: dict[str, Any],
+        runtime: Any,
+    ) -> None:
         execution_prompt = (
             "System update: a scheduled routine fired.\n"
             "Execute this routine now using tools/skills as needed.\n"
@@ -367,73 +418,104 @@ class WakeOrchestrator:
         except Exception as exc:
             queue_payload["execution_status"] = "failed"
             queue_payload["execution_error"] = str(exc)[:500]
-            self._backlog(
+            self._backlog_routine_event(
                 customer_id=customer_id,
-                source="routine",
                 event_type=event_type,
                 payload=queue_payload,
             )
             return
-
         execution_summary = str(execution_text or "").strip()
         if not execution_summary:
             execution_summary = "Routine executed, but no summary was produced."
         queue_payload["execution_status"] = "executed"
         queue_payload["execution_summary"] = execution_summary[:2000]
-
-        if not notify_user:
-            self._record_routine_execution(
-                customer_id=customer_id,
-                event_type=event_type,
-                payload=queue_payload,
-                notification_status="skipped",
-                notification_error="notify_user=false",
-            )
-            return
-        if not self._settings.telegram_bot_token or execution_summary == NO_NOTIFY_TOKEN:
-            self._record_routine_execution(
-                customer_id=customer_id,
-                event_type=event_type,
-                payload=queue_payload,
-                notification_status="skipped",
-                notification_error=(
-                    "telegram_bot_token_missing" if not self._settings.telegram_bot_token else "no_notify_token"
-                ),
-            )
-            return
-
-        routine_slots: list[dict[str, Any]] = []
-        with suppress(Exception):
-            routine_slots = self._get_telegram_chat().find_session_slots(customer_id)
-        routine_slots = self._direct_owner_slots(routine_slots)
-        if not routine_slots:
-            self._record_routine_execution(
-                customer_id=customer_id,
-                event_type=event_type,
-                payload=queue_payload,
-                notification_status="backlogged",
-                notification_error="no_telegram_session_slots",
-            )
-            return
-
-        notified_routine_chat_ids: list[int] = []
-        for slot in routine_slots:
-            chat_id = int(slot["chat_id"])
-            await self._get_telegram_client().send_message(
-                chat_id=chat_id,
-                text=execution_summary,
-                parse_mode="HTML",
-            )
-            with suppress(Exception):
-                self._get_telegram_chat().touch_assistant_message(chat_id)
-            notified_routine_chat_ids.append(chat_id)
-        self._record_routine_execution(
+        await self._record_routine_notification_result(
             customer_id=customer_id,
             event_type=event_type,
             payload=queue_payload,
-            notification_status="sent",
-            notified_chat_ids=notified_routine_chat_ids,
+            notify_user=notify_user,
+            execution_summary=execution_summary,
         )
+
+    async def _handle_routine_event(self, body: dict[str, Any]) -> None:
+        payload = self._payload(body.get("payload"))
+        customer_id = self._customer_id(body.get("customer_id") or payload.get("customer_id") or "")
+        if not customer_id:
+            return
+        event_type = str(body.get("event_type") or payload.get("event_type") or "scheduled").strip()
+        notify_raw = body.get("notify_user", payload.get("notify_user", True))
+        notify_user = not (
+            notify_raw is False or str(notify_raw).strip().lower() in {"0", "false", "no", "off"}
+        )
+        routine_id = str(body.get("routine_id") or payload.get("routine_id") or "").strip()
+        routine_name = str(body.get("routine_name") or payload.get("routine_name") or "").strip()
+        queue_payload = {
+            "routine_id": routine_id,
+            "routine_name": routine_name,
+            "event_type": event_type,
+            "notify_user": bool(notify_user),
+            "payload": payload,
+        }
+
+        runtime = self._get_agent_runtime()
+        if runtime is None:
+            self._backlog_routine_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=queue_payload,
+            )
+            return
+
+        if str(payload.get("workflow_type", "")).strip() == "intake_workflow":
+            workflow_id = str(payload.get("workflow_id", "")).strip()
+            await self._handle_intake_workflow_routine_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                workflow_id=workflow_id,
+                notify_user=notify_user,
+                queue_payload=queue_payload,
+            )
+            return
+
+        routine_instruction = str(payload.get("instruction", "")).strip()
+        if not routine_instruction:
+            self._record_invalid_routine_event(
+                customer_id=customer_id,
+                event_type=event_type,
+                payload=queue_payload,
+                error="routine payload missing required instruction",
+            )
+            return
+        await self._handle_agent_routine_event(
+            customer_id=customer_id,
+            event_type=event_type,
+            routine_id=routine_id,
+            routine_name=routine_name,
+            routine_instruction=routine_instruction,
+            notify_user=notify_user,
+            payload=payload,
+            queue_payload=queue_payload,
+            runtime=runtime,
+        )
+
+    async def _notify_routine_owner_slots(self, *, customer_id: str, text: str) -> list[int]:
+        routine_slots: list[dict[str, Any]] = []
+        with suppress(Exception):
+            routine_slots = self._get_telegram_chat().find_session_slots(customer_id)
+        notified_chat_ids: list[int] = []
+        for slot in self._direct_owner_slots(routine_slots):
+            chat_id = int(slot["chat_id"])
+            sent = await self._get_telegram_client().send_message(
+                chat_id=chat_id,
+                text=text,
+                parse_mode="HTML",
+            )
+            if not sent:
+                continue
+            with suppress(Exception):
+                self._get_telegram_chat().touch_assistant_message(chat_id)
+            notified_chat_ids.append(chat_id)
+        return notified_chat_ids
 
 
 def _safe_error_list(value: Any) -> list[str]:

--- a/src/opentulpa/business_knowledge/indexer.py
+++ b/src/opentulpa/business_knowledge/indexer.py
@@ -1,0 +1,102 @@
+"""Business knowledge source indexing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from opentulpa.business_knowledge.extraction import content_hash, extract_source_sections
+from opentulpa.business_knowledge.models import KnowledgeIndexedSource
+from opentulpa.business_knowledge.repository import BusinessKnowledgeRepository
+
+
+class BusinessKnowledgeIndexer:
+    def __init__(
+        self,
+        *,
+        file_vault: Any,
+        repository: BusinessKnowledgeRepository,
+        now_iso: Callable[[], str],
+    ) -> None:
+        self.file_vault = file_vault
+        self.repository = repository
+        self.now_iso = now_iso
+
+    def index_one_source(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        file_id: str,
+    ) -> KnowledgeIndexedSource:
+        record = self.file_vault.get_file(customer_id, file_id)
+        raw_bytes = self.file_vault.read_file_bytes(customer_id, file_id)
+        if not record or raw_bytes is None:
+            raise ValueError(f"file not found: {file_id}")
+
+        filename = str(record.get("original_filename", "") or "file.bin").strip() or "file.bin"
+        mime_type = str(record.get("mime_type", "") or "").strip()
+        source_hash = content_hash(
+            raw_bytes
+            + b"\0"
+            + str(record.get("summary", "") or "").encode("utf-8", errors="replace")
+            + b"\0"
+            + str(record.get("text_excerpt", "") or "").encode("utf-8", errors="replace")
+        )
+        existing = self.repository.get_source_row(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            file_id=file_id,
+        )
+        if existing is not None and str(existing["source_hash"]) == source_hash:
+            return KnowledgeIndexedSource(
+                file_id=file_id,
+                filename=str(existing["filename"]),
+                mime_type=str(existing["mime_type"]),
+                status=str(existing["status"]),
+                source_kind=str(existing["source_kind"]),
+                section_count=int(existing["section_count"] or 0),
+                char_count=int(existing["char_count"] or 0),
+                warnings=_safe_list_json(existing["warnings_json"]),
+            )
+
+        sections, warnings, source_kind = extract_source_sections(record=record, raw_bytes=raw_bytes)
+        status = "indexed" if sections else "unsupported"
+        char_count = sum(len(section.content) for section in sections)
+        self.repository.replace_source(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            file_id=file_id,
+            source_hash=source_hash,
+            filename=filename,
+            mime_type=mime_type,
+            status=status,
+            source_kind=source_kind,
+            warnings=warnings,
+            sections=sections,
+            indexed_at=self.now_iso(),
+        )
+        return KnowledgeIndexedSource(
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            status=status,
+            source_kind=source_kind,
+            section_count=len(sections),
+            char_count=char_count,
+            warnings=warnings,
+        )
+
+
+def _safe_list_json(value: Any) -> list[str]:
+    try:
+        parsed = json.loads(str(value or "[]"))
+    except Exception:
+        return []
+    if isinstance(parsed, list):
+        return [str(item).strip() for item in parsed if str(item).strip()]
+    return []

--- a/src/opentulpa/business_knowledge/oracle_client.py
+++ b/src/opentulpa/business_knowledge/oracle_client.py
@@ -1,0 +1,430 @@
+"""OpenAI-compatible oracle client for business knowledge queries."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from opentulpa.business_knowledge.extraction import content_hash
+
+DEFAULT_ORACLE_MODEL = "google/gemini-3.1-flash-lite-preview"
+DEFAULT_ORACLE_MAX_OUTPUT_TOKENS = 1000
+DEFAULT_OPENROUTER_APP_REFERER = "https://github.com/kvyb/opentulpa"
+DEFAULT_OPENROUTER_APP_TITLE = "OpenTulpa"
+
+
+class OpenAICompatibleKnowledgeOracleClient:
+    """Small OpenAI-compatible chat client for the business knowledge oracle."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: str = DEFAULT_ORACLE_MODEL,
+        timeout_seconds: float = 45.0,
+        trace_path: Path | None = None,
+        langfuse_tracer: Any | None = None,
+    ) -> None:
+        self.api_key = str(api_key or "").strip()
+        self.base_url = str(base_url or "").strip().rstrip("/")
+        self.model = str(model or "").strip() or DEFAULT_ORACLE_MODEL
+        self.timeout_seconds = float(timeout_seconds)
+        if not self.api_key:
+            raise ValueError("api_key is required")
+        if not self.base_url:
+            raise ValueError("base_url is required")
+        self.trace_path = trace_path.resolve() if isinstance(trace_path, Path) else None
+        self.langfuse_tracer = langfuse_tracer
+        self._trace_lock = threading.Lock()
+
+    def answer(
+        self,
+        *,
+        source_pack: str,
+        query: str,
+        workflow_context: dict[str, Any] | None = None,
+        max_output_tokens: int = DEFAULT_ORACLE_MAX_OUTPUT_TOKENS,
+    ) -> str:
+        started = time.monotonic()
+        request_body = {
+            "model": self.model,
+            "temperature": 0,
+            "max_tokens": max(1, int(max_output_tokens)),
+            "messages": [
+                {"role": "system", "content": oracle_system_prompt()},
+                {
+                    "role": "user",
+                    "content": oracle_user_prompt(
+                        source_pack=source_pack,
+                        query=query,
+                        workflow_context=workflow_context,
+                    ),
+                },
+            ],
+        }
+        request_body.update(oracle_reasoning_control(self.base_url))
+        response_payload: dict[str, Any] | None = None
+        answer_text = ""
+        error_text: str | None = None
+        try:
+            response = httpx.post(
+                f"{self.base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    **openrouter_app_headers(self.base_url),
+                },
+                json=request_body,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+            raw_payload = response.json()
+            response_payload = raw_payload if isinstance(raw_payload, dict) else {}
+            answer_text = extract_chat_text(response_payload)
+            return answer_text
+        except Exception as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            self._record_oracle_trace(
+                source_pack=source_pack,
+                query=query,
+                workflow_context=workflow_context,
+                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
+                response_payload=response_payload,
+                response_text=answer_text,
+                error=error_text,
+                elapsed_ms=_elapsed_ms(started),
+            )
+
+    def extract_intent(self, *, query: str) -> dict[str, Any]:
+        started = time.monotonic()
+        request_body = {
+            "model": self.model,
+            "temperature": 0,
+            "max_tokens": 180,
+            "messages": [
+                {"role": "system", "content": oracle_intent_system_prompt()},
+                {"role": "user", "content": str(query or "").strip()},
+            ],
+        }
+        request_body.update(oracle_reasoning_control(self.base_url))
+        response_payload: dict[str, Any] | None = None
+        response_text = ""
+        error_text: str | None = None
+        try:
+            response = httpx.post(
+                f"{self.base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    **openrouter_app_headers(self.base_url),
+                },
+                json=request_body,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+            raw_payload = response.json()
+            response_payload = raw_payload if isinstance(raw_payload, dict) else {}
+            response_text = extract_chat_text(response_payload)
+            return clean_query_intent(parse_json_object(response_text), str(query or ""))
+        except Exception as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            self._record_oracle_trace(
+                source_pack="",
+                query=query,
+                workflow_context={},
+                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
+                response_payload=response_payload,
+                response_text=response_text,
+                error=error_text,
+                elapsed_ms=_elapsed_ms(started),
+                call_site="knowledge_oracle_intent",
+            )
+
+    def _record_oracle_trace(
+        self,
+        *,
+        source_pack: str,
+        query: str,
+        workflow_context: dict[str, Any] | None,
+        max_output_tokens: int,
+        response_payload: dict[str, Any] | None,
+        response_text: str,
+        error: str | None,
+        elapsed_ms: int,
+        call_site: str = "knowledge_oracle",
+    ) -> None:
+        source_text = str(source_pack or "")
+        payload = _oracle_trace_payload(
+            model=self.model,
+            source_text=source_text,
+            query=query,
+            workflow_context=workflow_context,
+            max_output_tokens=max_output_tokens,
+            response_payload=response_payload,
+            response_text=response_text,
+            error=error,
+            elapsed_ms=elapsed_ms,
+            call_site=call_site,
+        )
+        tracer = getattr(self, "langfuse_tracer", None)
+        record_generation = getattr(tracer, "record_generation", None)
+        if callable(record_generation):
+            with suppress(Exception):
+                record_generation(payload)
+        path = self.trace_path
+        if path is None:
+            return
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+
+        def _commit() -> None:
+            existing: list[str] = []
+            with suppress(Exception):
+                existing = [
+                    line.rstrip("\n")
+                    for line in path.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                ]
+            kept = existing[-499:]
+            kept.append(serialized)
+            with path.open("w", encoding="utf-8") as f:
+                f.write("\n".join(kept) + "\n")
+
+        with suppress(Exception):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        with suppress(Exception), self._trace_lock:
+            _commit()
+
+
+def _oracle_trace_payload(
+    *,
+    model: str,
+    source_text: str,
+    query: str,
+    workflow_context: dict[str, Any] | None,
+    max_output_tokens: int,
+    response_payload: dict[str, Any] | None,
+    response_text: str,
+    error: str | None,
+    elapsed_ms: int,
+    call_site: str,
+) -> dict[str, Any]:
+    source_hash = content_hash(source_text.encode("utf-8", errors="replace"))
+    clean_response = str(response_text or "").strip()
+    return {
+        "ts": datetime.now(UTC).isoformat(),
+        "model_name": model,
+        "stable_prefix_count": 0,
+        "prompt_messages": _oracle_trace_messages(
+            source_text=source_text,
+            source_hash=source_hash,
+            query=query,
+            workflow_context=workflow_context,
+        ),
+        "prompt_message_count": 2,
+        "response_type": "KnowledgeOracleAnswer",
+        "response_message": None,
+        "response_text": clean_response,
+        "response_content": clean_response,
+        "response_tool_calls": None,
+        "error": str(error or "").strip() or None,
+        "call_site": str(call_site or "knowledge_oracle"),
+        "source_pack_chars": len(source_text),
+        "source_pack_sha256": source_hash,
+        "max_output_tokens": int(max_output_tokens),
+        "elapsed_ms": int(elapsed_ms),
+        "usage": (response_payload or {}).get("usage") if isinstance(response_payload, dict) else None,
+    }
+
+
+def _oracle_trace_messages(
+    *,
+    source_text: str,
+    source_hash: str,
+    query: str,
+    workflow_context: dict[str, Any] | None,
+) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "type": "SystemMessage", "text": oracle_system_prompt()},
+        {
+            "role": "user",
+            "type": "HumanMessage",
+            "text": (
+                f"QUERY:\n{str(query or '').strip()}\n\n"
+                f"WORKFLOW_CONTEXT_JSON:\n{_json_dumps(workflow_context or {})}\n\n"
+                f"SOURCE_PACK_CHARS: {len(source_text)}\n"
+                f"SOURCE_PACK_SHA256: {source_hash}"
+            ),
+        },
+    ]
+
+
+def oracle_system_prompt() -> str:
+    return (
+        "You are a workflow business knowledge oracle. Answer only from the SOURCE PACK. "
+        "The SOURCE PACK is normalized evidence from user-uploaded files. It may be compact TOON table evidence. "
+        "For TOON evidence, row_label is the original row text and cells contain column/header/value pairs. "
+        "When cells include header_group N, the group numbers are distinct column/header groups from left to right; "
+        "if the query names class, tier, category, option, or group N, use that matching header_group N. "
+        "Duplicate header suffixes like [1] and [2] mean repeated adjacent source columns in spreadsheet order; "
+        "when row_label clearly lists ordered variants, map earlier/later variants to earlier/later duplicate columns. "
+        "If SOURCE PACK mode is overview, summarize available matching services/categories and ask a concise clarifying "
+        "question when an exact price requires a service, variant, class, size, or other qualifier. "
+        "For capability questions, answer yes only if a matching source row supports that capability; otherwise say you need to confirm. "
+        "If the query or workflow context says the latest customer request is outside the configured workflow scope, "
+        "do not answer source facts for that out-of-scope category; return exactly NO_SOURCE. "
+        "If the query is only about cancelling, rescheduling, or correcting an existing booking and no new source-backed business fact is needed, return exactly NO_SOURCE. "
+        "Do not guess, infer unsupported facts, or use outside knowledge. "
+        "If multiple rows support the same requested fact with different values, state the concise distinction instead of choosing silently. "
+        "Return a plain string only: concise but informative facts the intake agent needs, with source refs when useful. "
+        "For broad pricing questions, include the relevant ranges/options and the missing qualifiers needed for an exact answer. "
+        "If the source does not answer the query, return exactly NO_SOURCE. "
+        "If the source is ambiguous, return AMBIGUOUS: followed by one concise clarifying question. "
+        "Stay under 1000 tokens, and prefer much shorter when the answer is narrow."
+    )
+
+
+def oracle_intent_system_prompt() -> str:
+    return (
+        "Extract structured search intent for local matching over arbitrary business files. "
+        "Return raw JSON only, no markdown. Keys: mode, target_terms, qualifier_terms, ignore_terms. "
+        "mode is one of specific_fact, category_overview, corpus_overview, capability_check. "
+        "target_terms are service/product/item/action names likely found in row labels, headings, or column groups. "
+        "qualifier_terms are variants/classes/sizes/dimensions/locations likely found in headers, row labels, or nearby context. "
+        "Use category_overview or corpus_overview for broad questions asking what exists, what services are offered, "
+        "or price lists for a whole category. Use capability_check for yes/no service availability questions. "
+        "ignore_terms are generic request words that should not drive retrieval. Preserve user wording. Do not answer."
+    )
+
+
+def openrouter_app_headers(base_url: str) -> dict[str, str]:
+    if "openrouter.ai" not in str(base_url or "").casefold():
+        return {}
+    title = str(os.environ.get("OPENROUTER_APP_TITLE", "")).strip() or DEFAULT_OPENROUTER_APP_TITLE
+    headers = {"HTTP-Referer": DEFAULT_OPENROUTER_APP_REFERER}
+    if title:
+        headers["X-OpenRouter-Title"] = title
+    return headers
+
+
+def oracle_reasoning_control(base_url: str) -> dict[str, Any]:
+    if "openrouter.ai" not in str(base_url or "").casefold():
+        return {}
+    return {"reasoning": {"effort": "none", "exclude": True}}
+
+
+def oracle_user_prompt(
+    *,
+    source_pack: str,
+    query: str,
+    workflow_context: dict[str, Any] | None,
+) -> str:
+    context = _json_dumps(workflow_context or {})
+    return (
+        f"QUERY:\n{query.strip()}\n\n"
+        f"WORKFLOW_CONTEXT_JSON:\n{context}\n\n"
+        "SOURCE PACK:\n"
+        f"{source_pack}"
+    )
+
+
+def extract_chat_text(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first = choices[0]
+    if not isinstance(first, dict):
+        return ""
+    message = first.get("message")
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                str(item.get("text", "")).strip()
+                for item in content
+                if isinstance(item, dict) and str(item.get("text", "")).strip()
+            ]
+            return "\n".join(parts)
+    text = first.get("text")
+    return str(text or "")
+
+
+def parse_json_object(text: str) -> dict[str, Any]:
+    raw = str(text or "").strip()
+    raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE).strip()
+    raw = re.sub(r"\s*```$", "", raw).strip()
+    with suppress(Exception):
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start >= 0 and end > start:
+        with suppress(Exception):
+            parsed = json.loads(raw[start : end + 1])
+            return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def clean_query_intent(value: Any, query: str) -> dict[str, Any]:
+    parsed = value if isinstance(value, dict) else {}
+    mode = str(parsed.get("mode", "") or "").strip().lower()
+    if mode not in {"specific_fact", "category_overview", "corpus_overview", "capability_check"}:
+        mode = "specific_fact"
+    intent = {
+        "mode": mode,
+        "target_terms": safe_text_list(parsed.get("target_terms")),
+        "qualifier_terms": safe_text_list(parsed.get("qualifier_terms")),
+        "ignore_terms": safe_text_list(parsed.get("ignore_terms")),
+    }
+    if not intent["target_terms"]:
+        intent["target_terms"] = [str(query or "").strip()]
+    return intent
+
+
+def safe_text_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return unique_strings([str(item).strip() for item in value if str(item).strip()])
+    text = str(value or "").strip()
+    return [text] if text else []
+
+
+def unique_strings(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        folded = text.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        out.append(text)
+    return out
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.monotonic() - started) * 1000)

--- a/src/opentulpa/business_knowledge/repository.py
+++ b/src/opentulpa/business_knowledge/repository.py
@@ -1,0 +1,579 @@
+"""SQLite repository for business knowledge sources and sections."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+from opentulpa.business_knowledge.extraction import metadata_json
+from opentulpa.business_knowledge.models import KnowledgeSourceSection
+from opentulpa.core.ids import new_short_id
+from opentulpa.persistence.sqlite import connect_sqlite
+
+KNOWLEDGE_PREFLIGHT_CACHE_VERSION = 1
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS knowledge_sources (
+    customer_id TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    file_id TEXT NOT NULL,
+    source_hash TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    warnings_json TEXT NOT NULL,
+    section_count INTEGER NOT NULL,
+    char_count INTEGER NOT NULL,
+    indexed_at TEXT NOT NULL,
+    PRIMARY KEY (customer_id, scope_type, scope_id, file_id)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_sources_scope
+    ON knowledge_sources(customer_id, scope_type, scope_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_sections (
+    section_id TEXT PRIMARY KEY,
+    customer_id TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    file_id TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    source_ref TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata_json TEXT NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_sections_scope
+    ON knowledge_sections(customer_id, scope_type, scope_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_sections_file
+    ON knowledge_sections(customer_id, scope_type, scope_id, file_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_preflight_cache (
+    customer_id TEXT NOT NULL,
+    cache_key TEXT NOT NULL,
+    cache_version INTEGER NOT NULL,
+    source_signature TEXT NOT NULL,
+    workflow_goal_hash TEXT NOT NULL,
+    oracle_model TEXT NOT NULL,
+    file_ids_json TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (customer_id, cache_key)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_preflight_cache_lookup
+    ON knowledge_preflight_cache(
+        customer_id, source_signature, workflow_goal_hash, oracle_model
+    );
+"""
+
+
+class BusinessKnowledgeRepository:
+    def __init__(self, *, root_dir: Path, db_path: Path) -> None:
+        self.root_dir = root_dir.resolve()
+        self.db_path = db_path.resolve()
+        self.init_db()
+
+    def conn(self) -> sqlite3.Connection:
+        return connect_sqlite(self.db_path, wal=True)
+
+    def init_db(self) -> None:
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.conn() as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(_SCHEMA_SQL)
+
+    def get_source_row(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        file_id: str,
+    ) -> sqlite3.Row | None:
+        with self.conn() as conn:
+            return cast(
+                "sqlite3.Row | None",
+                conn.execute(
+                    """
+                    SELECT *
+                    FROM knowledge_sources
+                    WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
+                    """,
+                    (customer_id, scope_type, scope_id, file_id),
+                ).fetchone(),
+            )
+
+    def replace_source(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        file_id: str,
+        source_hash: str,
+        filename: str,
+        mime_type: str,
+        status: str,
+        source_kind: str,
+        warnings: list[str],
+        sections: list[KnowledgeSourceSection],
+        indexed_at: str,
+    ) -> None:
+        char_count = sum(len(section.content) for section in sections)
+        with self.conn() as conn:
+            _delete_sections(
+                conn,
+                customer_id=customer_id,
+                scope_type=scope_type,
+                scope_id=scope_id,
+                file_id=file_id,
+            )
+            _insert_sections(
+                conn,
+                customer_id=customer_id,
+                scope_type=scope_type,
+                scope_id=scope_id,
+                file_id=file_id,
+                filename=filename,
+                sections=sections,
+                created_at=indexed_at,
+            )
+            _upsert_source(
+                conn,
+                customer_id=customer_id,
+                scope_type=scope_type,
+                scope_id=scope_id,
+                file_id=file_id,
+                source_hash=source_hash,
+                filename=filename,
+                mime_type=mime_type,
+                status=status,
+                source_kind=source_kind,
+                warnings=warnings,
+                section_count=len(sections),
+                char_count=char_count,
+                indexed_at=indexed_at,
+            )
+            conn.commit()
+
+    def load_sections(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+    ) -> list[KnowledgeSourceSection]:
+        with self.conn() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM knowledge_sections
+                WHERE customer_id=? AND scope_type=? AND scope_id=?
+                ORDER BY file_id, sort_order, source_ref, section_id
+                """,
+                (customer_id, scope_type, scope_id),
+            ).fetchall()
+        return [
+            KnowledgeSourceSection(
+                content=str(row["content"]),
+                source_ref=str(row["source_ref"]),
+                source_kind=str(row["source_kind"]),
+                metadata={
+                    "file_id": str(row["file_id"]),
+                    "filename": str(row["filename"]),
+                    **_json_loads_dict(row["metadata_json"]),
+                },
+                sort_order=int(row["sort_order"] or 0),
+            )
+            for row in rows
+        ]
+
+    def scope_warnings(self, *, customer_id: str, scope_type: str, scope_id: str) -> list[str]:
+        with self.conn() as conn:
+            rows = conn.execute(
+                """
+                SELECT warnings_json, status, filename
+                FROM knowledge_sources
+                WHERE customer_id=? AND scope_type=? AND scope_id=?
+                ORDER BY filename
+                """,
+                (customer_id, scope_type, scope_id),
+            ).fetchall()
+        warnings: list[str] = []
+        for row in rows:
+            warnings.extend(_safe_list_json(row["warnings_json"]))
+            if str(row["status"]) != "indexed":
+                warnings.append(f"{row['filename']}: {row['status']}")
+        return _unique_strings(warnings)
+
+    def scope_source_count(self, *, customer_id: str, scope_type: str, scope_id: str) -> int:
+        with self.conn() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM knowledge_sources
+                WHERE customer_id=? AND scope_type=? AND scope_id=?
+                """,
+                (customer_id, scope_type, scope_id),
+            ).fetchone()
+        return int((row or {})["count"] or 0) if row is not None else 0
+
+    def source_rows(self, *, customer_id: str, scope_type: str, scope_id: str) -> list[sqlite3.Row]:
+        if not scope_id:
+            return []
+        with self.conn() as conn:
+            return list(
+                conn.execute(
+                    """
+                    SELECT *
+                    FROM knowledge_sources
+                    WHERE customer_id=? AND scope_type=? AND scope_id=?
+                    ORDER BY filename
+                    """,
+                    (customer_id, scope_type, scope_id),
+                ).fetchall()
+            )
+
+    def get_preflight_cache(self, *, customer_id: str, cache_key: str) -> dict[str, Any]:
+        with self.conn() as conn:
+            row = conn.execute(
+                """
+                SELECT result_json
+                FROM knowledge_preflight_cache
+                WHERE customer_id=? AND cache_key=? AND cache_version=?
+                """,
+                (customer_id, cache_key, KNOWLEDGE_PREFLIGHT_CACHE_VERSION),
+            ).fetchone()
+        if row is None:
+            return {}
+        return _json_loads_dict(row["result_json"])
+
+    def store_preflight_cache(
+        self,
+        *,
+        customer_id: str,
+        cache_meta: dict[str, Any],
+        result: dict[str, Any],
+        now: str,
+    ) -> None:
+        with self.conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO knowledge_preflight_cache (
+                    customer_id, cache_key, cache_version, source_signature,
+                    workflow_goal_hash, oracle_model, file_ids_json, result_json,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(customer_id, cache_key) DO UPDATE SET
+                    source_signature=excluded.source_signature,
+                    workflow_goal_hash=excluded.workflow_goal_hash,
+                    oracle_model=excluded.oracle_model,
+                    file_ids_json=excluded.file_ids_json,
+                    result_json=excluded.result_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    customer_id,
+                    str(cache_meta.get("cache_key", "") or ""),
+                    int(cache_meta.get("cache_version") or KNOWLEDGE_PREFLIGHT_CACHE_VERSION),
+                    str(cache_meta.get("source_signature", "") or ""),
+                    str(cache_meta.get("workflow_goal_hash", "") or ""),
+                    str(cache_meta.get("oracle_model", "") or ""),
+                    _json_dumps(_safe_text_list(cache_meta.get("file_ids"))),
+                    _json_dumps(result),
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+
+    def promote_scope(
+        self,
+        *,
+        customer_id: str,
+        source_scope_type: str,
+        source_scope_id: str,
+        target_scope_type: str,
+        target_scope_id: str,
+        indexed_at: str,
+    ) -> tuple[int, int]:
+        with self.conn() as conn:
+            sources = conn.execute(
+                """
+                SELECT *
+                FROM knowledge_sources
+                WHERE customer_id=? AND scope_type=? AND scope_id=?
+                """,
+                (customer_id, source_scope_type, source_scope_id),
+            ).fetchall()
+            sections = conn.execute(
+                """
+                SELECT *
+                FROM knowledge_sections
+                WHERE customer_id=? AND scope_type=? AND scope_id=?
+                ORDER BY file_id, sort_order, source_ref
+                """,
+                (customer_id, source_scope_type, source_scope_id),
+            ).fetchall()
+            _delete_scope(conn, customer_id=customer_id, scope_type=target_scope_type, scope_id=target_scope_id)
+            _copy_source_rows(
+                conn,
+                customer_id=customer_id,
+                scope_type=target_scope_type,
+                scope_id=target_scope_id,
+                rows=sources,
+                indexed_at=indexed_at,
+            )
+            _copy_section_rows(
+                conn,
+                customer_id=customer_id,
+                scope_type=target_scope_type,
+                scope_id=target_scope_id,
+                rows=sections,
+                created_at=indexed_at,
+            )
+            conn.commit()
+        return len(sources), len(sections)
+
+
+def _delete_sections(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+    file_id: str,
+) -> None:
+    conn.execute(
+        """
+        DELETE FROM knowledge_sections
+        WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
+        """,
+        (customer_id, scope_type, scope_id, file_id),
+    )
+
+
+def _insert_sections(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+    file_id: str,
+    filename: str,
+    sections: list[KnowledgeSourceSection],
+    created_at: str,
+) -> None:
+    for section in sections:
+        conn.execute(
+            """
+            INSERT INTO knowledge_sections (
+                section_id, customer_id, scope_type, scope_id, file_id, filename,
+                source_ref, source_kind, content, metadata_json, sort_order, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                new_short_id("knsec"),
+                customer_id,
+                scope_type,
+                scope_id,
+                file_id,
+                filename,
+                section.source_ref,
+                section.source_kind,
+                section.content,
+                metadata_json(section.metadata),
+                int(section.sort_order),
+                created_at,
+            ),
+        )
+
+
+def _upsert_source(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+    file_id: str,
+    source_hash: str,
+    filename: str,
+    mime_type: str,
+    status: str,
+    source_kind: str,
+    warnings: list[str],
+    section_count: int,
+    char_count: int,
+    indexed_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO knowledge_sources (
+            customer_id, scope_type, scope_id, file_id, source_hash, filename,
+            mime_type, status, source_kind, warnings_json, section_count, char_count, indexed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(customer_id, scope_type, scope_id, file_id) DO UPDATE SET
+            source_hash=excluded.source_hash,
+            filename=excluded.filename,
+            mime_type=excluded.mime_type,
+            status=excluded.status,
+            source_kind=excluded.source_kind,
+            warnings_json=excluded.warnings_json,
+            section_count=excluded.section_count,
+            char_count=excluded.char_count,
+            indexed_at=excluded.indexed_at
+        """,
+        (
+            customer_id,
+            scope_type,
+            scope_id,
+            file_id,
+            source_hash,
+            filename,
+            mime_type,
+            status,
+            source_kind,
+            _json_dumps(warnings),
+            section_count,
+            char_count,
+            indexed_at,
+        ),
+    )
+
+
+def _delete_scope(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+) -> None:
+    conn.execute(
+        "DELETE FROM knowledge_sources WHERE customer_id=? AND scope_type=? AND scope_id=?",
+        (customer_id, scope_type, scope_id),
+    )
+    conn.execute(
+        "DELETE FROM knowledge_sections WHERE customer_id=? AND scope_type=? AND scope_id=?",
+        (customer_id, scope_type, scope_id),
+    )
+
+
+def _copy_source_rows(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+    rows: list[sqlite3.Row],
+    indexed_at: str,
+) -> None:
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO knowledge_sources (
+                customer_id, scope_type, scope_id, file_id, source_hash, filename,
+                mime_type, status, source_kind, warnings_json, section_count, char_count, indexed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                customer_id,
+                scope_type,
+                scope_id,
+                str(row["file_id"]),
+                str(row["source_hash"]),
+                str(row["filename"]),
+                str(row["mime_type"]),
+                str(row["status"]),
+                str(row["source_kind"]),
+                str(row["warnings_json"]),
+                int(row["section_count"] or 0),
+                int(row["char_count"] or 0),
+                indexed_at,
+            ),
+        )
+
+
+def _copy_section_rows(
+    conn: sqlite3.Connection,
+    *,
+    customer_id: str,
+    scope_type: str,
+    scope_id: str,
+    rows: list[sqlite3.Row],
+    created_at: str,
+) -> None:
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO knowledge_sections (
+                section_id, customer_id, scope_type, scope_id, file_id, filename,
+                source_ref, source_kind, content, metadata_json, sort_order, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                new_short_id("knsec"),
+                customer_id,
+                scope_type,
+                scope_id,
+                str(row["file_id"]),
+                str(row["filename"]),
+                str(row["source_ref"]),
+                str(row["source_kind"]),
+                str(row["content"]),
+                str(row["metadata_json"]),
+                int(row["sort_order"] or 0),
+                created_at,
+            ),
+        )
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _json_loads_dict(value: Any) -> dict[str, Any]:
+    try:
+        parsed = json.loads(str(value or "{}"))
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _safe_list_json(value: Any) -> list[str]:
+    try:
+        parsed = json.loads(str(value or "[]"))
+    except Exception:
+        return []
+    if isinstance(parsed, list):
+        return [str(item).strip() for item in parsed if str(item).strip()]
+    return []
+
+
+def _safe_text_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return _unique_strings([str(item).strip() for item in value if str(item).strip()])
+    text = str(value or "").strip()
+    return [text] if text else []
+
+
+def _unique_strings(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        folded = text.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        out.append(text)
+    return out

--- a/src/opentulpa/business_knowledge/service.py
+++ b/src/opentulpa/business_knowledge/service.py
@@ -14,7 +14,7 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -193,7 +193,7 @@ class OpenAICompatibleKnowledgeOracleClient:
                 source_pack=source_pack,
                 query=query,
                 workflow_context=workflow_context,
-                max_output_tokens=int(request_body["max_tokens"]),
+                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
                 response_payload=response_payload,
                 response_text=answer_text,
                 error=error_text,
@@ -239,7 +239,7 @@ class OpenAICompatibleKnowledgeOracleClient:
                 source_pack="",
                 query=query,
                 workflow_context={},
-                max_output_tokens=int(request_body["max_tokens"]),
+                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
                 response_payload=response_payload,
                 response_text=response_text,
                 error=error_text,
@@ -1145,14 +1145,17 @@ class BusinessKnowledgeService:
         file_id: str,
     ) -> sqlite3.Row | None:
         with self._conn() as conn:
-            return conn.execute(
-                """
-                SELECT *
-                FROM knowledge_sources
-                WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
-                """,
-                (customer_id, scope_type, scope_id, file_id),
-            ).fetchone()
+            return cast(
+                "sqlite3.Row | None",
+                conn.execute(
+                    """
+                    SELECT *
+                    FROM knowledge_sources
+                    WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
+                    """,
+                    (customer_id, scope_type, scope_id, file_id),
+                ).fetchone(),
+            )
 
     def _load_sections(
         self,

--- a/src/opentulpa/business_knowledge/service.py
+++ b/src/opentulpa/business_knowledge/service.py
@@ -2,53 +2,61 @@
 
 from __future__ import annotations
 
-import csv
 import json
 import logging
-import os
 import re
 import sqlite3
-import threading
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from io import StringIO
 from pathlib import Path
-from typing import Any, cast
-
-import httpx
+from typing import Any
 
 from opentulpa.business_knowledge.extraction import (
     content_hash,
-    extract_source_sections,
-    metadata_json,
 )
+from opentulpa.business_knowledge.indexer import BusinessKnowledgeIndexer
 from opentulpa.business_knowledge.models import (
     KnowledgeIndexedSource,
     KnowledgeQueryAnswer,
     KnowledgeQueryResult,
     KnowledgeSourceSection,
 )
-from opentulpa.business_knowledge.table_normalizer import (
-    select_table_evidence,
-    table_evidence_selection_stats,
-    table_evidence_to_toon,
-    table_facts_from_sections,
-    table_overview_to_toon,
+from opentulpa.business_knowledge.oracle_client import (
+    DEFAULT_ORACLE_MAX_OUTPUT_TOKENS as _DEFAULT_ORACLE_MAX_OUTPUT_TOKENS,
 )
+from opentulpa.business_knowledge.oracle_client import (
+    DEFAULT_ORACLE_MODEL as _DEFAULT_ORACLE_MODEL,
+)
+from opentulpa.business_knowledge.oracle_client import (
+    OpenAICompatibleKnowledgeOracleClient as OpenAICompatibleKnowledgeOracleClient,
+)
+from opentulpa.business_knowledge.oracle_client import clean_query_intent
+from opentulpa.business_knowledge.repository import (
+    KNOWLEDGE_PREFLIGHT_CACHE_VERSION,
+    BusinessKnowledgeRepository,
+)
+from opentulpa.business_knowledge.source_pack_planner import BusinessKnowledgeSourcePackPlanner
 from opentulpa.context.file_vault import FileVaultService
-from opentulpa.core.ids import new_short_id
-from opentulpa.persistence.sqlite import connect_sqlite
 
 _VALID_SCOPE_TYPES = {"workflow_setup", "intake_workflow", "customer_business", "user_context"}
 _DEFAULT_SOURCE_PACK_CHAR_LIMIT = 800_000
-_DEFAULT_ORACLE_MODEL = "google/gemini-3.1-flash-lite-preview"
-_DEFAULT_ORACLE_MAX_OUTPUT_TOKENS = 1000
 _NO_SOURCE_MARKERS = {"no_source", "no source", "not found", "unsupported"}
-_DEFAULT_OPENROUTER_APP_REFERER = "https://github.com/kvyb/opentulpa"
-_DEFAULT_OPENROUTER_APP_TITLE = "OpenTulpa"
-_KNOWLEDGE_PREFLIGHT_CACHE_VERSION = 1
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _PreparedQueryScope:
+    customer_id: str
+    scope_type: str
+    scope_id: str
+    query: str
+    max_chars: int
+    sections: list[KnowledgeSourceSection]
+    warnings: list[str]
+    source_count: int
+    timing_ms: dict[str, int]
 
 
 def _utc_now_iso() -> str:
@@ -79,14 +87,6 @@ def _json_dumps(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True)
 
 
-def _json_loads_dict(value: Any) -> dict[str, Any]:
-    try:
-        parsed = json.loads(str(value or "{}"))
-    except Exception:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
 def _hash_json(value: Any) -> str:
     return content_hash(_json_dumps(value).encode("utf-8", errors="replace"))
 
@@ -107,220 +107,6 @@ def _safe_int_dict(value: Any) -> dict[str, int]:
     return out
 
 
-def _safe_intent_diagnostics(intent: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "mode": str(intent.get("mode", "") or ""),
-        "target_term_count": len(_safe_text_list(intent.get("target_terms"))),
-        "qualifier_term_count": len(_safe_text_list(intent.get("qualifier_terms"))),
-    }
-
-
-class OpenAICompatibleKnowledgeOracleClient:
-    """Small OpenAI-compatible chat client for the business knowledge oracle."""
-
-    def __init__(
-        self,
-        *,
-        api_key: str,
-        base_url: str,
-        model: str = _DEFAULT_ORACLE_MODEL,
-        timeout_seconds: float = 45.0,
-        trace_path: Path | None = None,
-        langfuse_tracer: Any | None = None,
-    ) -> None:
-        self.api_key = str(api_key or "").strip()
-        self.base_url = str(base_url or "").strip().rstrip("/")
-        self.model = str(model or "").strip() or _DEFAULT_ORACLE_MODEL
-        self.timeout_seconds = float(timeout_seconds)
-        if not self.api_key:
-            raise ValueError("api_key is required")
-        if not self.base_url:
-            raise ValueError("base_url is required")
-        self.trace_path = trace_path.resolve() if isinstance(trace_path, Path) else None
-        self.langfuse_tracer = langfuse_tracer
-        self._trace_lock = threading.Lock()
-
-    def answer(
-        self,
-        *,
-        source_pack: str,
-        query: str,
-        workflow_context: dict[str, Any] | None = None,
-        max_output_tokens: int = _DEFAULT_ORACLE_MAX_OUTPUT_TOKENS,
-    ) -> str:
-        started = time.monotonic()
-        request_body = {
-            "model": self.model,
-            "temperature": 0,
-            "max_tokens": max(1, int(max_output_tokens)),
-            "messages": [
-                {"role": "system", "content": _oracle_system_prompt()},
-                {
-                    "role": "user",
-                    "content": _oracle_user_prompt(
-                        source_pack=source_pack,
-                        query=query,
-                        workflow_context=workflow_context,
-                    ),
-                },
-            ],
-        }
-        request_body.update(_oracle_reasoning_control(self.base_url))
-        response_payload: dict[str, Any] | None = None
-        answer_text = ""
-        error_text: str | None = None
-        try:
-            response = httpx.post(
-                f"{self.base_url}/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                    **_openrouter_app_headers(self.base_url),
-                },
-                json=request_body,
-                timeout=self.timeout_seconds,
-            )
-            response.raise_for_status()
-            raw_payload = response.json()
-            response_payload = raw_payload if isinstance(raw_payload, dict) else {}
-            answer_text = _extract_chat_text(response_payload)
-            return answer_text
-        except Exception as exc:
-            error_text = f"{type(exc).__name__}: {exc}"
-            raise
-        finally:
-            self._record_oracle_trace(
-                source_pack=source_pack,
-                query=query,
-                workflow_context=workflow_context,
-                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
-                response_payload=response_payload,
-                response_text=answer_text,
-                error=error_text,
-                elapsed_ms=int((time.monotonic() - started) * 1000),
-            )
-
-    def extract_intent(self, *, query: str) -> dict[str, Any]:
-        started = time.monotonic()
-        request_body = {
-            "model": self.model,
-            "temperature": 0,
-            "max_tokens": 180,
-            "messages": [
-                {"role": "system", "content": _oracle_intent_system_prompt()},
-                {"role": "user", "content": str(query or "").strip()},
-            ],
-        }
-        request_body.update(_oracle_reasoning_control(self.base_url))
-        response_payload: dict[str, Any] | None = None
-        response_text = ""
-        error_text: str | None = None
-        try:
-            response = httpx.post(
-                f"{self.base_url}/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                    **_openrouter_app_headers(self.base_url),
-                },
-                json=request_body,
-                timeout=self.timeout_seconds,
-            )
-            response.raise_for_status()
-            raw_payload = response.json()
-            response_payload = raw_payload if isinstance(raw_payload, dict) else {}
-            response_text = _extract_chat_text(response_payload)
-            return _clean_query_intent(_parse_json_object(response_text), str(query or ""))
-        except Exception as exc:
-            error_text = f"{type(exc).__name__}: {exc}"
-            raise
-        finally:
-            self._record_oracle_trace(
-                source_pack="",
-                query=query,
-                workflow_context={},
-                max_output_tokens=int(str(request_body.get("max_tokens") or "0")),
-                response_payload=response_payload,
-                response_text=response_text,
-                error=error_text,
-                elapsed_ms=_elapsed_ms(started),
-                call_site="knowledge_oracle_intent",
-            )
-
-    def _record_oracle_trace(
-        self,
-        *,
-        source_pack: str,
-        query: str,
-        workflow_context: dict[str, Any] | None,
-        max_output_tokens: int,
-        response_payload: dict[str, Any] | None,
-        response_text: str,
-        error: str | None,
-        elapsed_ms: int,
-        call_site: str = "knowledge_oracle",
-    ) -> None:
-        source_text = str(source_pack or "")
-        payload: dict[str, Any] = {
-            "ts": datetime.now(UTC).isoformat(),
-            "model_name": self.model,
-            "stable_prefix_count": 0,
-            "prompt_messages": [
-                {"role": "system", "type": "SystemMessage", "text": _oracle_system_prompt()},
-                {
-                    "role": "user",
-                    "type": "HumanMessage",
-                    "text": (
-                        f"QUERY:\n{str(query or '').strip()}\n\n"
-                        f"WORKFLOW_CONTEXT_JSON:\n{_json_dumps(workflow_context or {})}\n\n"
-                        f"SOURCE_PACK_CHARS: {len(source_text)}\n"
-                        f"SOURCE_PACK_SHA256: {content_hash(source_text.encode('utf-8', errors='replace'))}"
-                    ),
-                },
-            ],
-            "prompt_message_count": 2,
-            "response_type": "KnowledgeOracleAnswer",
-            "response_message": None,
-            "response_text": str(response_text or "").strip(),
-            "response_content": str(response_text or "").strip(),
-            "response_tool_calls": None,
-            "error": str(error or "").strip() or None,
-            "call_site": str(call_site or "knowledge_oracle"),
-            "source_pack_chars": len(source_text),
-            "source_pack_sha256": content_hash(source_text.encode("utf-8", errors="replace")),
-            "max_output_tokens": int(max_output_tokens),
-            "elapsed_ms": int(elapsed_ms),
-            "usage": (response_payload or {}).get("usage") if isinstance(response_payload, dict) else None,
-        }
-        tracer = getattr(self, "langfuse_tracer", None)
-        record_generation = getattr(tracer, "record_generation", None)
-        if callable(record_generation):
-            with suppress(Exception):
-                record_generation(payload)
-        path = self.trace_path
-        if path is None:
-            return
-        serialized = json.dumps(payload, ensure_ascii=False, default=str)
-
-        def _commit() -> None:
-            existing: list[str] = []
-            with suppress(Exception):
-                existing = [
-                    line.rstrip("\n")
-                    for line in path.read_text(encoding="utf-8").splitlines()
-                    if line.strip()
-                ]
-            kept = existing[-499:]
-            kept.append(serialized)
-            with path.open("w", encoding="utf-8") as f:
-                f.write("\n".join(kept) + "\n")
-
-        with suppress(Exception):
-            path.parent.mkdir(parents=True, exist_ok=True)
-        with suppress(Exception), self._trace_lock:
-            _commit()
-
-
 class BusinessKnowledgeService:
     """Prepares source packs and answers scoped business questions through an oracle."""
 
@@ -338,16 +124,21 @@ class BusinessKnowledgeService:
     ) -> None:
         self.root_dir = root_dir.resolve()
         self.db_path = db_path.resolve()
-        self.file_vault = file_vault
+        self.repository = BusinessKnowledgeRepository(root_dir=self.root_dir, db_path=self.db_path)
+        self.indexer = BusinessKnowledgeIndexer(
+            file_vault=file_vault,
+            repository=self.repository,
+            now_iso=_utc_now_iso,
+        )
         self.oracle_client = oracle_client
         self.langfuse_tracer = langfuse_tracer
         self.oracle_model = str(oracle_model or "").strip() or _DEFAULT_ORACLE_MODEL
         self.max_source_pack_chars = max(1, int(max_source_pack_chars))
         self.max_output_tokens = max(1, int(max_output_tokens))
-        self._init_db()
-
-    def _conn(self) -> sqlite3.Connection:
-        return connect_sqlite(self.db_path, wal=True)
+        self._source_pack_planner = BusinessKnowledgeSourcePackPlanner(
+            extract_intent=self._query_intent,
+            record_span=self._record_observability_span,
+        )
 
     def _record_observability_span(
         self,
@@ -372,71 +163,6 @@ class BusinessKnowledgeService:
                     status=status,
                 )
 
-    def _init_db(self) -> None:
-        self.root_dir.mkdir(parents=True, exist_ok=True)
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        with self._conn() as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.executescript(
-                """
-                CREATE TABLE IF NOT EXISTS knowledge_sources (
-                    customer_id TEXT NOT NULL,
-                    scope_type TEXT NOT NULL,
-                    scope_id TEXT NOT NULL,
-                    file_id TEXT NOT NULL,
-                    source_hash TEXT NOT NULL,
-                    filename TEXT NOT NULL,
-                    mime_type TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    source_kind TEXT NOT NULL,
-                    warnings_json TEXT NOT NULL,
-                    section_count INTEGER NOT NULL,
-                    char_count INTEGER NOT NULL,
-                    indexed_at TEXT NOT NULL,
-                    PRIMARY KEY (customer_id, scope_type, scope_id, file_id)
-                );
-                CREATE INDEX IF NOT EXISTS idx_knowledge_sources_scope
-                    ON knowledge_sources(customer_id, scope_type, scope_id);
-
-                CREATE TABLE IF NOT EXISTS knowledge_sections (
-                    section_id TEXT PRIMARY KEY,
-                    customer_id TEXT NOT NULL,
-                    scope_type TEXT NOT NULL,
-                    scope_id TEXT NOT NULL,
-                    file_id TEXT NOT NULL,
-                    filename TEXT NOT NULL,
-                    source_ref TEXT NOT NULL,
-                    source_kind TEXT NOT NULL,
-                    content TEXT NOT NULL,
-                    metadata_json TEXT NOT NULL,
-                    sort_order INTEGER NOT NULL,
-                    created_at TEXT NOT NULL
-                );
-                CREATE INDEX IF NOT EXISTS idx_knowledge_sections_scope
-                    ON knowledge_sections(customer_id, scope_type, scope_id);
-                CREATE INDEX IF NOT EXISTS idx_knowledge_sections_file
-                    ON knowledge_sections(customer_id, scope_type, scope_id, file_id);
-
-                CREATE TABLE IF NOT EXISTS knowledge_preflight_cache (
-                    customer_id TEXT NOT NULL,
-                    cache_key TEXT NOT NULL,
-                    cache_version INTEGER NOT NULL,
-                    source_signature TEXT NOT NULL,
-                    workflow_goal_hash TEXT NOT NULL,
-                    oracle_model TEXT NOT NULL,
-                    file_ids_json TEXT NOT NULL,
-                    result_json TEXT NOT NULL,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    PRIMARY KEY (customer_id, cache_key)
-                );
-                CREATE INDEX IF NOT EXISTS idx_knowledge_preflight_cache_lookup
-                    ON knowledge_preflight_cache(
-                        customer_id, source_signature, workflow_goal_hash, oracle_model
-                    );
-                """
-            )
-
     def index_sources(
         self,
         *,
@@ -454,7 +180,7 @@ class BusinessKnowledgeService:
             raise ValueError("file_ids is required")
 
         sources = [
-            self._index_one_source(
+            self.indexer.index_one_source(
                 customer_id=cid,
                 scope_type=safe_scope_type,
                 scope_id=safe_scope_id,
@@ -488,126 +214,6 @@ class BusinessKnowledgeService:
         )
         return result
 
-    def _index_one_source(
-        self,
-        *,
-        customer_id: str,
-        scope_type: str,
-        scope_id: str,
-        file_id: str,
-    ) -> KnowledgeIndexedSource:
-        record = self.file_vault.get_file(customer_id, file_id)
-        raw_bytes = self.file_vault.read_file_bytes(customer_id, file_id)
-        if not record or raw_bytes is None:
-            raise ValueError(f"file not found: {file_id}")
-
-        filename = str(record.get("original_filename", "") or "file.bin").strip() or "file.bin"
-        mime_type = str(record.get("mime_type", "") or "").strip()
-        source_hash = content_hash(
-            raw_bytes
-            + b"\0"
-            + str(record.get("summary", "") or "").encode("utf-8", errors="replace")
-            + b"\0"
-            + str(record.get("text_excerpt", "") or "").encode("utf-8", errors="replace")
-        )
-        existing = self._get_source_row(
-            customer_id=customer_id,
-            scope_type=scope_type,
-            scope_id=scope_id,
-            file_id=file_id,
-        )
-        if existing is not None and str(existing["source_hash"]) == source_hash:
-            return KnowledgeIndexedSource(
-                file_id=file_id,
-                filename=str(existing["filename"]),
-                mime_type=str(existing["mime_type"]),
-                status=str(existing["status"]),
-                source_kind=str(existing["source_kind"]),
-                section_count=int(existing["section_count"] or 0),
-                char_count=int(existing["char_count"] or 0),
-                warnings=_safe_list_json(existing["warnings_json"]),
-            )
-
-        sections, warnings, source_kind = extract_source_sections(record=record, raw_bytes=raw_bytes)
-        status = "indexed" if sections else "unsupported"
-        char_count = sum(len(section.content) for section in sections)
-        now = _utc_now_iso()
-        with self._conn() as conn:
-            conn.execute(
-                """
-                DELETE FROM knowledge_sections
-                WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
-                """,
-                (customer_id, scope_type, scope_id, file_id),
-            )
-            for section in sections:
-                conn.execute(
-                    """
-                    INSERT INTO knowledge_sections (
-                        section_id, customer_id, scope_type, scope_id, file_id, filename,
-                        source_ref, source_kind, content, metadata_json, sort_order, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        new_short_id("knsec"),
-                        customer_id,
-                        scope_type,
-                        scope_id,
-                        file_id,
-                        filename,
-                        section.source_ref,
-                        section.source_kind,
-                        section.content,
-                        metadata_json(section.metadata),
-                        int(section.sort_order),
-                        now,
-                    ),
-                )
-            conn.execute(
-                """
-                INSERT INTO knowledge_sources (
-                    customer_id, scope_type, scope_id, file_id, source_hash, filename,
-                    mime_type, status, source_kind, warnings_json, section_count, char_count, indexed_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(customer_id, scope_type, scope_id, file_id) DO UPDATE SET
-                    source_hash=excluded.source_hash,
-                    filename=excluded.filename,
-                    mime_type=excluded.mime_type,
-                    status=excluded.status,
-                    source_kind=excluded.source_kind,
-                    warnings_json=excluded.warnings_json,
-                    section_count=excluded.section_count,
-                    char_count=excluded.char_count,
-                    indexed_at=excluded.indexed_at
-                """,
-                (
-                    customer_id,
-                    scope_type,
-                    scope_id,
-                    file_id,
-                    source_hash,
-                    filename,
-                    mime_type,
-                    status,
-                    source_kind,
-                    _json_dumps(warnings),
-                    len(sections),
-                    char_count,
-                    now,
-                ),
-            )
-            conn.commit()
-        return KnowledgeIndexedSource(
-            file_id=file_id,
-            filename=filename,
-            mime_type=mime_type,
-            status=status,
-            source_kind=source_kind,
-            section_count=len(sections),
-            char_count=char_count,
-            warnings=warnings,
-        )
-
     def query(
         self,
         *,
@@ -620,6 +226,59 @@ class BusinessKnowledgeService:
         file_ids: list[str] | None = None,
     ) -> KnowledgeQueryResult:
         query_started = time.monotonic()
+        prepared = self._prepare_query_scope(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            query=query,
+            max_extract_chars=max_extract_chars,
+            file_ids=file_ids,
+        )
+        timing_ms = prepared.timing_ms
+        if not prepared.sections:
+            return self._empty_source_query_result(prepared=prepared, started=query_started)
+
+        source_pack, source_pack_diagnostics = self._source_pack_planner.plan(
+            sections=prepared.sections,
+            query=prepared.query,
+        )
+        timing_ms.update(_safe_int_dict(source_pack_diagnostics.get("timing_ms")))
+        if len(source_pack) > self.max_source_pack_chars:
+            return self._oversized_source_pack_result(
+                prepared=prepared,
+                source_pack_diagnostics=source_pack_diagnostics,
+                started=query_started,
+            )
+        if self.oracle_client is None:
+            return self._missing_oracle_query_result(
+                prepared=prepared,
+                source_pack_diagnostics=source_pack_diagnostics,
+                started=query_started,
+            )
+
+        raw_answer = self._answer_with_oracle(
+            prepared=prepared,
+            source_pack=source_pack,
+            workflow_context=workflow_context,
+        )
+        timing_ms["total"] = _elapsed_ms(query_started)
+        self._log_query_timing(prepared=prepared, source_pack_diagnostics=source_pack_diagnostics)
+        return self._successful_query_result(
+            prepared=prepared,
+            raw_answer=raw_answer,
+            source_pack_diagnostics=source_pack_diagnostics,
+        )
+
+    def _prepare_query_scope(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        query: str,
+        max_extract_chars: int,
+        file_ids: list[str] | None,
+    ) -> _PreparedQueryScope:
         timing_ms: dict[str, int] = {}
         cid = _safe_id(customer_id, field="customer_id")
         safe_scope_type = _safe_scope_type(scope_type)
@@ -627,7 +286,7 @@ class BusinessKnowledgeService:
         safe_query = str(query or "").strip()
         if not safe_query:
             raise ValueError("query is required")
-        max_chars = max(200, min(int(max_extract_chars), 5000))
+
         load_started = time.monotonic()
         sections = self._load_sections(
             customer_id=cid,
@@ -637,274 +296,171 @@ class BusinessKnowledgeService:
         safe_file_ids = set(_unique_strings(file_ids or []))
         if safe_file_ids:
             sections = [section for section in sections if str(section.metadata.get("file_id", "")) in safe_file_ids]
-        warnings = self._scope_warnings(
-            customer_id=cid,
-            scope_type=safe_scope_type,
-            scope_id=safe_scope_id,
-        )
         source_count = self._scope_source_count(
             customer_id=cid,
             scope_type=safe_scope_type,
             scope_id=safe_scope_id,
         )
-        if safe_file_ids:
-            source_count = len(safe_file_ids)
         timing_ms["load_scope"] = _elapsed_ms(load_started)
-        if not sections:
-            timing_ms["total"] = _elapsed_ms(query_started)
-            return self._query_result(
-                ok=False,
-                query=safe_query,
-                scope_type=safe_scope_type,
-                scope_id=safe_scope_id,
-                answer=self._no_source_answer(),
-                warnings=[*warnings, "no prepared source sections found"],
-                source_count=source_count,
-                section_count=0,
-                diagnostics={"timing_ms": timing_ms},
-            )
-
-        source_pack, source_pack_diagnostics = self._source_pack_for_query_with_diagnostics(
-            sections=sections,
+        return _PreparedQueryScope(
+            customer_id=cid,
+            scope_type=safe_scope_type,
+            scope_id=safe_scope_id,
             query=safe_query,
+            max_chars=max(200, min(int(max_extract_chars), 5000)),
+            sections=sections,
+            warnings=self._scope_warnings(
+                customer_id=cid,
+                scope_type=safe_scope_type,
+                scope_id=safe_scope_id,
+            ),
+            source_count=len(safe_file_ids) if safe_file_ids else source_count,
+            timing_ms=timing_ms,
         )
-        timing_ms.update(_safe_int_dict(source_pack_diagnostics.get("timing_ms")))
-        if len(source_pack) > self.max_source_pack_chars:
-            timing_ms["total"] = _elapsed_ms(query_started)
-            return self._query_result(
-                ok=False,
-                query=safe_query,
-                scope_type=safe_scope_type,
-                scope_id=safe_scope_id,
-                answer=self._no_source_answer(),
-                warnings=[
-                    *warnings,
-                    (
-                        "business knowledge source pack exceeds "
-                        f"{self.max_source_pack_chars} characters; split or narrow source files"
-                    ),
-                ],
-                source_count=source_count,
-                section_count=len(sections),
-                diagnostics={
-                    "timing_ms": timing_ms,
-                    "source_pack": source_pack_diagnostics,
-                },
-            )
-        if self.oracle_client is None:
-            timing_ms["total"] = _elapsed_ms(query_started)
-            return self._query_result(
-                ok=False,
-                query=safe_query,
-                scope_type=safe_scope_type,
-                scope_id=safe_scope_id,
-                answer=self._no_source_answer(),
-                warnings=[*warnings, "business knowledge oracle client is not configured"],
-                source_count=source_count,
-                section_count=len(sections),
-                diagnostics={
-                    "timing_ms": timing_ms,
-                    "source_pack": source_pack_diagnostics,
-                },
-            )
 
+    def _empty_source_query_result(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        started: float,
+    ) -> KnowledgeQueryResult:
+        prepared.timing_ms["total"] = _elapsed_ms(started)
+        return self._query_result(
+            ok=False,
+            query=prepared.query,
+            scope_type=prepared.scope_type,
+            scope_id=prepared.scope_id,
+            answer=self._no_source_answer(),
+            warnings=[*prepared.warnings, "no prepared source sections found"],
+            source_count=prepared.source_count,
+            section_count=0,
+            diagnostics={"timing_ms": prepared.timing_ms},
+        )
+
+    def _oversized_source_pack_result(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        source_pack_diagnostics: dict[str, Any],
+        started: float,
+    ) -> KnowledgeQueryResult:
+        prepared.timing_ms["total"] = _elapsed_ms(started)
+        warning = (
+            "business knowledge source pack exceeds "
+            f"{self.max_source_pack_chars} characters; split or narrow source files"
+        )
+        return self._query_result(
+            ok=False,
+            query=prepared.query,
+            scope_type=prepared.scope_type,
+            scope_id=prepared.scope_id,
+            answer=self._no_source_answer(),
+            warnings=[*prepared.warnings, warning],
+            source_count=prepared.source_count,
+            section_count=len(prepared.sections),
+            diagnostics={"timing_ms": prepared.timing_ms, "source_pack": source_pack_diagnostics},
+        )
+
+    def _missing_oracle_query_result(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        source_pack_diagnostics: dict[str, Any],
+        started: float,
+    ) -> KnowledgeQueryResult:
+        prepared.timing_ms["total"] = _elapsed_ms(started)
+        return self._query_result(
+            ok=False,
+            query=prepared.query,
+            scope_type=prepared.scope_type,
+            scope_id=prepared.scope_id,
+            answer=self._no_source_answer(),
+            warnings=[*prepared.warnings, "business knowledge oracle client is not configured"],
+            source_count=prepared.source_count,
+            section_count=len(prepared.sections),
+            diagnostics={"timing_ms": prepared.timing_ms, "source_pack": source_pack_diagnostics},
+        )
+
+    def _answer_with_oracle(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        source_pack: str,
+        workflow_context: dict[str, Any] | None,
+    ) -> str:
+        assert self.oracle_client is not None
         answer_started = time.monotonic()
         raw_answer = str(
             self.oracle_client.answer(
                 source_pack=source_pack,
-                query=safe_query,
+                query=prepared.query,
                 workflow_context=workflow_context,
                 max_output_tokens=self.max_output_tokens,
             )
             or ""
         )
-        timing_ms["oracle_answer"] = _elapsed_ms(answer_started)
+        prepared.timing_ms["oracle_answer"] = _elapsed_ms(answer_started)
         self._record_observability_span(
             name="knowledge.oracle_answer",
-            input={"query": safe_query, "scope_type": safe_scope_type, "scope_id": safe_scope_id},
+            input={
+                "query": prepared.query,
+                "scope_type": prepared.scope_type,
+                "scope_id": prepared.scope_id,
+            },
             output={"answer_chars": len(raw_answer)},
-            metadata={"timing_ms": {"oracle_answer": timing_ms["oracle_answer"]}},
+            metadata={"timing_ms": {"oracle_answer": prepared.timing_ms["oracle_answer"]}},
         )
-        timing_ms["total"] = _elapsed_ms(query_started)
+        return raw_answer
+
+    def _successful_query_result(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        raw_answer: str,
+        source_pack_diagnostics: dict[str, Any],
+    ) -> KnowledgeQueryResult:
         answer_extract = _clean_oracle_answer(raw_answer)
-        result = self._query_result(
+        return self._query_result(
             ok=bool(answer_extract),
-            query=safe_query,
-            scope_type=safe_scope_type,
-            scope_id=safe_scope_id,
+            query=prepared.query,
+            scope_type=prepared.scope_type,
+            scope_id=prepared.scope_id,
             answer=KnowledgeQueryAnswer(
-                answer_extract=_trim_text(answer_extract, max_chars=max_chars),
+                answer_extract=_trim_text(answer_extract, max_chars=prepared.max_chars),
             ),
-            warnings=warnings,
-            source_count=source_count,
-            section_count=len(sections),
+            warnings=prepared.warnings,
+            source_count=prepared.source_count,
+            section_count=len(prepared.sections),
             diagnostics={
-                "timing_ms": timing_ms,
+                "timing_ms": prepared.timing_ms,
                 "source_pack": source_pack_diagnostics,
             },
         )
+
+    def _log_query_timing(
+        self,
+        *,
+        prepared: _PreparedQueryScope,
+        source_pack_diagnostics: dict[str, Any],
+    ) -> None:
         logger.info(
             "business_knowledge.query timing customer_id=%s scope_type=%s scope_id=%s total_ms=%s source_pack_ms=%s oracle_answer_ms=%s section_count=%s source_pack_chars=%s",
-            cid,
-            safe_scope_type,
-            safe_scope_id,
-            timing_ms.get("total"),
-            timing_ms.get("source_pack_total"),
-            timing_ms.get("oracle_answer"),
-            len(sections),
+            prepared.customer_id,
+            prepared.scope_type,
+            prepared.scope_id,
+            prepared.timing_ms.get("total"),
+            prepared.timing_ms.get("source_pack_total"),
+            prepared.timing_ms.get("oracle_answer"),
+            len(prepared.sections),
             source_pack_diagnostics.get("chars"),
         )
-        return result
-
-    def _source_pack_for_query(
-        self,
-        *,
-        sections: list[KnowledgeSourceSection],
-        query: str,
-    ) -> str:
-        source_pack, _ = self._source_pack_for_query_with_diagnostics(
-            sections=sections,
-            query=query,
-        )
-        return source_pack
-
-    def _source_pack_for_query_with_diagnostics(
-        self,
-        *,
-        sections: list[KnowledgeSourceSection],
-        query: str,
-    ) -> tuple[str, dict[str, Any]]:
-        started = time.monotonic()
-        timing_ms: dict[str, int] = {}
-        facts_started = time.monotonic()
-        facts = table_facts_from_sections(sections)
-        timing_ms["table_facts"] = _elapsed_ms(facts_started)
-        self._record_observability_span(
-            name="knowledge.table_facts",
-            input={"section_count": len(sections), "query": query},
-            output={"fact_count": len(facts)},
-            metadata={"timing_ms": {"table_facts": timing_ms["table_facts"]}},
-        )
-        if not facts:
-            source_pack = _source_pack_for_sections(sections)
-            timing_ms["source_pack_total"] = _elapsed_ms(started)
-            return source_pack, {
-                "mode": "section_pack",
-                "chars": len(source_pack),
-                "section_count": len(sections),
-                "fact_count": 0,
-                "timing_ms": timing_ms,
-            }
-        intent_started = time.monotonic()
-        intent = self._query_intent(query)
-        timing_ms["intent"] = _elapsed_ms(intent_started)
-        self._record_observability_span(
-            name="knowledge.extract_intent",
-            input={"query": query},
-            output=_safe_intent_diagnostics(intent),
-            metadata={"timing_ms": {"intent": timing_ms["intent"]}},
-        )
-        if intent["mode"] in {"category_overview", "corpus_overview"}:
-            overview_started = time.monotonic()
-            source_pack = table_overview_to_toon(
-                facts,
-                query=query,
-                category_terms=[*intent["target_terms"], *intent["qualifier_terms"]],
-            )
-            source_pack, supplemental_section_count = _with_relevant_non_table_sections(
-                source_pack=source_pack,
-                sections=sections,
-                query=query,
-            )
-            timing_ms["table_overview"] = _elapsed_ms(overview_started)
-            timing_ms["source_pack_total"] = _elapsed_ms(started)
-            return source_pack, {
-                "mode": intent["mode"],
-                "chars": len(source_pack),
-                "section_count": len(sections),
-                "supplemental_section_count": supplemental_section_count,
-                "fact_count": len(facts),
-                "intent": _safe_intent_diagnostics(intent),
-                "timing_ms": timing_ms,
-            }
-        selection_started = time.monotonic()
-        rows = select_table_evidence(
-            facts,
-            query=query,
-            target_terms=intent["target_terms"],
-            qualifier_terms=intent["qualifier_terms"],
-            limit=20,
-        )
-        timing_ms["table_select"] = _elapsed_ms(selection_started)
-        self._record_observability_span(
-            name="knowledge.select_table_evidence",
-            input={"query": query, "fact_count": len(facts)},
-            output={"selected_row_count": len(rows)},
-            metadata={"timing_ms": {"table_select": timing_ms["table_select"]}},
-        )
-        if not rows:
-            overview_started = time.monotonic()
-            source_pack = table_overview_to_toon(
-                facts,
-                query=query,
-                category_terms=[*intent["target_terms"], *intent["qualifier_terms"]],
-            )
-            source_pack, supplemental_section_count = _with_relevant_non_table_sections(
-                source_pack=source_pack,
-                sections=sections,
-                query=query,
-            )
-            timing_ms["table_overview"] = _elapsed_ms(overview_started)
-            timing_ms["source_pack_total"] = _elapsed_ms(started)
-            return source_pack, {
-                "mode": "fallback_overview",
-                "chars": len(source_pack),
-                "section_count": len(sections),
-                "supplemental_section_count": supplemental_section_count,
-                "fact_count": len(facts),
-                "selected_row_count": 0,
-                "intent": _safe_intent_diagnostics(intent),
-                "timing_ms": timing_ms,
-            }
-        evidence_started = time.monotonic()
-        source_pack = table_evidence_to_toon(
-            rows,
-            query=query,
-            target_terms=intent["target_terms"],
-            qualifier_terms=intent["qualifier_terms"],
-        )
-        source_pack, supplemental_section_count = _with_relevant_non_table_sections(
-            source_pack=source_pack,
-            sections=sections,
-            query=query,
-        )
-        timing_ms["table_evidence_pack"] = _elapsed_ms(evidence_started)
-        timing_ms["source_pack_total"] = _elapsed_ms(started)
-        selection_stats = table_evidence_selection_stats(
-            facts,
-            query=query,
-            target_terms=intent["target_terms"],
-            qualifier_terms=intent["qualifier_terms"],
-            limit=20,
-        )
-        return source_pack, {
-            "mode": intent["mode"],
-            "chars": len(source_pack),
-            "section_count": len(sections),
-            "supplemental_section_count": supplemental_section_count,
-            "fact_count": len(facts),
-            "selected_row_count": len(rows),
-            "selection": selection_stats,
-            "intent": _safe_intent_diagnostics(intent),
-            "timing_ms": timing_ms,
-        }
 
     def _query_intent(self, query: str) -> dict[str, Any]:
         extractor = getattr(self.oracle_client, "extract_intent", None)
         if callable(extractor):
             with suppress(Exception):
-                return _clean_query_intent(extractor(query=query), query)
-        return _clean_query_intent({}, query)
+                return clean_query_intent(extractor(query=query), query)
+        return clean_query_intent({}, query)
 
     def preflight_scope(
         self,
@@ -929,33 +485,42 @@ class BusinessKnowledgeService:
             source_rows=source_rows,
             workflow_goal=goal,
         )
-        cached = self._get_preflight_cache(customer_id=cid, cache_key=cache_meta["cache_key"])
-        if cached:
-            diagnostics = _safe_dict(cached.get("diagnostics"))
-            timing_ms = dict(_safe_int_dict(diagnostics.get("timing_ms")))
-            timing_ms["preflight_total"] = _elapsed_ms(started)
-            diagnostics["timing_ms"] = timing_ms
-            diagnostics["cache"] = {**cache_meta, "hit": True}
-            cached["diagnostics"] = diagnostics
-            cached["cache_hit"] = True
-            logger.info(
-                "business_knowledge.preflight cache_hit customer_id=%s scope_type=%s scope_id=%s cache_key=%s preflight_total_ms=%s",
-                cid,
-                safe_scope_type,
-                safe_scope_id,
-                cache_meta["cache_key"],
-                timing_ms.get("preflight_total"),
-            )
-            return cached
-        result = self.query(
+        cached = self._cached_preflight_result(
             customer_id=cid,
             scope_type=safe_scope_type,
             scope_id=safe_scope_id,
-            query=(
-                "Can these source files support this intake workflow? "
-                "Mention only source-backed useful facts and missing gaps. "
-                f"Workflow goal: {goal}"
-            ),
+            cache_meta=cache_meta,
+            started=started,
+        )
+        if cached:
+            return cached
+
+        return self._uncached_preflight_result(
+            customer_id=cid,
+            scope_type=safe_scope_type,
+            scope_id=safe_scope_id,
+            workflow_goal=goal,
+            source_rows=source_rows,
+            cache_meta=cache_meta,
+            started=started,
+        )
+
+    def _uncached_preflight_result(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        workflow_goal: str,
+        source_rows: list[sqlite3.Row],
+        cache_meta: dict[str, Any],
+        started: float,
+    ) -> dict[str, Any]:
+        result = self._query_preflight_scope(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            workflow_goal=workflow_goal,
         )
         derived_only = bool(source_rows) and all(
             str(row["source_kind"]) == "derived_from_media" for row in source_rows
@@ -969,15 +534,90 @@ class BusinessKnowledgeService:
         diagnostics["cache"] = {**cache_meta, "hit": False}
         logger.info(
             "business_knowledge.preflight timing customer_id=%s scope_type=%s scope_id=%s status=%s preflight_total_ms=%s query_total_ms=%s source_pack_ms=%s",
-            cid,
-            safe_scope_type,
-            safe_scope_id,
+            customer_id,
+            scope_type,
+            scope_id,
             "ready" if ready else "needs_better_source",
             timing_ms.get("preflight_total"),
             timing_ms.get("total"),
             timing_ms.get("source_pack_total"),
         )
-        payload = {
+        payload = self._preflight_payload(
+            result=result,
+            ready=ready,
+            derived_only=derived_only,
+            diagnostics=diagnostics,
+        )
+        self._store_preflight_cache(
+            customer_id=customer_id,
+            cache_meta=cache_meta,
+            result=payload,
+        )
+        return payload
+
+    def _cached_preflight_result(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        cache_meta: dict[str, Any],
+        started: float,
+    ) -> dict[str, Any]:
+        cached = self._get_preflight_cache(customer_id=customer_id, cache_key=cache_meta["cache_key"])
+        if not cached:
+            return {}
+
+        diagnostics = _safe_dict(cached.get("diagnostics"))
+        timing_ms = dict(_safe_int_dict(diagnostics.get("timing_ms")))
+        timing_ms["preflight_total"] = _elapsed_ms(started)
+        diagnostics["timing_ms"] = timing_ms
+        diagnostics["cache"] = {**cache_meta, "hit": True}
+        cached["diagnostics"] = diagnostics
+        cached["cache_hit"] = True
+        logger.info(
+            "business_knowledge.preflight cache_hit customer_id=%s scope_type=%s scope_id=%s cache_key=%s preflight_total_ms=%s",
+            customer_id,
+            scope_type,
+            scope_id,
+            cache_meta["cache_key"],
+            timing_ms.get("preflight_total"),
+        )
+        return cached
+
+    def _query_preflight_scope(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        workflow_goal: str,
+    ) -> KnowledgeQueryResult:
+        return self.query(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            query=(
+                "Can these source files support this intake workflow? "
+                "Mention only source-backed useful facts and missing gaps. "
+                f"Workflow goal: {workflow_goal}"
+            ),
+        )
+
+    def _preflight_payload(
+        self,
+        *,
+        result: KnowledgeQueryResult,
+        ready: bool,
+        derived_only: bool,
+        diagnostics: dict[str, Any],
+    ) -> dict[str, Any]:
+        warnings = list(result.warnings)
+        if derived_only:
+            warnings.append(
+                "only media-derived evidence was prepared; exact prices, policies, and service menus need a text/table/document source"
+            )
+        return {
             "ok": ready,
             "status": "ready" if ready else "needs_better_source",
             "source_count": result.source_count,
@@ -985,23 +625,8 @@ class BusinessKnowledgeService:
             "answer_extract": result.answer.answer_extract,
             "diagnostics": diagnostics,
             "cache_hit": False,
-            "warnings": [
-                *result.warnings,
-                *(
-                    [
-                        "only media-derived evidence was prepared; exact prices, policies, and service menus need a text/table/document source"
-                    ]
-                    if derived_only
-                    else []
-                ),
-            ],
+            "warnings": warnings,
         }
-        self._store_preflight_cache(
-            customer_id=cid,
-            cache_meta=cache_meta,
-            result=payload,
-        )
-        return payload
 
     def promote_scope(
         self,
@@ -1018,91 +643,25 @@ class BusinessKnowledgeService:
         source_scope_id = _safe_id(source_scope_id, field="source_scope_id")
         target_scope_id = _safe_id(target_scope_id, field="target_scope_id")
         now = _utc_now_iso()
-        with self._conn() as conn:
-            sources = conn.execute(
-                """
-                SELECT *
-                FROM knowledge_sources
-                WHERE customer_id=? AND scope_type=? AND scope_id=?
-                """,
-                (cid, source_scope_type, source_scope_id),
-            ).fetchall()
-            sections = conn.execute(
-                """
-                SELECT *
-                FROM knowledge_sections
-                WHERE customer_id=? AND scope_type=? AND scope_id=?
-                ORDER BY file_id, sort_order, source_ref
-                """,
-                (cid, source_scope_type, source_scope_id),
-            ).fetchall()
-            conn.execute(
-                "DELETE FROM knowledge_sources WHERE customer_id=? AND scope_type=? AND scope_id=?",
-                (cid, target_scope_type, target_scope_id),
-            )
-            conn.execute(
-                "DELETE FROM knowledge_sections WHERE customer_id=? AND scope_type=? AND scope_id=?",
-                (cid, target_scope_type, target_scope_id),
-            )
-            for row in sources:
-                conn.execute(
-                    """
-                    INSERT INTO knowledge_sources (
-                        customer_id, scope_type, scope_id, file_id, source_hash, filename,
-                        mime_type, status, source_kind, warnings_json, section_count, char_count, indexed_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        cid,
-                        target_scope_type,
-                        target_scope_id,
-                        str(row["file_id"]),
-                        str(row["source_hash"]),
-                        str(row["filename"]),
-                        str(row["mime_type"]),
-                        str(row["status"]),
-                        str(row["source_kind"]),
-                        str(row["warnings_json"]),
-                        int(row["section_count"] or 0),
-                        int(row["char_count"] or 0),
-                        now,
-                    ),
-                )
-            for row in sections:
-                conn.execute(
-                    """
-                    INSERT INTO knowledge_sections (
-                        section_id, customer_id, scope_type, scope_id, file_id, filename,
-                        source_ref, source_kind, content, metadata_json, sort_order, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        new_short_id("knsec"),
-                        cid,
-                        target_scope_type,
-                        target_scope_id,
-                        str(row["file_id"]),
-                        str(row["filename"]),
-                        str(row["source_ref"]),
-                        str(row["source_kind"]),
-                        str(row["content"]),
-                        str(row["metadata_json"]),
-                        int(row["sort_order"] or 0),
-                        now,
-                    ),
-                )
-            conn.commit()
+        source_count, section_count = self.repository.promote_scope(
+            customer_id=cid,
+            source_scope_type=source_scope_type,
+            source_scope_id=source_scope_id,
+            target_scope_type=target_scope_type,
+            target_scope_id=target_scope_id,
+            indexed_at=now,
+        )
         return {
             "ok": True,
-            "source_count": len(sources),
-            "section_count": len(sections),
+            "source_count": source_count,
+            "section_count": section_count,
             "target_scope_type": target_scope_type,
             "target_scope_id": target_scope_id,
             "index": {
                 "engine": "knowledge_oracle",
                 "model": self.oracle_model,
-                "source_count": len(sources),
-                "section_count": len(sections),
+                "source_count": source_count,
+                "section_count": section_count,
             },
         }
 
@@ -1136,27 +695,6 @@ class BusinessKnowledgeService:
     def _no_source_answer(self) -> KnowledgeQueryAnswer:
         return KnowledgeQueryAnswer(answer_extract="")
 
-    def _get_source_row(
-        self,
-        *,
-        customer_id: str,
-        scope_type: str,
-        scope_id: str,
-        file_id: str,
-    ) -> sqlite3.Row | None:
-        with self._conn() as conn:
-            return cast(
-                "sqlite3.Row | None",
-                conn.execute(
-                    """
-                    SELECT *
-                    FROM knowledge_sources
-                    WHERE customer_id=? AND scope_type=? AND scope_id=? AND file_id=?
-                    """,
-                    (customer_id, scope_type, scope_id, file_id),
-                ).fetchone(),
-            )
-
     def _load_sections(
         self,
         *,
@@ -1164,30 +702,11 @@ class BusinessKnowledgeService:
         scope_type: str,
         scope_id: str,
     ) -> list[KnowledgeSourceSection]:
-        with self._conn() as conn:
-            rows = conn.execute(
-                """
-                SELECT *
-                FROM knowledge_sections
-                WHERE customer_id=? AND scope_type=? AND scope_id=?
-                ORDER BY file_id, sort_order, source_ref, section_id
-                """,
-                (customer_id, scope_type, scope_id),
-            ).fetchall()
-        return [
-            KnowledgeSourceSection(
-                content=str(row["content"]),
-                source_ref=str(row["source_ref"]),
-                source_kind=str(row["source_kind"]),
-                metadata={
-                    "file_id": str(row["file_id"]),
-                    "filename": str(row["filename"]),
-                    **_json_loads_dict(row["metadata_json"]),
-                },
-                sort_order=int(row["sort_order"] or 0),
-            )
-            for row in rows
-        ]
+        return self.repository.load_sections(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        )
 
     def _scope_warnings(
         self,
@@ -1196,34 +715,18 @@ class BusinessKnowledgeService:
         scope_type: str,
         scope_id: str,
     ) -> list[str]:
-        with self._conn() as conn:
-            rows = conn.execute(
-                """
-                SELECT warnings_json, status, filename
-                FROM knowledge_sources
-                WHERE customer_id=? AND scope_type=? AND scope_id=?
-                ORDER BY filename
-                """,
-                (customer_id, scope_type, scope_id),
-            ).fetchall()
-        warnings: list[str] = []
-        for row in rows:
-            warnings.extend(_safe_list_json(row["warnings_json"]))
-            if str(row["status"]) != "indexed":
-                warnings.append(f"{row['filename']}: {row['status']}")
-        return _unique_strings(warnings)
+        return self.repository.scope_warnings(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        )
 
     def _scope_source_count(self, *, customer_id: str, scope_type: str, scope_id: str) -> int:
-        with self._conn() as conn:
-            row = conn.execute(
-                """
-                SELECT COUNT(*) AS count
-                FROM knowledge_sources
-                WHERE customer_id=? AND scope_type=? AND scope_id=?
-                """,
-                (customer_id, scope_type, scope_id),
-            ).fetchone()
-        return int((row or {})["count"] or 0) if row is not None else 0
+        return self.repository.scope_source_count(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        )
 
     def _preflight_cache_meta(
         self,
@@ -1248,7 +751,7 @@ class BusinessKnowledgeService:
         workflow_goal_hash = _hash_json(str(workflow_goal or "").strip())
         cache_key = _hash_json(
             {
-                "cache_version": _KNOWLEDGE_PREFLIGHT_CACHE_VERSION,
+                "cache_version": KNOWLEDGE_PREFLIGHT_CACHE_VERSION,
                 "customer_id": customer_id,
                 "source_signature": source_signature,
                 "workflow_goal_hash": workflow_goal_hash,
@@ -1258,7 +761,7 @@ class BusinessKnowledgeService:
         )
         return {
             "cache_key": cache_key,
-            "cache_version": _KNOWLEDGE_PREFLIGHT_CACHE_VERSION,
+            "cache_version": KNOWLEDGE_PREFLIGHT_CACHE_VERSION,
             "source_signature": source_signature,
             "workflow_goal_hash": workflow_goal_hash,
             "oracle_model": self.oracle_model,
@@ -1267,18 +770,7 @@ class BusinessKnowledgeService:
         }
 
     def _get_preflight_cache(self, *, customer_id: str, cache_key: str) -> dict[str, Any]:
-        with self._conn() as conn:
-            row = conn.execute(
-                """
-                SELECT result_json
-                FROM knowledge_preflight_cache
-                WHERE customer_id=? AND cache_key=? AND cache_version=?
-                """,
-                (customer_id, cache_key, _KNOWLEDGE_PREFLIGHT_CACHE_VERSION),
-            ).fetchone()
-        if row is None:
-            return {}
-        return _json_loads_dict(row["result_json"])
+        return self.repository.get_preflight_cache(customer_id=customer_id, cache_key=cache_key)
 
     def _store_preflight_cache(
         self,
@@ -1287,298 +779,34 @@ class BusinessKnowledgeService:
         cache_meta: dict[str, Any],
         result: dict[str, Any],
     ) -> None:
-        now = _utc_now_iso()
-        with self._conn() as conn:
-            conn.execute(
-                """
-                INSERT INTO knowledge_preflight_cache (
-                    customer_id, cache_key, cache_version, source_signature,
-                    workflow_goal_hash, oracle_model, file_ids_json, result_json,
-                    created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(customer_id, cache_key) DO UPDATE SET
-                    source_signature=excluded.source_signature,
-                    workflow_goal_hash=excluded.workflow_goal_hash,
-                    oracle_model=excluded.oracle_model,
-                    file_ids_json=excluded.file_ids_json,
-                    result_json=excluded.result_json,
-                    updated_at=excluded.updated_at
-                """,
-                (
-                    customer_id,
-                    str(cache_meta.get("cache_key", "") or ""),
-                    int(cache_meta.get("cache_version") or _KNOWLEDGE_PREFLIGHT_CACHE_VERSION),
-                    str(cache_meta.get("source_signature", "") or ""),
-                    str(cache_meta.get("workflow_goal_hash", "") or ""),
-                    str(cache_meta.get("oracle_model", "") or ""),
-                    _json_dumps(_safe_text_list(cache_meta.get("file_ids"))),
-                    _json_dumps(result),
-                    now,
-                    now,
-                ),
-            )
-            conn.commit()
+        self.repository.store_preflight_cache(
+            customer_id=customer_id,
+            cache_meta=cache_meta,
+            result=result,
+            now=_utc_now_iso(),
+        )
 
     def _source_rows(self, *, customer_id: str, scope_type: str, scope_id: str) -> list[sqlite3.Row]:
-        if not scope_id:
-            return []
-        with self._conn() as conn:
-            return list(
-                conn.execute(
-                    """
-                    SELECT *
-                    FROM knowledge_sources
-                    WHERE customer_id=? AND scope_type=? AND scope_id=?
-                    ORDER BY filename
-                    """,
-                    (customer_id, scope_type, scope_id),
-                ).fetchall()
-            )
-
-
-def _oracle_system_prompt() -> str:
-    return (
-        "You are a workflow business knowledge oracle. Answer only from the SOURCE PACK. "
-        "The SOURCE PACK is normalized evidence from user-uploaded files. It may be compact TOON table evidence. "
-        "For TOON evidence, row_label is the original row text and cells contain column/header/value pairs. "
-        "When cells include header_group N, the group numbers are distinct column/header groups from left to right; "
-        "if the query names class, tier, category, option, or group N, use that matching header_group N. "
-        "Duplicate header suffixes like [1] and [2] mean repeated adjacent source columns in spreadsheet order; "
-        "when row_label clearly lists ordered variants, map earlier/later variants to earlier/later duplicate columns. "
-        "If SOURCE PACK mode is overview, summarize available matching services/categories and ask a concise clarifying "
-        "question when an exact price requires a service, variant, class, size, or other qualifier. "
-        "For capability questions, answer yes only if a matching source row supports that capability; otherwise say you need to confirm. "
-        "If the query or workflow context says the latest customer request is outside the configured workflow scope, "
-        "do not answer source facts for that out-of-scope category; return exactly NO_SOURCE. "
-        "If the query is only about cancelling, rescheduling, or correcting an existing booking and no new source-backed business fact is needed, return exactly NO_SOURCE. "
-        "Do not guess, infer unsupported facts, or use outside knowledge. "
-        "If multiple rows support the same requested fact with different values, state the concise distinction instead of choosing silently. "
-        "Return a plain string only: concise but informative facts the intake agent needs, with source refs when useful. "
-        "For broad pricing questions, include the relevant ranges/options and the missing qualifiers needed for an exact answer. "
-        "If the source does not answer the query, return exactly NO_SOURCE. "
-        "If the source is ambiguous, return AMBIGUOUS: followed by one concise clarifying question. "
-        "Stay under 1000 tokens, and prefer much shorter when the answer is narrow."
-    )
-
-
-def _oracle_intent_system_prompt() -> str:
-    return (
-        "Extract structured search intent for local matching over arbitrary business files. "
-        "Return raw JSON only, no markdown. Keys: mode, target_terms, qualifier_terms, ignore_terms. "
-        "mode is one of specific_fact, category_overview, corpus_overview, capability_check. "
-        "target_terms are service/product/item/action names likely found in row labels, headings, or column groups. "
-        "qualifier_terms are variants/classes/sizes/dimensions/locations likely found in headers, row labels, or nearby context. "
-        "Use category_overview or corpus_overview for broad questions asking what exists, what services are offered, "
-        "or price lists for a whole category. Use capability_check for yes/no service availability questions. "
-        "ignore_terms are generic request words that should not drive retrieval. Preserve user wording. Do not answer."
-    )
-
-
-def _openrouter_app_headers(base_url: str) -> dict[str, str]:
-    if "openrouter.ai" not in str(base_url or "").casefold():
-        return {}
-    title = str(os.environ.get("OPENROUTER_APP_TITLE", "")).strip() or _DEFAULT_OPENROUTER_APP_TITLE
-    headers = {"HTTP-Referer": _DEFAULT_OPENROUTER_APP_REFERER}
-    if title:
-        headers["X-OpenRouter-Title"] = title
-    return headers
-
-
-def _oracle_reasoning_control(base_url: str) -> dict[str, Any]:
-    if "openrouter.ai" not in str(base_url or "").casefold():
-        return {}
-    return {"reasoning": {"effort": "none", "exclude": True}}
-
-
-def _oracle_user_prompt(
-    *,
-    source_pack: str,
-    query: str,
-    workflow_context: dict[str, Any] | None,
-) -> str:
-    context = _json_dumps(workflow_context or {})
-    return (
-        f"QUERY:\n{query.strip()}\n\n"
-        f"WORKFLOW_CONTEXT_JSON:\n{context}\n\n"
-        "SOURCE PACK:\n"
-        f"{source_pack}"
-    )
-
-
-def _source_pack_for_sections(sections: list[KnowledgeSourceSection]) -> str:
-    parts: list[str] = []
-    for index, section in enumerate(sections, start=1):
-        metadata = section.metadata if isinstance(section.metadata, dict) else {}
-        filename = str(metadata.get("filename", "") or "source").strip()
-        parts.append(
-            "\n".join(
-                [
-                    f"## Source {index}",
-                    f"source_ref: {section.source_ref}",
-                    f"filename: {filename}",
-                    f"source_kind: {section.source_kind}",
-                    _section_content_for_oracle(section),
-                ]
-            ).strip()
+        return self.repository.source_rows(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
         )
-    return "\n\n".join(parts).strip()
 
-
-def _with_relevant_non_table_sections(
-    *,
-    source_pack: str,
-    sections: list[KnowledgeSourceSection],
-    query: str,
-) -> tuple[str, int]:
-    selected = _select_relevant_non_table_sections(sections=sections, query=query)
-    if not selected:
-        return source_pack, 0
-    supplement = _source_pack_for_sections(selected)
-    if not supplement:
-        return source_pack, 0
-    return "\n\n## Supplemental non-table sources\n\n".join([source_pack, supplement]).strip(), len(selected)
-
-
-def _select_relevant_non_table_sections(
-    *,
-    sections: list[KnowledgeSourceSection],
-    query: str,
-    limit: int = 8,
-) -> list[KnowledgeSourceSection]:
-    candidates = [section for section in sections if section.source_kind != "structured_table"]
-    if not candidates:
-        return []
-    tokens = _query_tokens(query)
-    if not tokens:
-        return candidates[:limit]
-    scored: list[tuple[int, int, str, KnowledgeSourceSection]] = []
-    for section in candidates:
-        metadata = section.metadata if isinstance(section.metadata, dict) else {}
-        haystack = " ".join(
-            [
-                str(section.source_ref or ""),
-                str(section.source_kind or ""),
-                str(metadata.get("filename", "") or ""),
-                str(metadata.get("section_title", "") or ""),
-                str(section.content or ""),
-            ]
+    def _get_source_row(
+        self,
+        *,
+        customer_id: str,
+        scope_type: str,
+        scope_id: str,
+        file_id: str,
+    ) -> sqlite3.Row | None:
+        return self.repository.get_source_row(
+            customer_id=customer_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            file_id=file_id,
         )
-        score = len(tokens & _query_tokens(haystack))
-        if score:
-            scored.append((score, int(section.sort_order or 0), str(section.source_ref), section))
-    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
-    return [item[3] for item in scored[:limit]]
-
-
-def _query_tokens(value: str) -> set[str]:
-    return {
-        token.casefold()
-        for token in re.findall(r"[\w-]+", str(value or ""), flags=re.UNICODE)
-        if len(token.strip()) >= 2
-    }
-
-
-def _section_content_for_oracle(section: KnowledgeSourceSection) -> str:
-    content = str(section.content or "").strip()
-    if section.source_kind != "structured_table":
-        return content
-    lines = content.splitlines()
-    table_lines: list[str] = []
-    for line in lines:
-        if line.startswith(("Workbook:", "Sheet:", "Table:", "Rows:")):
-            table_lines.append(line)
-    cell_rows = _normalized_cell_rows(content)
-    if not cell_rows:
-        return content
-    out = StringIO()
-    writer = csv.writer(out)
-    writer.writerow(["source_ref", "row", "column", "value"])
-    for row in cell_rows:
-        writer.writerow([section.source_ref, *row])
-    return "\n".join([*table_lines, "normalized_csv:", out.getvalue().strip()]).strip()
-
-
-def _normalized_cell_rows(content: str) -> list[tuple[str, str, str]]:
-    rows: list[tuple[str, str, str]] = []
-    for line in content.splitlines():
-        match = re.match(r"Row\s+(\d+):\s*(.*)$", line.strip())
-        if not match:
-            continue
-        row_number = match.group(1)
-        rest = match.group(2)
-        for cell in rest.split(" | "):
-            if "=" not in cell:
-                continue
-            column, value = cell.split("=", 1)
-            column = column.strip()
-            value = value.strip()
-            if column and value:
-                rows.append((row_number, column, value))
-    return rows
-
-
-def _extract_chat_text(payload: Any) -> str:
-    if not isinstance(payload, dict):
-        return ""
-    choices = payload.get("choices")
-    if not isinstance(choices, list) or not choices:
-        return ""
-    first = choices[0]
-    if not isinstance(first, dict):
-        return ""
-    message = first.get("message")
-    if isinstance(message, dict):
-        content = message.get("content")
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            parts = [
-                str(item.get("text", "")).strip()
-                for item in content
-                if isinstance(item, dict) and str(item.get("text", "")).strip()
-            ]
-            return "\n".join(parts)
-    text = first.get("text")
-    return str(text or "")
-
-
-def _parse_json_object(text: str) -> dict[str, Any]:
-    raw = str(text or "").strip()
-    raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE).strip()
-    raw = re.sub(r"\s*```$", "", raw).strip()
-    with suppress(Exception):
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else {}
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start >= 0 and end > start:
-        with suppress(Exception):
-            parsed = json.loads(raw[start : end + 1])
-            return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
-def _clean_query_intent(value: Any, query: str) -> dict[str, Any]:
-    parsed = value if isinstance(value, dict) else {}
-    mode = str(parsed.get("mode", "") or "").strip().lower()
-    if mode not in {"specific_fact", "category_overview", "corpus_overview", "capability_check"}:
-        mode = "specific_fact"
-    intent = {
-        "mode": mode,
-        "target_terms": _safe_text_list(parsed.get("target_terms")),
-        "qualifier_terms": _safe_text_list(parsed.get("qualifier_terms")),
-        "ignore_terms": _safe_text_list(parsed.get("ignore_terms")),
-    }
-    if not intent["target_terms"]:
-        intent["target_terms"] = [str(query or "").strip()]
-    return intent
-
-
-def _safe_text_list(value: Any) -> list[str]:
-    if isinstance(value, list):
-        return _unique_strings([str(item).strip() for item in value if str(item).strip()])
-    text = str(value or "").strip()
-    return [text] if text else []
 
 
 def _clean_oracle_answer(text: str) -> str:
@@ -1624,14 +852,6 @@ def query_result_payload(result: KnowledgeQueryResult) -> dict[str, Any]:
         "cached": result.cached,
         "diagnostics": result.diagnostics,
     }
-
-
-def _safe_list_json(value: Any) -> list[str]:
-    with suppress(Exception):
-        parsed = json.loads(str(value or "[]"))
-        if isinstance(parsed, list):
-            return [str(item).strip() for item in parsed if str(item).strip()]
-    return []
 
 
 def _unique_strings(values: Any) -> list[str]:

--- a/src/opentulpa/business_knowledge/source_pack_planner.py
+++ b/src/opentulpa/business_knowledge/source_pack_planner.py
@@ -1,0 +1,371 @@
+"""Business knowledge source-pack planning."""
+
+from __future__ import annotations
+
+import csv
+import re
+import time
+from collections.abc import Callable
+from io import StringIO
+from typing import Any
+
+from opentulpa.business_knowledge.models import KnowledgeSourceSection
+from opentulpa.business_knowledge.table_normalizer import (
+    select_table_evidence,
+    table_evidence_selection_stats,
+    table_evidence_to_toon,
+    table_facts_from_sections,
+    table_overview_to_toon,
+)
+
+IntentExtractor = Callable[[str], dict[str, Any]]
+SpanRecorder = Callable[..., None]
+
+
+class BusinessKnowledgeSourcePackPlanner:
+    """Selects compact source evidence for one business-knowledge query."""
+
+    def __init__(
+        self,
+        *,
+        extract_intent: IntentExtractor,
+        record_span: SpanRecorder,
+    ) -> None:
+        self._extract_intent = extract_intent
+        self._record_span = record_span
+
+    def plan(
+        self,
+        *,
+        sections: list[KnowledgeSourceSection],
+        query: str,
+    ) -> tuple[str, dict[str, Any]]:
+        started = time.monotonic()
+        timing_ms: dict[str, int] = {}
+        facts = self._table_facts(sections=sections, query=query, timing_ms=timing_ms)
+        if not facts:
+            return _section_pack(sections=sections, started=started, timing_ms=timing_ms)
+
+        intent = self._query_intent(query=query, timing_ms=timing_ms)
+        if intent["mode"] in {"category_overview", "corpus_overview"}:
+            return _overview_pack(
+                sections=sections,
+                facts=facts,
+                query=query,
+                intent=intent,
+                started=started,
+                timing_ms=timing_ms,
+                mode=str(intent["mode"]),
+            )
+
+        rows = self._select_table_rows(
+            facts=facts,
+            query=query,
+            intent=intent,
+            timing_ms=timing_ms,
+        )
+        if not rows:
+            return _overview_pack(
+                sections=sections,
+                facts=facts,
+                query=query,
+                intent=intent,
+                started=started,
+                timing_ms=timing_ms,
+                mode="fallback_overview",
+                selected_row_count=0,
+            )
+
+        return _evidence_pack(
+            sections=sections,
+            facts=facts,
+            query=query,
+            intent=intent,
+            rows=rows,
+            started=started,
+            timing_ms=timing_ms,
+        )
+
+    def _table_facts(
+        self,
+        *,
+        sections: list[KnowledgeSourceSection],
+        query: str,
+        timing_ms: dict[str, int],
+    ) -> list[Any]:
+        facts_started = time.monotonic()
+        facts = table_facts_from_sections(sections)
+        timing_ms["table_facts"] = _elapsed_ms(facts_started)
+        self._record_span(
+            name="knowledge.table_facts",
+            input={"section_count": len(sections), "query": query},
+            output={"fact_count": len(facts)},
+            metadata={"timing_ms": {"table_facts": timing_ms["table_facts"]}},
+        )
+        return facts
+
+    def _query_intent(self, *, query: str, timing_ms: dict[str, int]) -> dict[str, Any]:
+        intent_started = time.monotonic()
+        intent = self._extract_intent(query)
+        timing_ms["intent"] = _elapsed_ms(intent_started)
+        self._record_span(
+            name="knowledge.extract_intent",
+            input={"query": query},
+            output=safe_intent_diagnostics(intent),
+            metadata={"timing_ms": {"intent": timing_ms["intent"]}},
+        )
+        return intent
+
+    def _select_table_rows(
+        self,
+        *,
+        facts: list[Any],
+        query: str,
+        intent: dict[str, Any],
+        timing_ms: dict[str, int],
+    ) -> list[Any]:
+        selection_started = time.monotonic()
+        rows = select_table_evidence(
+            facts,
+            query=query,
+            target_terms=intent["target_terms"],
+            qualifier_terms=intent["qualifier_terms"],
+            limit=20,
+        )
+        timing_ms["table_select"] = _elapsed_ms(selection_started)
+        self._record_span(
+            name="knowledge.select_table_evidence",
+            input={"query": query, "fact_count": len(facts)},
+            output={"selected_row_count": len(rows)},
+            metadata={"timing_ms": {"table_select": timing_ms["table_select"]}},
+        )
+        return rows
+
+
+def _section_pack(
+    *,
+    sections: list[KnowledgeSourceSection],
+    started: float,
+    timing_ms: dict[str, int],
+) -> tuple[str, dict[str, Any]]:
+    source_pack = source_pack_for_sections(sections)
+    timing_ms["source_pack_total"] = _elapsed_ms(started)
+    return source_pack, {
+        "mode": "section_pack",
+        "chars": len(source_pack),
+        "section_count": len(sections),
+        "fact_count": 0,
+        "timing_ms": timing_ms,
+    }
+
+
+def _overview_pack(
+    *,
+    sections: list[KnowledgeSourceSection],
+    facts: list[Any],
+    query: str,
+    intent: dict[str, Any],
+    started: float,
+    timing_ms: dict[str, int],
+    mode: str,
+    selected_row_count: int | None = None,
+) -> tuple[str, dict[str, Any]]:
+    overview_started = time.monotonic()
+    source_pack = table_overview_to_toon(
+        facts,
+        query=query,
+        category_terms=[*intent["target_terms"], *intent["qualifier_terms"]],
+    )
+    source_pack, supplemental_section_count = with_relevant_non_table_sections(
+        source_pack=source_pack,
+        sections=sections,
+        query=query,
+    )
+    timing_ms["table_overview"] = _elapsed_ms(overview_started)
+    timing_ms["source_pack_total"] = _elapsed_ms(started)
+    diagnostics: dict[str, Any] = {
+        "mode": mode,
+        "chars": len(source_pack),
+        "section_count": len(sections),
+        "supplemental_section_count": supplemental_section_count,
+        "fact_count": len(facts),
+        "intent": safe_intent_diagnostics(intent),
+        "timing_ms": timing_ms,
+    }
+    if selected_row_count is not None:
+        diagnostics["selected_row_count"] = selected_row_count
+    return source_pack, diagnostics
+
+
+def _evidence_pack(
+    *,
+    sections: list[KnowledgeSourceSection],
+    facts: list[Any],
+    query: str,
+    intent: dict[str, Any],
+    rows: list[Any],
+    started: float,
+    timing_ms: dict[str, int],
+) -> tuple[str, dict[str, Any]]:
+    evidence_started = time.monotonic()
+    source_pack = table_evidence_to_toon(
+        rows,
+        query=query,
+        target_terms=intent["target_terms"],
+        qualifier_terms=intent["qualifier_terms"],
+    )
+    source_pack, supplemental_section_count = with_relevant_non_table_sections(
+        source_pack=source_pack,
+        sections=sections,
+        query=query,
+    )
+    timing_ms["table_evidence_pack"] = _elapsed_ms(evidence_started)
+    timing_ms["source_pack_total"] = _elapsed_ms(started)
+    selection_stats = table_evidence_selection_stats(
+        facts,
+        query=query,
+        target_terms=intent["target_terms"],
+        qualifier_terms=intent["qualifier_terms"],
+        limit=20,
+    )
+    return source_pack, {
+        "mode": intent["mode"],
+        "chars": len(source_pack),
+        "section_count": len(sections),
+        "supplemental_section_count": supplemental_section_count,
+        "fact_count": len(facts),
+        "selected_row_count": len(rows),
+        "selection": selection_stats,
+        "intent": safe_intent_diagnostics(intent),
+        "timing_ms": timing_ms,
+    }
+
+
+def source_pack_for_sections(sections: list[KnowledgeSourceSection]) -> str:
+    parts: list[str] = []
+    for index, section in enumerate(sections, start=1):
+        metadata = section.metadata if isinstance(section.metadata, dict) else {}
+        filename = str(metadata.get("filename", "") or "source").strip()
+        parts.append(
+            "\n".join(
+                [
+                    f"## Source {index}",
+                    f"source_ref: {section.source_ref}",
+                    f"filename: {filename}",
+                    f"source_kind: {section.source_kind}",
+                    section_content_for_oracle(section),
+                ]
+            ).strip()
+        )
+    return "\n\n".join(parts).strip()
+
+
+def with_relevant_non_table_sections(
+    *,
+    source_pack: str,
+    sections: list[KnowledgeSourceSection],
+    query: str,
+) -> tuple[str, int]:
+    selected = select_relevant_non_table_sections(sections=sections, query=query)
+    if not selected:
+        return source_pack, 0
+    supplement = source_pack_for_sections(selected)
+    if not supplement:
+        return source_pack, 0
+    return "\n\n## Supplemental non-table sources\n\n".join([source_pack, supplement]).strip(), len(selected)
+
+
+def select_relevant_non_table_sections(
+    *,
+    sections: list[KnowledgeSourceSection],
+    query: str,
+    limit: int = 8,
+) -> list[KnowledgeSourceSection]:
+    candidates = [section for section in sections if section.source_kind != "structured_table"]
+    if not candidates:
+        return []
+    tokens = query_tokens(query)
+    if not tokens:
+        return candidates[:limit]
+    scored: list[tuple[int, int, str, KnowledgeSourceSection]] = []
+    for section in candidates:
+        metadata = section.metadata if isinstance(section.metadata, dict) else {}
+        haystack = " ".join(
+            [
+                str(section.source_ref or ""),
+                str(section.source_kind or ""),
+                str(metadata.get("filename", "") or ""),
+                str(metadata.get("section_title", "") or ""),
+                str(section.content or ""),
+            ]
+        )
+        score = len(tokens & query_tokens(haystack))
+        if score:
+            scored.append((score, int(section.sort_order or 0), str(section.source_ref), section))
+    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+    return [item[3] for item in scored[:limit]]
+
+
+def query_tokens(value: str) -> set[str]:
+    return {
+        token.casefold()
+        for token in re.findall(r"[\w-]+", str(value or ""), flags=re.UNICODE)
+        if len(token.strip()) >= 2
+    }
+
+
+def section_content_for_oracle(section: KnowledgeSourceSection) -> str:
+    content = str(section.content or "").strip()
+    if section.source_kind != "structured_table":
+        return content
+    lines = content.splitlines()
+    table_lines: list[str] = []
+    for line in lines:
+        if line.startswith(("Workbook:", "Sheet:", "Table:", "Rows:")):
+            table_lines.append(line)
+    cell_rows = normalized_cell_rows(content)
+    if not cell_rows:
+        return content
+    out = StringIO()
+    writer = csv.writer(out)
+    writer.writerow(["source_ref", "row", "column", "value"])
+    for row in cell_rows:
+        writer.writerow([section.source_ref, *row])
+    return "\n".join([*table_lines, "normalized_csv:", out.getvalue().strip()]).strip()
+
+
+def normalized_cell_rows(content: str) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for line in content.splitlines():
+        match = re.match(r"Row\s+(\d+):\s*(.*)$", line.strip())
+        if not match:
+            continue
+        row_number = match.group(1)
+        rest = match.group(2)
+        for cell in rest.split(" | "):
+            if "=" not in cell:
+                continue
+            column, value = cell.split("=", 1)
+            column = column.strip()
+            value = value.strip()
+            if column and value:
+                rows.append((row_number, column, value))
+    return rows
+
+
+def safe_intent_diagnostics(intent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "mode": str(intent.get("mode", "") or ""),
+        "target_term_count": len(_safe_text_list(intent.get("target_terms"))),
+        "qualifier_term_count": len(_safe_text_list(intent.get("qualifier_terms"))),
+    }
+
+
+def _safe_text_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.monotonic() - started) * 1000)

--- a/src/opentulpa/context/file_vault.py
+++ b/src/opentulpa/context/file_vault.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import re
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
@@ -14,6 +12,7 @@ from xml.etree import ElementTree
 from zipfile import BadZipFile, ZipFile
 
 from opentulpa.core.ids import new_short_id
+from opentulpa.persistence.sqlite import connect_sqlite
 
 
 def _utc_now_iso() -> str:

--- a/src/opentulpa/context/link_aliases.py
+++ b/src/opentulpa/context/link_aliases.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import re
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from opentulpa.core.ids import new_short_id
+from opentulpa.persistence.sqlite import connect_sqlite
 
 _HTTP_URL_RE = re.compile(r"https?://[^\s<>'\"`]+", re.IGNORECASE)
 _LINK_ID_RE = re.compile(r"\blink_[A-Za-z0-9]{4,12}\b")

--- a/src/opentulpa/context/service.py
+++ b/src/opentulpa/context/service.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from opentulpa.persistence.sqlite import connect_sqlite
 
 
 class EventContextService:
@@ -70,7 +70,7 @@ class EventContextService:
                 ),
             )
             conn.commit()
-            return int(cur.lastrowid)
+            return int(cur.lastrowid or 0)
 
     def list_events(self, customer_id: str, *, limit: int = 20) -> list[dict[str, Any]]:
         cid = str(customer_id or "").strip()
@@ -123,4 +123,3 @@ class EventContextService:
                 )
             conn.commit()
             return int(cur.rowcount or 0)
-

--- a/src/opentulpa/context/thread_rollups.py
+++ b/src/opentulpa/context/thread_rollups.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from opentulpa.persistence.sqlite import connect_sqlite
 
 
 class ThreadRollupService:

--- a/src/opentulpa/core/debug_logs.py
+++ b/src/opentulpa/core/debug_logs.py
@@ -19,7 +19,7 @@ ProcessOutputEventCallback = Callable[[dict[str, Any]], None]
 _PROCESS_OUTPUT_EVENT_STATE = threading.local()
 
 
-class _ProcessOutputTee(io.TextIOBase):
+class _ProcessOutputTee:
     def __init__(
         self,
         wrapped: Any,
@@ -43,7 +43,7 @@ class _ProcessOutputTee(io.TextIOBase):
         return str(getattr(self._wrapped, "errors", None) or "replace")
 
     def fileno(self) -> int:
-        return self._wrapped.fileno()
+        return int(self._wrapped.fileno())
 
     def isatty(self) -> bool:
         return bool(getattr(self._wrapped, "isatty", lambda: False)())

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -16,6 +16,13 @@ from typing import Any
 
 from opentulpa.context.file_vault import FileVaultService
 from opentulpa.core.ids import new_short_id
+from opentulpa.intake.workflow_boundaries import (
+    DECISION_BOOKING_ACTIONS,
+    BookingTargetResolution,
+    ConversationCursorSignals,
+    DecisionActions,
+    WorkflowRunAccumulator,
+)
 from opentulpa.intake.workflow_skill import build_intake_workflow_skill, workflow_skill_name
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
 from opentulpa.persistence.sqlite import connect_sqlite
@@ -2907,17 +2914,14 @@ class IntakeWorkflowService:
                 "summary": source_error,
             }
 
-        processed = 0
-        matched = 0
-        saved_notifications: list[str] = []
-        errors: list[str] = []
-        result_items: list[dict[str, Any]] = []
+        run_state = WorkflowRunAccumulator()
         for item in items:
             conversation_summary = self._enrich_conversation_summary(
                 workflow=workflow,
                 conversation_summary=_safe_dict(item),
             )
-            conversation_id = str(conversation_summary.get("conversation_id", "") or "").strip()
+            signals = ConversationCursorSignals.from_summary(conversation_summary)
+            conversation_id = signals.conversation_id
             if not conversation_id:
                 continue
             async with self._conversation_lock(
@@ -2940,7 +2944,7 @@ class IntakeWorkflowService:
                         conversation_summary=conversation_summary,
                     )
                     if refresh_error:
-                        errors.append(f"{conversation_id}: {refresh_error}")
+                        run_state.errors.append(f"{conversation_id}: {refresh_error}")
                         self._emit_observability(
                             event="intake.conversation.error",
                             workflow=workflow,
@@ -2950,18 +2954,7 @@ class IntakeWorkflowService:
                         )
                         continue
 
-                latest_inbound_id = str(
-                    conversation_summary.get("latest_inbound_message_id", "") or ""
-                ).strip()
-                latest_inbound_time = str(
-                    conversation_summary.get("latest_inbound_message_created_time", "") or ""
-                ).strip()
-                conversation_updated_time = str(
-                    conversation_summary.get("conversation_updated_time", "") or ""
-                ).strip()
-                latest_outbound_id = str(
-                    conversation_summary.get("latest_outbound_message_id", "") or ""
-                ).strip()
+                signals = ConversationCursorSignals.from_summary(conversation_summary)
                 cursor = self._get_cursor(
                     workflow_id=str(workflow["workflow_id"]),
                     conversation_id=conversation_id,
@@ -2982,14 +2975,14 @@ class IntakeWorkflowService:
                     self._set_cursor(
                         workflow_id=str(workflow["workflow_id"]),
                         conversation_id=conversation_id,
-                        latest_inbound_message_id=latest_inbound_id,
-                        latest_inbound_message_time=latest_inbound_time,
-                        conversation_updated_time=conversation_updated_time,
-                        latest_outbound_message_id=latest_outbound_id,
+                        latest_inbound_message_id=signals.latest_inbound_message_id,
+                        latest_inbound_message_time=signals.latest_inbound_message_time,
+                        conversation_updated_time=signals.conversation_updated_time,
+                        latest_outbound_message_id=signals.latest_outbound_message_id,
                     )
                     continue
 
-                processed += 1
+                run_state.processed += 1
                 self._emit_observability(
                     event="intake.conversation.start",
                     workflow=workflow,
@@ -3013,7 +3006,7 @@ class IntakeWorkflowService:
                     detail_error = str(exc)
                 if detail_error:
                     error_text = str(detail_error)
-                    errors.append(f"{conversation_id}: {error_text}")
+                    run_state.errors.append(f"{conversation_id}: {error_text}")
                     self._emit_observability(
                         event="intake.conversation.error",
                         workflow=workflow,
@@ -3027,16 +3020,7 @@ class IntakeWorkflowService:
                     workflow=workflow,
                     conversation_summary=detailed_summary or conversation_summary,
                 )
-                latest_inbound_id = str(cursor_summary.get("latest_inbound_message_id", "") or "").strip()
-                latest_inbound_time = str(
-                    cursor_summary.get("latest_inbound_message_created_time", "") or ""
-                ).strip()
-                conversation_updated_time = str(
-                    cursor_summary.get("conversation_updated_time", "") or ""
-                ).strip()
-                latest_outbound_id = str(
-                    cursor_summary.get("latest_outbound_message_id", "") or ""
-                ).strip()
+                signals = ConversationCursorSignals.from_summary(cursor_summary)
                 active_booking = self._get_active_booking(
                     customer_id=str(workflow["customer_id"]),
                     workflow_id=str(workflow["workflow_id"]),
@@ -3055,7 +3039,7 @@ class IntakeWorkflowService:
                     recent_completed_booking=recent_completed_booking,
                 )
                 if error:
-                    errors.append(f"{conversation_id}: {error}")
+                    run_state.errors.append(f"{conversation_id}: {error}")
                     self._emit_observability(
                         event="intake.conversation.error",
                         workflow=workflow,
@@ -3100,7 +3084,7 @@ class IntakeWorkflowService:
                                 matched=effective_matches,
                             )
                             if stale_result is not None:
-                                result_items.append(stale_result)
+                                run_state.result_items.append(stale_result)
                                 skip_conversation = True
                             break
                         self._emit_observability(
@@ -3122,7 +3106,7 @@ class IntakeWorkflowService:
                             detail_error = str(exc)
                         if detail_error:
                             error_text = str(detail_error)
-                            errors.append(f"{conversation_id}: {error_text}")
+                            run_state.errors.append(f"{conversation_id}: {error_text}")
                             self._emit_observability(
                                 event="intake.conversation.error",
                                 workflow=workflow,
@@ -3136,18 +3120,7 @@ class IntakeWorkflowService:
                             workflow=workflow,
                             conversation_summary=detailed_summary or latest_summary,
                         )
-                        latest_inbound_id = str(
-                            cursor_summary.get("latest_inbound_message_id", "") or ""
-                        ).strip()
-                        latest_inbound_time = str(
-                            cursor_summary.get("latest_inbound_message_created_time", "") or ""
-                        ).strip()
-                        conversation_updated_time = str(
-                            cursor_summary.get("conversation_updated_time", "") or ""
-                        ).strip()
-                        latest_outbound_id = str(
-                            cursor_summary.get("latest_outbound_message_id", "") or ""
-                        ).strip()
+                        signals = ConversationCursorSignals.from_summary(cursor_summary)
                         active_booking = self._get_active_booking(
                             customer_id=str(workflow["customer_id"]),
                             workflow_id=str(workflow["workflow_id"]),
@@ -3166,7 +3139,7 @@ class IntakeWorkflowService:
                             recent_completed_booking=recent_completed_booking,
                         )
                         if error:
-                            errors.append(f"{conversation_id}: {error}")
+                            run_state.errors.append(f"{conversation_id}: {error}")
                             self._emit_observability(
                                 event="intake.conversation.error",
                                 workflow=workflow,
@@ -3212,7 +3185,7 @@ class IntakeWorkflowService:
                                 matched=False,
                             )
                             if stale_result is not None:
-                                result_items.append(stale_result)
+                                run_state.result_items.append(stale_result)
                                 continue
                         self._emit_observability(
                             event="intake.apply.start",
@@ -3235,7 +3208,7 @@ class IntakeWorkflowService:
                             reply_text=reply_text,
                         )
                         if reply_error is not None:
-                            errors.append(f"{conversation_id}: {reply_error}")
+                            run_state.errors.append(f"{conversation_id}: {reply_error}")
                             self._emit_observability(
                                 event="intake.reply.error",
                                 workflow=workflow,
@@ -3269,13 +3242,13 @@ class IntakeWorkflowService:
                         self._set_cursor(
                             workflow_id=str(workflow["workflow_id"]),
                             conversation_id=conversation_id,
-                            latest_inbound_message_id=latest_inbound_id,
-                            latest_inbound_message_time=latest_inbound_time,
-                            conversation_updated_time=conversation_updated_time,
-                            latest_outbound_message_id=latest_outbound_id,
+                            latest_inbound_message_id=signals.latest_inbound_message_id,
+                            latest_inbound_message_time=signals.latest_inbound_message_time,
+                            conversation_updated_time=signals.conversation_updated_time,
+                            latest_outbound_message_id=signals.latest_outbound_message_id,
                             agent_action_at=_utc_now_iso(),
                         )
-                        result_items.append(
+                        run_state.result_items.append(
                             {
                                 "conversation_id": conversation_id,
                                 "matched": False,
@@ -3295,12 +3268,12 @@ class IntakeWorkflowService:
                     self._set_cursor(
                         workflow_id=str(workflow["workflow_id"]),
                         conversation_id=conversation_id,
-                        latest_inbound_message_id=latest_inbound_id,
-                        latest_inbound_message_time=latest_inbound_time,
-                        conversation_updated_time=conversation_updated_time,
-                        latest_outbound_message_id=latest_outbound_id,
+                        latest_inbound_message_id=signals.latest_inbound_message_id,
+                        latest_inbound_message_time=signals.latest_inbound_message_time,
+                        conversation_updated_time=signals.conversation_updated_time,
+                        latest_outbound_message_id=signals.latest_outbound_message_id,
                     )
-                    result_items.append(
+                    run_state.result_items.append(
                         {
                             "conversation_id": conversation_id,
                             "matched": False,
@@ -3316,7 +3289,7 @@ class IntakeWorkflowService:
                     )
                     continue
 
-                matched += 1
+                run_state.matched += 1
                 recovery_feedback: list[dict[str, Any]] = []
                 applied: dict[str, Any] = {}
                 apply_error: str | None = None
@@ -3368,7 +3341,7 @@ class IntakeWorkflowService:
                         apply_error = "recovery decision no longer matches workflow"
                         break
                 if apply_error:
-                    errors.append(f"{conversation_id}: {apply_error}")
+                    run_state.errors.append(f"{conversation_id}: {apply_error}")
                     self._emit_observability(
                         event="intake.conversation.error",
                         workflow=workflow,
@@ -3378,21 +3351,21 @@ class IntakeWorkflowService:
                     )
                     continue
                 if str(applied.get("status", "") or "").strip() in _STALE_TERMINAL_STATUSES:
-                    result_items.append(applied)
+                    run_state.result_items.append(applied)
                     continue
                 self._set_cursor(
                     workflow_id=str(workflow["workflow_id"]),
                     conversation_id=conversation_id,
-                    latest_inbound_message_id=latest_inbound_id,
-                    latest_inbound_message_time=latest_inbound_time,
-                    conversation_updated_time=conversation_updated_time,
-                    latest_outbound_message_id=latest_outbound_id,
+                    latest_inbound_message_id=signals.latest_inbound_message_id,
+                    latest_inbound_message_time=signals.latest_inbound_message_time,
+                    conversation_updated_time=signals.conversation_updated_time,
+                    latest_outbound_message_id=signals.latest_outbound_message_id,
                     agent_action_at=_utc_now_iso(),
                 )
-                result_items.append(applied)
+                run_state.result_items.append(applied)
                 saved_summary = str(applied.get("saved_summary", "") or "").strip()
                 if saved_summary:
-                    saved_notifications.append(saved_summary)
+                    run_state.saved_notifications.append(saved_summary)
                 self._emit_observability(
                     event="intake.conversation.complete",
                     workflow=workflow,
@@ -3403,25 +3376,13 @@ class IntakeWorkflowService:
                     saved_summary=saved_summary,
                 )
 
-        if errors:
-            summary = (
-                f"Workflow {workflow['name']} hit errors: " + " | ".join(errors[:3])
-            )[:2000]
-        elif saved_notifications:
-            summary = "\n".join(saved_notifications[:3])[:2000]
-        else:
-            summary = NO_NOTIFY_TOKEN
-        return {
-            "ok": not errors,
-            "workflow_id": str(workflow["workflow_id"]),
-            "event_type": event_type,
-            "processed_conversations": processed,
-            "matched_conversations": matched,
-            "results": result_items,
-            "errors": errors,
-            "source_warnings": source_warnings,
-            "summary": summary,
-        }
+        return run_state.build_response(
+            workflow=workflow,
+            workflow_id=str(workflow["workflow_id"]),
+            event_type=event_type,
+            source_warnings=source_warnings,
+            empty_summary_token=NO_NOTIFY_TOKEN,
+        )
 
     async def _decide_workflow_action(
         self,
@@ -3621,6 +3582,83 @@ class IntakeWorkflowService:
         )
         return decision, None
 
+    def _emit_apply_decision_validation_error(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+        error: str,
+        booking_action: str,
+        sink_action: str,
+    ) -> None:
+        assert error
+        assert booking_action == booking_action.strip().lower()
+        assert sink_action == sink_action.strip().lower()
+        fields: dict[str, Any] = {}
+        if error.startswith("unsupported sink_action="):
+            fields["sink_action"] = sink_action
+        elif error.startswith("unsupported booking_action="):
+            fields["booking_action"] = booking_action
+        else:
+            fields["booking_action"] = booking_action
+            fields["sink_action"] = sink_action
+        self._emit_observability(
+            event="intake.apply.error",
+            workflow=workflow,
+            conversation_summary=conversation_summary,
+            phase="decision_validation",
+            error=error,
+            **fields,
+        )
+
+    def _resolve_booking_target(
+        self,
+        *,
+        workflow: dict[str, Any],
+        conversation_summary: dict[str, Any],
+        booking_action: str,
+        active_booking: dict[str, Any] | None,
+        recent_completed_booking: dict[str, Any] | None,
+    ) -> BookingTargetResolution:
+        assert booking_action in DECISION_BOOKING_ACTIONS
+        assert booking_action != "ignore"
+        normalized_booking_action = booking_action
+        target_booking: dict[str, Any] | None = None
+        if booking_action == "create_new_booking" and active_booking is not None:
+            normalized_booking_action = "update_active"
+        if normalized_booking_action == "update_active":
+            if active_booking is None:
+                normalized_booking_action = "create_new_booking"
+            else:
+                target_booking = dict(active_booking)
+        elif normalized_booking_action == "edit_recent_completed":
+            if recent_completed_booking is None:
+                normalized_booking_action = "create_new_booking"
+            else:
+                target_booking = dict(recent_completed_booking)
+        if normalized_booking_action == "create_new_booking":
+            target_booking = {
+                "booking_id": new_short_id("bkg"),
+                "workflow_id": workflow["workflow_id"],
+                "customer_id": workflow["customer_id"],
+                "conversation_id": str(conversation_summary.get("conversation_id", "") or ""),
+                "status": "active",
+                "extracted_fields": {},
+                "sink_write_status": "pending",
+                "sink_record_ref": {},
+                "conversation_summary": "",
+                "last_customer_message_at": "",
+                "opened_at": _utc_now_iso(),
+                "completed_at": "",
+                "edit_window_until": "",
+                "created_at": _utc_now_iso(),
+                "updated_at": _utc_now_iso(),
+            }
+        return BookingTargetResolution(
+            booking_action=normalized_booking_action,
+            booking=target_booking,
+        )
+
     async def _apply_decision(
         self,
         *,
@@ -3632,12 +3670,13 @@ class IntakeWorkflowService:
         decision: dict[str, Any],
         stale_guard: bool = False,
     ) -> tuple[dict[str, Any], str | None, dict[str, Any] | None]:
-        booking_action = str(decision.get("booking_action", "ignore") or "ignore").strip().lower()
-        ready_to_save = bool(decision.get("ready_to_save"))
-        reply_action = str(decision.get("reply_action", "none") or "none").strip().lower()
-        reply_text = str(decision.get("reply_text", "") or "").strip()
-        sink_action = str(decision.get("sink_action", "none") or "none").strip().lower()
-        sink_payload = _safe_dict(decision.get("sink_payload"))
+        actions = DecisionActions.from_decision(decision)
+        booking_action = actions.booking_action
+        ready_to_save = actions.ready_to_save
+        reply_action = actions.reply_action
+        reply_text = actions.reply_text
+        sink_action = actions.sink_action
+        sink_payload = actions.sink_payload
         self._emit_observability(
             event="intake.apply.start",
             workflow=workflow,
@@ -3647,55 +3686,18 @@ class IntakeWorkflowService:
             ready_to_save=ready_to_save,
             sink_action=sink_action,
         )
-        if sink_action not in {"none", "upsert_partial"}:
-            error = f"unsupported sink_action={sink_action}"
-            self._emit_observability(
-                event="intake.apply.error",
+        validation_error = actions.validation_error()
+        if validation_error is not None:
+            self._emit_apply_decision_validation_error(
                 workflow=workflow,
                 conversation_summary=conversation_summary,
-                phase="decision_validation",
-                error=error,
-                sink_action=sink_action,
-            )
-            return {}, error, self._build_recovery_feedback(
-                phase="decision_validation",
-                error=error,
-                decision=decision,
-            )
-        if booking_action not in {
-            "ignore",
-            "update_active",
-            "edit_recent_completed",
-            "create_new_booking",
-        }:
-            error = f"unsupported booking_action={booking_action}"
-            self._emit_observability(
-                event="intake.apply.error",
-                workflow=workflow,
-                conversation_summary=conversation_summary,
-                phase="decision_validation",
-                error=error,
-                booking_action=booking_action,
-            )
-            return {}, error, self._build_recovery_feedback(
-                phase="decision_validation",
-                error=error,
-                decision=decision,
-            )
-        if booking_action == "ignore" and sink_action != "none":
-            error = "sink_action requires an active booking action"
-            self._emit_observability(
-                event="intake.apply.error",
-                workflow=workflow,
-                conversation_summary=conversation_summary,
-                phase="decision_validation",
-                error=error,
+                error=validation_error,
                 booking_action=booking_action,
                 sink_action=sink_action,
             )
-            return {}, error, self._build_recovery_feedback(
+            return {}, validation_error, self._build_recovery_feedback(
                 phase="decision_validation",
-                error=error,
+                error=validation_error,
                 decision=decision,
             )
         if booking_action == "ignore":
@@ -3766,38 +3768,14 @@ class IntakeWorkflowService:
                 ignored_result["replied"] = True
             return ignored_result, None, None
 
-        target_booking: dict[str, Any] | None = None
-        normalized_booking_action = booking_action
-        if booking_action == "create_new_booking" and active_booking is not None:
-            normalized_booking_action = "update_active"
-        if normalized_booking_action == "update_active":
-            if active_booking is None:
-                normalized_booking_action = "create_new_booking"
-            else:
-                target_booking = dict(active_booking)
-        elif normalized_booking_action == "edit_recent_completed":
-            if recent_completed_booking is None:
-                normalized_booking_action = "create_new_booking"
-            else:
-                target_booking = dict(recent_completed_booking)
-        if normalized_booking_action == "create_new_booking":
-            target_booking = {
-                "booking_id": new_short_id("bkg"),
-                "workflow_id": workflow["workflow_id"],
-                "customer_id": workflow["customer_id"],
-                "conversation_id": str(conversation_summary.get("conversation_id", "") or ""),
-                "status": "active",
-                "extracted_fields": {},
-                "sink_write_status": "pending",
-                "sink_record_ref": {},
-                "conversation_summary": "",
-                "last_customer_message_at": "",
-                "opened_at": _utc_now_iso(),
-                "completed_at": "",
-                "edit_window_until": "",
-                "created_at": _utc_now_iso(),
-                "updated_at": _utc_now_iso(),
-            }
+        target = self._resolve_booking_target(
+            workflow=workflow,
+            conversation_summary=conversation_summary,
+            booking_action=booking_action,
+            active_booking=active_booking,
+            recent_completed_booking=recent_completed_booking,
+        )
+        target_booking = target.booking
         if target_booking is None:
             error = "workflow decision did not resolve a booking target"
             self._emit_observability(

--- a/src/opentulpa/intake/service.py
+++ b/src/opentulpa/intake/service.py
@@ -2472,10 +2472,10 @@ class IntakeWorkflowService:
         channel = str(workflow.get("channel", "") or "").strip().lower()
         if channel == "telegram_business_dm":
             messages = _safe_list(conversation.get("messages"))
-            normalized: list[dict[str, Any]] = []
+            telegram_normalized: list[dict[str, Any]] = []
             for item in messages:
                 msg = _safe_dict(item)
-                normalized.append(
+                telegram_normalized.append(
                     {
                         "id": str(msg.get("message_id", msg.get("id", "")) or "").strip(),
                         "created_time": str(msg.get("date_iso", msg.get("created_time", "")) or "").strip(),
@@ -2485,8 +2485,8 @@ class IntakeWorkflowService:
                         "text": str(msg.get("text", "") or "").strip(),
                     }
                 )
-            normalized.sort(key=lambda item: str(item.get("created_time", "")))
-            return normalized[-_RECENT_MESSAGE_HISTORY_LIMIT:]
+            telegram_normalized.sort(key=lambda item: str(item.get("created_time", "")))
+            return telegram_normalized[-_RECENT_MESSAGE_HISTORY_LIMIT:]
         payload = _safe_dict(conversation.get("data")) if "data" in conversation else _safe_dict(conversation)
         participants = _safe_list(_safe_dict(payload.get("participants")).get("data"))
         messages = _safe_list(_safe_dict(payload.get("messages")).get("data"))
@@ -2817,6 +2817,8 @@ class IntakeWorkflowService:
         channel = str(workflow.get("channel", "") or "").strip().lower()
         provider = str(workflow.get("provider", "") or "").strip().lower()
         if channel == "instagram_dm" and provider == "composio":
+            if self._composio is None:
+                return {}, {}, "Composio is not configured"
             source_config = _safe_dict(workflow.get("source_config"))
             connected_account_id = str(source_config.get("connected_account_id", "") or "").strip() or None
             try:
@@ -2829,6 +2831,8 @@ class IntakeWorkflowService:
                 return {}, {}, str(exc)
             return _safe_dict(detailed.get("summary")), _safe_dict(detailed.get("conversation")), None
         if channel == "telegram_business_dm" and provider == "telegram_bot_api":
+            if self._telegram_business is None:
+                return {}, {}, "Telegram Business service is not configured"
             source_config = _safe_dict(workflow.get("source_config"))
             business_connection_id = str(source_config.get("business_connection_id", "") or "").strip()
             detailed = self._telegram_business.get_conversation(
@@ -4208,6 +4212,8 @@ class IntakeWorkflowService:
             arguments["reply_to_message_id"] = latest_inbound
         source_config = _safe_dict(workflow.get("source_config"))
         connected_account_id = str(source_config.get("connected_account_id", "") or "").strip() or None
+        if self._composio is None:
+            return "Composio is not configured"
         try:
             result = self._composio.execute_tool(
                 customer_id=str(workflow["customer_id"]),

--- a/src/opentulpa/intake/workflow_boundaries.py
+++ b/src/opentulpa/intake/workflow_boundaries.py
@@ -1,0 +1,129 @@
+"""Typed boundaries for intake workflow execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any
+
+DECISION_BOOKING_ACTIONS = {
+    "ignore",
+    "update_active",
+    "edit_recent_completed",
+    "create_new_booking",
+}
+DECISION_SINK_ACTIONS = {"none", "upsert_partial"}
+
+
+@dataclass(frozen=True)
+class DecisionActions:
+    booking_action: str
+    ready_to_save: bool
+    reply_action: str
+    reply_text: str
+    sink_action: str
+    sink_payload: dict[str, Any]
+
+    @classmethod
+    def from_decision(cls, decision: dict[str, Any]) -> DecisionActions:
+        raw_sink_payload = decision.get("sink_payload")
+        sink_payload: dict[str, Any] = dict(raw_sink_payload) if isinstance(raw_sink_payload, dict) else {}
+        actions = cls(
+            booking_action=str(decision.get("booking_action", "ignore") or "ignore").strip().lower(),
+            ready_to_save=bool(decision.get("ready_to_save")),
+            reply_action=str(decision.get("reply_action", "none") or "none").strip().lower(),
+            reply_text=str(decision.get("reply_text", "") or "").strip(),
+            sink_action=str(decision.get("sink_action", "none") or "none").strip().lower(),
+            sink_payload=sink_payload,
+        )
+        assert actions.booking_action == actions.booking_action.strip().lower()
+        assert actions.reply_action == actions.reply_action.strip().lower()
+        assert actions.sink_action == actions.sink_action.strip().lower()
+        return actions
+
+    def validation_error(self) -> str | None:
+        assert self.booking_action == self.booking_action.strip().lower()
+        assert self.sink_action == self.sink_action.strip().lower()
+        if self.sink_action not in DECISION_SINK_ACTIONS:
+            return f"unsupported sink_action={self.sink_action}"
+        if self.booking_action not in DECISION_BOOKING_ACTIONS:
+            return f"unsupported booking_action={self.booking_action}"
+        if self.booking_action == "ignore" and self.sink_action != "none":
+            return "sink_action requires an active booking action"
+        return None
+
+
+@dataclass(frozen=True)
+class ConversationCursorSignals:
+    conversation_id: str
+    latest_inbound_message_id: str
+    latest_inbound_message_time: str
+    conversation_updated_time: str
+    latest_outbound_message_id: str
+
+    @classmethod
+    def from_summary(cls, conversation_summary: dict[str, Any]) -> ConversationCursorSignals:
+        signals = cls(
+            conversation_id=str(conversation_summary.get("conversation_id", "") or "").strip(),
+            latest_inbound_message_id=str(
+                conversation_summary.get("latest_inbound_message_id", "") or ""
+            ).strip(),
+            latest_inbound_message_time=str(
+                conversation_summary.get("latest_inbound_message_created_time", "") or ""
+            ).strip(),
+            conversation_updated_time=str(
+                conversation_summary.get("conversation_updated_time", "") or ""
+            ).strip(),
+            latest_outbound_message_id=str(
+                conversation_summary.get("latest_outbound_message_id", "") or ""
+            ).strip(),
+        )
+        assert signals.conversation_id == signals.conversation_id.strip()
+        assert signals.latest_inbound_message_id == signals.latest_inbound_message_id.strip()
+        return signals
+
+
+@dataclass
+class WorkflowRunAccumulator:
+    processed: int = 0
+    matched: int = 0
+    saved_notifications: list[str] = dataclass_field(default_factory=list)
+    errors: list[str] = dataclass_field(default_factory=list)
+    result_items: list[dict[str, Any]] = dataclass_field(default_factory=list)
+
+    def build_response(
+        self,
+        *,
+        workflow: dict[str, Any],
+        workflow_id: str,
+        event_type: str,
+        source_warnings: list[dict[str, Any]],
+        empty_summary_token: str,
+    ) -> dict[str, Any]:
+        assert self.processed >= 0
+        assert self.matched >= 0
+        if self.errors:
+            summary = (
+                f"Workflow {workflow['name']} hit errors: " + " | ".join(self.errors[:3])
+            )[:2000]
+        elif self.saved_notifications:
+            summary = "\n".join(self.saved_notifications[:3])[:2000]
+        else:
+            summary = empty_summary_token
+        return {
+            "ok": not self.errors,
+            "workflow_id": workflow_id,
+            "event_type": event_type,
+            "processed_conversations": self.processed,
+            "matched_conversations": self.matched,
+            "results": self.result_items,
+            "errors": self.errors,
+            "source_warnings": source_warnings,
+            "summary": summary,
+        }
+
+
+@dataclass(frozen=True)
+class BookingTargetResolution:
+    booking_action: str
+    booking: dict[str, Any] | None

--- a/src/opentulpa/intake/workflow_setup_store.py
+++ b/src/opentulpa/intake/workflow_setup_store.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
 from opentulpa.core.ids import new_short_id
+from opentulpa.persistence.sqlite import connect_sqlite
 
 SetupSessionStatus = Literal["active", "paused", "completed", "cancelled"]
 SetupSessionMode = Literal["create", "edit"]

--- a/src/opentulpa/integrations/browser_use_local.py
+++ b/src/opentulpa/integrations/browser_use_local.py
@@ -10,18 +10,40 @@ import re
 import shutil
 import time
 from contextlib import suppress
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from opentulpa.core.ids import new_short_id
+from opentulpa.integrations.browser_use_session_registry import (
+    TERMINAL_STATUSES as _TERMINAL_STATUSES,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    BrowserUseSessionRegistry,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    BrowserUseSessionState as _BrowserUseSessionState,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    BrowserUseTaskState as _BrowserUseTaskState,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    normalize_customer_id as _normalize_customer_id,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    normalize_optional_customer_id as _normalize_optional_customer_id,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    safe_profile_name as _safe_profile_name,
+)
+from opentulpa.integrations.browser_use_session_registry import (
+    session_key as _browser_session_key,
+)
 from opentulpa.tasks.sandbox import TULPA_STUFF_DIR
 
 logger = logging.getLogger(__name__)
 
-_TERMINAL_STATUSES = {"finished", "stopped", "failed"}
 _OWNER_WAITING_STATUS = "waiting_for_owner"
 _OWNER_INPUT_TIMEOUT_SECONDS = 24 * 60 * 60
 _SESSION_IDLE_TIMEOUT_SECONDS = 3600
@@ -29,7 +51,6 @@ _SESSION_CLEANUP_POLL_SECONDS = 60.0
 _MAX_BROWSER_USE_SESSIONS = 20
 _SESSION_CLOSE_TIMEOUT_SECONDS = 30
 _DEFAULT_SESSION_ID = "default"
-_DEFAULT_CUSTOMER_ID = "default"
 _PROFILE_RETENTION_SECONDS = 14 * 24 * 60 * 60
 _PROFILE_METADATA_FILE = "profile.json"
 _DEFAULT_BROWSER_MODEL = "google/gemini-3-flash-preview"
@@ -131,48 +152,6 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-@dataclass(slots=True)
-class _BrowserUseTaskState:
-    task_id: str
-    session_id: str | None
-    task: str
-    llm: str
-    customer_id: str = _DEFAULT_CUSTOMER_ID
-    status: str = "queued"
-    is_success: bool | None = None
-    started_at: str | None = None
-    finished_at: str | None = None
-    output: str | None = None
-    output_files: list[dict[str, Any]] = field(default_factory=list)
-    steps: list[dict[str, Any]] = field(default_factory=list)
-    image_candidates: list[dict[str, Any]] = field(default_factory=list)
-    network_image_resources: list[dict[str, Any]] = field(default_factory=list)
-    error: str | None = None
-    created_monotonic: float = field(default_factory=time.monotonic)
-    updated_monotonic: float = field(default_factory=time.monotonic)
-    runner: asyncio.Task[Any] | None = None
-    browser_session: Any = None
-    allow_owner_input: bool = True
-    owner_input_prompt: str | None = None
-    owner_input_type: str | None = None
-    owner_input_requested_at: str | None = None
-    owner_input_future: asyncio.Future[str] | None = None
-    stop_requested: bool = False
-    close_session_when_done: bool = False
-
-
-@dataclass(slots=True)
-class _BrowserUseSessionState:
-    session: Any
-    customer_id: str
-    session_id: str
-    backend: str = "local"
-    cloud_profile_id: str | None = None
-    cloud_browser_session_id: str | None = None
-    live_url: str | None = None
-    updated_monotonic: float = field(default_factory=time.monotonic)
-
-
 class BrowserUseLocalManager:
     """Manage local Browser Use runs with in-memory task/session state."""
 
@@ -213,8 +192,9 @@ class BrowserUseLocalManager:
         self._cloud_session_ids_by_browser_session: dict[int, str] = {}
         self._semaphore = asyncio.Semaphore(max(1, int(max_concurrent_tasks)))
         self._lock = asyncio.Lock()
-        self._tasks: dict[str, _BrowserUseTaskState] = {}
-        self._sessions: dict[str, _BrowserUseSessionState] = {}
+        self._registry = BrowserUseSessionRegistry()
+        self._tasks = self._registry.tasks
+        self._sessions = self._registry.sessions
         self._preflight_checked = False
         self._preflight_error: str | None = None
         self._cleanup_task: asyncio.Task[Any] | None = None
@@ -386,7 +366,7 @@ class BrowserUseLocalManager:
                     self._cloud_session_ids_by_browser_session[id(browser_session)] = (
                         session_state.cloud_browser_session_id
                     )
-                self._sessions[session_key] = session_state
+                self._registry.set_session(session_state)
                 self._write_profile_metadata(
                     customer_id=safe_customer_id,
                     session_id=safe_session_id,
@@ -425,7 +405,7 @@ class BrowserUseLocalManager:
                 name=f"browser_use_local:{task_id}",
             )
             state.runner = runner
-            self._tasks[task_id] = state
+            self._registry.set_task(state)
             self._write_profile_metadata(
                 customer_id=safe_customer_id,
                 session_id=safe_session_id,
@@ -1198,27 +1178,19 @@ class BrowserUseLocalManager:
 
     @staticmethod
     def _safe_profile_name(session_id: str) -> str:
-        value = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(session_id or "").strip())
-        value = value.strip("._-")
-        return value[:80] or "default"
+        return _safe_profile_name(session_id)
 
     @classmethod
     def _normalize_customer_id(cls, customer_id: str | None) -> str:
-        raw = str(customer_id or "").strip()
-        return raw or _DEFAULT_CUSTOMER_ID
+        return _normalize_customer_id(customer_id)
 
     @classmethod
     def _normalize_optional_customer_id(cls, customer_id: str | None) -> str | None:
-        raw = str(customer_id or "").strip()
-        if not raw:
-            return None
-        return raw
+        return _normalize_optional_customer_id(customer_id)
 
     @staticmethod
     def _session_key(customer_id: str, session_id: str) -> str:
-        customer = BrowserUseLocalManager._normalize_customer_id(customer_id)
-        session = BrowserUseLocalManager._safe_profile_name(session_id)
-        return f"{customer}\0{session}"
+        return _browser_session_key(customer_id, session_id)
 
     @classmethod
     def _profile_customer_dir_name(cls, customer_id: str) -> str:
@@ -1333,8 +1305,9 @@ class BrowserUseLocalManager:
         return None, None, BrowserSession
 
     def _state_to_payload(self, state: _BrowserUseTaskState) -> dict[str, Any]:
-        session_state = self._sessions.get(
-            self._session_key(state.customer_id, str(state.session_id or ""))
+        session_state = self._registry.session_state(
+            customer_id=state.customer_id,
+            session_id=state.session_id,
         )
         return {
             "id": state.task_id,
@@ -1407,32 +1380,20 @@ class BrowserUseLocalManager:
 
     def _cleanup_locked(self) -> None:
         now = time.monotonic()
-        expired: list[str] = []
-        for task_id, state in self._tasks.items():
-            if state.status not in _TERMINAL_STATUSES:
-                continue
-            age = now - float(state.updated_monotonic or state.created_monotonic)
-            if age >= self._task_retention_seconds:
-                expired.append(task_id)
-        for task_id in expired:
-            self._tasks.pop(task_id, None)
-
-        expired_sessions: list[str] = []
-        for session_key, session_state in self._sessions.items():
-            if self._session_has_active_tasks_locked(session_state.customer_id, session_state.session_id):
-                continue
-            age = now - float(session_state.updated_monotonic or now)
-            if age >= _SESSION_IDLE_TIMEOUT_SECONDS:
-                expired_sessions.append(session_key)
-        for session_key in expired_sessions:
-            session_state = self._sessions.pop(session_key)
-            if session_state is not None:
-                self._write_profile_metadata(
-                    customer_id=session_state.customer_id,
-                    session_id=session_state.session_id,
-                    status="idle",
-                )
-                asyncio.create_task(self._close_session(session_state.session))
+        self._registry.pop_expired_terminal_tasks(
+            now=now,
+            retention_seconds=self._task_retention_seconds,
+        )
+        for session_state in self._registry.pop_expired_idle_sessions(
+            now=now,
+            idle_timeout_seconds=_SESSION_IDLE_TIMEOUT_SECONDS,
+        ):
+            self._write_profile_metadata(
+                customer_id=session_state.customer_id,
+                session_id=session_state.session_id,
+                status="idle",
+            )
+            asyncio.create_task(self._close_session(session_state.session))
 
         self._delete_stale_profiles_locked()
 
@@ -1465,14 +1426,10 @@ class BrowserUseLocalManager:
         safe_session = str(session_id or "").strip()
         if not safe_session:
             return None
-        for state in self._tasks.values():
-            if state.customer_id != safe_customer:
-                continue
-            if str(state.session_id or "").strip() != safe_session:
-                continue
-            if state.status not in _TERMINAL_STATUSES:
-                return None
-        session_state = self._sessions.pop(self._session_key(safe_customer, safe_session), None)
+        session_state = self._registry.detach_session_if_unused(
+            customer_id=safe_customer,
+            session_id=safe_session,
+        )
         self._write_profile_metadata(
             customer_id=safe_customer,
             session_id=safe_session,
@@ -1485,9 +1442,7 @@ class BrowserUseLocalManager:
         safe_session = str(session_id or "").strip()
         if not safe_session:
             return
-        session_state = self._sessions.get(self._session_key(safe_customer, safe_session))
-        if session_state is not None:
-            session_state.updated_monotonic = time.monotonic()
+        self._registry.touch_session(customer_id=safe_customer, session_id=safe_session)
         self._write_profile_metadata(
             customer_id=safe_customer,
             session_id=safe_session,
@@ -1495,43 +1450,13 @@ class BrowserUseLocalManager:
         )
 
     def _pick_reusable_session_id_locked(self, customer_id: str) -> str | None:
-        safe_customer = self._normalize_customer_id(customer_id)
-        reusable: list[tuple[float, str]] = []
-        for _, session_state in self._sessions.items():
-            if session_state.customer_id != safe_customer:
-                continue
-            if self._session_has_active_tasks_locked(session_state.customer_id, session_state.session_id):
-                continue
-            reusable.append((float(session_state.updated_monotonic or 0.0), session_state.session_id))
-        if not reusable:
-            return None
-        reusable.sort(reverse=True)
-        return reusable[0][1]
+        return self._registry.pick_reusable_session_id(customer_id)
 
     def _live_session_count_for_customer_locked(self, customer_id: str) -> int:
-        safe_customer = self._normalize_customer_id(customer_id)
-        return sum(1 for item in self._sessions.values() if item.customer_id == safe_customer)
+        return self._registry.live_session_count_for_customer(customer_id)
 
     def _session_summaries_locked(self, customer_id: str | None = None) -> list[dict[str, Any]]:
-        safe_customer = self._normalize_customer_id(customer_id)
-        out: list[dict[str, Any]] = []
-        for _, session_state in self._sessions.items():
-            if session_state.customer_id != safe_customer:
-                continue
-            active_task = self._active_task_for_session_locked(
-                session_state.customer_id, session_state.session_id
-            )
-            out.append(
-                {
-                    "session_id": session_state.session_id,
-                    "customer_id": session_state.customer_id,
-                    "reusable": active_task is None,
-                    "active_task_id": active_task.task_id if active_task is not None else None,
-                    "last_used_monotonic": float(session_state.updated_monotonic or 0.0),
-                }
-            )
-        out.sort(key=lambda item: item["last_used_monotonic"], reverse=True)
-        return out
+        return self._registry.session_summaries(customer_id)
 
     def _browser_use_cloud_enabled(self) -> bool:
         return bool(self._browser_use_api_key)
@@ -1561,36 +1486,15 @@ class BrowserUseLocalManager:
         return f"opentulpa-{customer}-{session}"[:100]
 
     def _session_has_active_tasks_locked(self, customer_id: str, session_id: str) -> bool:
-        safe_customer = self._normalize_customer_id(customer_id)
-        safe_session = str(session_id or "").strip()
-        if not safe_session:
-            return False
-        for state in self._tasks.values():
-            if state.customer_id != safe_customer:
-                continue
-            if str(state.session_id or "").strip() != safe_session:
-                continue
-            if state.status not in _TERMINAL_STATUSES:
-                return True
-        return False
+        return self._registry.session_has_active_tasks(
+            customer_id=customer_id,
+            session_id=session_id,
+        )
 
     def _active_task_for_session_locked(
         self, customer_id: str, session_id: str
     ) -> _BrowserUseTaskState | None:
-        safe_customer = self._normalize_customer_id(customer_id)
-        safe_session = str(session_id or "").strip()
-        if not safe_session:
-            return None
-        active: list[_BrowserUseTaskState] = []
-        for state in self._tasks.values():
-            if state.customer_id != safe_customer:
-                continue
-            if str(state.session_id or "").strip() != safe_session:
-                continue
-            if state.status in _TERMINAL_STATUSES:
-                continue
-            active.append(state)
-        if not active:
-            return None
-        active.sort(key=lambda item: float(item.updated_monotonic or item.created_monotonic), reverse=True)
-        return active[0]
+        return self._registry.active_task_for_session(
+            customer_id=customer_id,
+            session_id=session_id,
+        )

--- a/src/opentulpa/integrations/browser_use_session_registry.py
+++ b/src/opentulpa/integrations/browser_use_session_registry.py
@@ -1,0 +1,240 @@
+"""Browser Use task/session registry state."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+TERMINAL_STATUSES = {"finished", "stopped", "failed"}
+DEFAULT_CUSTOMER_ID = "default"
+
+
+def safe_profile_name(session_id: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(session_id or "").strip())
+    value = value.strip("._-")
+    return value[:80] or "default"
+
+
+def normalize_customer_id(customer_id: str | None) -> str:
+    raw = str(customer_id or "").strip()
+    return raw or DEFAULT_CUSTOMER_ID
+
+
+def normalize_optional_customer_id(customer_id: str | None) -> str | None:
+    raw = str(customer_id or "").strip()
+    if not raw:
+        return None
+    return raw
+
+
+def session_key(customer_id: str, session_id: str) -> str:
+    customer = normalize_customer_id(customer_id)
+    session = safe_profile_name(session_id)
+    return f"{customer}\0{session}"
+
+
+@dataclass(slots=True)
+class BrowserUseTaskState:
+    task_id: str
+    session_id: str | None
+    task: str
+    llm: str
+    customer_id: str = DEFAULT_CUSTOMER_ID
+    status: str = "queued"
+    is_success: bool | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    output: str | None = None
+    output_files: list[dict[str, Any]] = field(default_factory=list)
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    image_candidates: list[dict[str, Any]] = field(default_factory=list)
+    network_image_resources: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+    created_monotonic: float = field(default_factory=time.monotonic)
+    updated_monotonic: float = field(default_factory=time.monotonic)
+    runner: asyncio.Task[Any] | None = None
+    browser_session: Any = None
+    allow_owner_input: bool = True
+    owner_input_prompt: str | None = None
+    owner_input_type: str | None = None
+    owner_input_requested_at: str | None = None
+    owner_input_future: asyncio.Future[str] | None = None
+    stop_requested: bool = False
+    close_session_when_done: bool = False
+
+
+@dataclass(slots=True)
+class BrowserUseSessionState:
+    session: Any
+    customer_id: str
+    session_id: str
+    backend: str = "local"
+    cloud_profile_id: str | None = None
+    cloud_browser_session_id: str | None = None
+    live_url: str | None = None
+    updated_monotonic: float = field(default_factory=time.monotonic)
+
+
+class BrowserUseSessionRegistry:
+    """Own in-memory Browser Use task/session indexes and reuse rules."""
+
+    def __init__(self) -> None:
+        self.tasks: dict[str, BrowserUseTaskState] = {}
+        self.sessions: dict[str, BrowserUseSessionState] = {}
+
+    def set_task(self, state: BrowserUseTaskState) -> None:
+        assert state.task_id.strip()
+        self.tasks[state.task_id] = state
+
+    def set_session(self, state: BrowserUseSessionState) -> None:
+        assert state.customer_id.strip()
+        assert state.session_id.strip()
+        self.sessions[session_key(state.customer_id, state.session_id)] = state
+
+    def session_state(
+        self,
+        *,
+        customer_id: str,
+        session_id: str | None,
+    ) -> BrowserUseSessionState | None:
+        safe_session = str(session_id or "").strip()
+        if not safe_session:
+            return None
+        return self.sessions.get(session_key(customer_id, safe_session))
+
+    def related_tasks(
+        self,
+        *,
+        customer_id: str,
+        session_id: str,
+    ) -> list[BrowserUseTaskState]:
+        safe_customer = normalize_customer_id(customer_id)
+        safe_session = str(session_id or "").strip()
+        related = [
+            state
+            for state in self.tasks.values()
+            if state.customer_id == safe_customer
+            and str(state.session_id or "").strip() == safe_session
+        ]
+        related.sort(
+            key=lambda item: float(item.updated_monotonic or item.created_monotonic),
+            reverse=True,
+        )
+        return related
+
+    def active_task_for_session(
+        self,
+        *,
+        customer_id: str,
+        session_id: str,
+    ) -> BrowserUseTaskState | None:
+        active = [
+            state
+            for state in self.related_tasks(customer_id=customer_id, session_id=session_id)
+            if state.status not in TERMINAL_STATUSES
+        ]
+        return active[0] if active else None
+
+    def session_has_active_tasks(self, *, customer_id: str, session_id: str | None) -> bool:
+        safe_session = str(session_id or "").strip()
+        if not safe_session:
+            return False
+        return self.active_task_for_session(customer_id=customer_id, session_id=safe_session) is not None
+
+    def live_session_count_for_customer(self, customer_id: str | None = None) -> int:
+        safe_customer = normalize_customer_id(customer_id)
+        return sum(1 for item in self.sessions.values() if item.customer_id == safe_customer)
+
+    def pick_reusable_session_id(self, customer_id: str) -> str | None:
+        safe_customer = normalize_customer_id(customer_id)
+        reusable: list[tuple[float, str]] = []
+        for session_state in self.sessions.values():
+            if session_state.customer_id != safe_customer:
+                continue
+            if self.session_has_active_tasks(
+                customer_id=session_state.customer_id,
+                session_id=session_state.session_id,
+            ):
+                continue
+            reusable.append((float(session_state.updated_monotonic or 0.0), session_state.session_id))
+        if not reusable:
+            return None
+        reusable.sort(reverse=True)
+        return reusable[0][1]
+
+    def detach_session_if_unused(
+        self,
+        *,
+        customer_id: str,
+        session_id: str | None,
+    ) -> BrowserUseSessionState | None:
+        safe_customer = normalize_customer_id(customer_id)
+        safe_session = str(session_id or "").strip()
+        if not safe_session:
+            return None
+        if self.session_has_active_tasks(customer_id=safe_customer, session_id=safe_session):
+            return None
+        return self.sessions.pop(session_key(safe_customer, safe_session), None)
+
+    def touch_session(self, *, customer_id: str, session_id: str | None) -> None:
+        state = self.session_state(customer_id=customer_id, session_id=session_id)
+        if state is not None:
+            state.updated_monotonic = time.monotonic()
+
+    def session_summaries(self, customer_id: str | None = None) -> list[dict[str, Any]]:
+        safe_customer = normalize_customer_id(customer_id)
+        out: list[dict[str, Any]] = []
+        for session_state in self.sessions.values():
+            if session_state.customer_id != safe_customer:
+                continue
+            active_task = self.active_task_for_session(
+                customer_id=session_state.customer_id,
+                session_id=session_state.session_id,
+            )
+            out.append(
+                {
+                    "session_id": session_state.session_id,
+                    "customer_id": session_state.customer_id,
+                    "reusable": active_task is None,
+                    "active_task_id": active_task.task_id if active_task is not None else None,
+                    "last_used_monotonic": float(session_state.updated_monotonic or 0.0),
+                }
+            )
+        out.sort(key=lambda item: item["last_used_monotonic"], reverse=True)
+        return out
+
+    def pop_expired_terminal_tasks(self, *, now: float, retention_seconds: int) -> list[str]:
+        expired = [
+            task_id
+            for task_id, state in self.tasks.items()
+            if state.status in TERMINAL_STATUSES
+            and now - float(state.updated_monotonic or state.created_monotonic) >= retention_seconds
+        ]
+        for task_id in expired:
+            self.tasks.pop(task_id, None)
+        return expired
+
+    def pop_expired_idle_sessions(
+        self,
+        *,
+        now: float,
+        idle_timeout_seconds: int,
+    ) -> list[BrowserUseSessionState]:
+        expired: list[str] = []
+        for key, session_state in self.sessions.items():
+            if self.session_has_active_tasks(
+                customer_id=session_state.customer_id,
+                session_id=session_state.session_id,
+            ):
+                continue
+            age = now - float(session_state.updated_monotonic or now)
+            if age >= idle_timeout_seconds:
+                expired.append(key)
+        out: list[BrowserUseSessionState] = []
+        for key in expired:
+            if key in self.sessions:
+                out.append(self.sessions.pop(key))
+        return out

--- a/src/opentulpa/integrations/composio.py
+++ b/src/opentulpa/integrations/composio.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, cast
 
 from opentulpa.core.public_urls import build_public_composio_callback_url
+from opentulpa.integrations.composio_google_sheets import GoogleSheetsComposioAdapter
+from opentulpa.integrations.composio_instagram import InstagramComposioAdapter
 
 
 def _load_composio_sdk() -> tuple[type[Any], type[Any]]:
@@ -58,26 +59,6 @@ def _coerce_status_list(values: list[str] | None) -> list[str]:
     return out
 
 
-def _parse_datetime(value: Any) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    for candidate in (text, text.replace("Z", "+00:00")):
-        try:
-            return datetime.fromisoformat(candidate)
-        except ValueError:
-            continue
-    return None
-
-
-def _safe_dict(value: Any) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
-
-
-def _safe_list(value: Any) -> list[Any]:
-    return value if isinstance(value, list) else []
-
-
 def _unique_strings(values: list[Any]) -> list[str]:
     out: list[str] = []
     seen: set[str] = set()
@@ -93,74 +74,83 @@ def _unique_strings(values: list[Any]) -> list[str]:
     return out
 
 
-def _extract_google_sheet_names(value: Any) -> list[str]:
-    """Extract worksheet names from common Google Sheets metadata payloads."""
-
-    names: list[Any] = []
-
-    def visit(node: Any, *, sheet_context: bool = False) -> None:
-        if isinstance(node, list):
-            if all(isinstance(item, str) for item in node):
-                names.extend(node)
-                return
-            for item in node:
-                if isinstance(item, str) and sheet_context:
-                    names.append(item)
-                    continue
-                visit(item, sheet_context=sheet_context)
-            return
-        if not isinstance(node, dict):
-            return
-
-        for key in (
-            "sheet_names",
-            "sheetNames",
-            "worksheet_names",
-            "worksheetNames",
-        ):
-            raw = node.get(key)
-            if isinstance(raw, list):
-                names.extend(raw)
-
-        for key in ("sheets", "worksheets", "tabs"):
-            raw = node.get(key)
-            if isinstance(raw, list):
-                for item in raw:
-                    if isinstance(item, str):
-                        names.append(item)
-                    elif isinstance(item, dict):
-                        props = _safe_dict(item.get("properties"))
-                        candidate = (
-                            item.get("sheetName")
-                            or item.get("sheet_name")
-                            or item.get("name")
-                            or item.get("title")
-                            or props.get("title")
-                            or props.get("sheetName")
-                            or props.get("name")
-                        )
-                        if str(candidate or "").strip():
-                            names.append(candidate)
-                        else:
-                            visit(item, sheet_context=True)
-
-        data = node.get("data")
-        if isinstance(data, dict | list):
-            visit(data, sheet_context=sheet_context)
-
-        result = node.get("result")
-        if isinstance(result, dict | list):
-            visit(result, sheet_context=sheet_context)
-
-    visit(value)
-    return _unique_strings(names)
-
-
 def _is_invalid_instagram_reply_to_error(error: Any) -> bool:
     text = str(error or "").lower()
     if not text:
         return False
     return "invalid message id" in text or "error_subcode\\\":2534002" in text or "error_subcode:2534002" in text
+
+
+def _blocked_instagram_send_result(
+    *,
+    tool_slug: str,
+    preflight: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if tool_slug.upper() != "INSTAGRAM_SEND_TEXT_MESSAGE" or preflight is None:
+        return {}
+    if not bool(preflight.get("recipient_id_verified")):
+        return {
+            "ok": True,
+            "tool_slug": tool_slug,
+            "successful": False,
+            "error": (
+                "Instagram send blocked: could not verify the exact conversation for "
+                "this recipient_id. Inspect the thread first and retry with the verified target."
+            ),
+            "data": {"blocked": True, "preflight": preflight},
+        }
+    if str(preflight.get("latest_inbound_message_created_time", "") or "").strip():
+        return {}
+    return {
+        "ok": True,
+        "tool_slug": tool_slug,
+        "successful": False,
+        "error": (
+            "Instagram send blocked: no inbound message timestamp was found on the "
+            "verified thread, so OpenTulpa cannot claim the reply window is open."
+        ),
+        "data": {"blocked": True, "preflight": preflight},
+    }
+
+
+def _should_retry_without_reply_to(
+    *,
+    tool_slug: str,
+    result: dict[str, Any],
+    arguments: dict[str, Any],
+) -> bool:
+    return (
+        tool_slug.upper() == "INSTAGRAM_SEND_TEXT_MESSAGE"
+        and bool(str(arguments.get("reply_to_message_id", "") or "").strip())
+        and not bool(result.get("successful", False))
+        and _is_invalid_instagram_reply_to_error(result.get("error"))
+    )
+
+
+def _tool_result_data_with_preflight(
+    *,
+    result: dict[str, Any],
+    preflight: dict[str, Any] | None,
+    retried_without_reply_to: bool,
+) -> Any:
+    data = result.get("data")
+    if preflight is None:
+        return data
+    payload = data if isinstance(data, dict) else {"result": data}
+    payload["preflight"] = preflight
+    if retried_without_reply_to:
+        payload["retried_without_reply_to_message_id"] = True
+        payload["retry_reason"] = (
+            "Meta rejected reply_to_message_id as invalid, so OpenTulpa retried as a plain DM."
+        )
+    if not bool(result.get("successful", False)) and "outside of allowed window" in str(
+        result.get("error") or ""
+    ).lower():
+        preflight["reply_window_status"] = "rejected_by_meta"
+        preflight["reply_window_reason"] = (
+            "Meta rejected the send on this verified thread as outside the allowed window."
+        )
+    return payload
 
 
 @dataclass(slots=True)
@@ -440,36 +430,15 @@ class ComposioService:
         if not safe_slug:
             raise ValueError("tool_slug is required")
         safe_arguments = dict(arguments) if isinstance(arguments, dict) else {}
-        preflight: dict[str, Any] | None = None
-        if safe_slug.upper() == "INSTAGRAM_SEND_TEXT_MESSAGE":
-            preflight = self.inspect_instagram_reply_target(
-                customer_id=customer_id,
-                recipient_id=str(safe_arguments.get("recipient_id", "")).strip() or None,
-                conversation_id=str(safe_arguments.pop("conversation_id", "")).strip() or None,
-                connected_account_id=str(connected_account_id or "").strip() or None,
-            )
-            if not bool(preflight.get("recipient_id_verified")):
-                return {
-                    "ok": True,
-                    "tool_slug": safe_slug,
-                    "successful": False,
-                    "error": (
-                        "Instagram send blocked: could not verify the exact conversation for "
-                        "this recipient_id. Inspect the thread first and retry with the verified target."
-                    ),
-                    "data": {"blocked": True, "preflight": preflight},
-                }
-            if not str(preflight.get("latest_inbound_message_created_time", "") or "").strip():
-                return {
-                    "ok": True,
-                    "tool_slug": safe_slug,
-                    "successful": False,
-                    "error": (
-                        "Instagram send blocked: no inbound message timestamp was found on the "
-                        "verified thread, so OpenTulpa cannot claim the reply window is open."
-                    ),
-                    "data": {"blocked": True, "preflight": preflight},
-                }
+        preflight = self._instagram_send_preflight(
+            customer_id=customer_id,
+            tool_slug=safe_slug,
+            arguments=safe_arguments,
+            connected_account_id=connected_account_id,
+        )
+        blocked = _blocked_instagram_send_result(tool_slug=safe_slug, preflight=preflight)
+        if blocked:
+            return blocked
         result = self._sdk_execute_tool(
             slug=safe_slug,
             arguments=safe_arguments,
@@ -477,46 +446,64 @@ class ComposioService:
             user_id=str(customer_id or "").strip(),
             text=str(text or "").strip() or None,
         )
-        retried_without_reply_to = False
-        if (
-            safe_slug.upper() == "INSTAGRAM_SEND_TEXT_MESSAGE"
-            and str(safe_arguments.get("reply_to_message_id", "") or "").strip()
-            and not bool(result.get("successful", False))
-            and _is_invalid_instagram_reply_to_error(result.get("error"))
-        ):
-            retry_arguments = dict(safe_arguments)
-            retry_arguments.pop("reply_to_message_id", None)
-            retry_result = self._sdk_execute_tool(
-                slug=safe_slug,
-                arguments=retry_arguments,
-                connected_account_id=str(connected_account_id or "").strip() or None,
-                user_id=str(customer_id or "").strip(),
-                text=str(text or "").strip() or None,
-            )
-            retried_without_reply_to = True
-            result = retry_result
-        data = result.get("data")
-        if preflight is not None:
-            payload = data if isinstance(data, dict) else {"result": data}
-            payload["preflight"] = preflight
-            if retried_without_reply_to:
-                payload["retried_without_reply_to_message_id"] = True
-                payload["retry_reason"] = "Meta rejected reply_to_message_id as invalid, so OpenTulpa retried as a plain DM."
-            if not bool(result.get("successful", False)) and "outside of allowed window" in str(
-                result.get("error") or ""
-            ).lower():
-                preflight["reply_window_status"] = "rejected_by_meta"
-                preflight["reply_window_reason"] = (
-                    "Meta rejected the send on this verified thread as outside the allowed window."
-                )
-            data = payload
+        result, retried = self._retry_instagram_send_without_reply_to(
+            tool_slug=safe_slug,
+            result=result,
+            arguments=safe_arguments,
+            connected_account_id=connected_account_id,
+            customer_id=customer_id,
+            text=text,
+        )
         return {
             "ok": True,
             "tool_slug": safe_slug,
             "successful": bool(result.get("successful", False)),
             "error": result.get("error"),
-            "data": data,
+            "data": _tool_result_data_with_preflight(
+                result=result,
+                preflight=preflight,
+                retried_without_reply_to=retried,
+            ),
         }
+
+    def _instagram_send_preflight(
+        self,
+        *,
+        customer_id: str,
+        tool_slug: str,
+        arguments: dict[str, Any],
+        connected_account_id: str | None,
+    ) -> dict[str, Any] | None:
+        if tool_slug.upper() != "INSTAGRAM_SEND_TEXT_MESSAGE":
+            return None
+        return self.inspect_instagram_reply_target(
+            customer_id=customer_id,
+            recipient_id=str(arguments.get("recipient_id", "")).strip() or None,
+            conversation_id=str(arguments.pop("conversation_id", "")).strip() or None,
+            connected_account_id=str(connected_account_id or "").strip() or None,
+        )
+
+    def _retry_instagram_send_without_reply_to(
+        self,
+        *,
+        tool_slug: str,
+        result: dict[str, Any],
+        arguments: dict[str, Any],
+        connected_account_id: str | None,
+        customer_id: str,
+        text: str | None,
+    ) -> tuple[dict[str, Any], bool]:
+        if not _should_retry_without_reply_to(tool_slug=tool_slug, result=result, arguments=arguments):
+            return result, False
+        retry_arguments = dict(arguments)
+        retry_arguments.pop("reply_to_message_id", None)
+        return self._sdk_execute_tool(
+            slug=tool_slug,
+            arguments=retry_arguments,
+            connected_account_id=str(connected_account_id or "").strip() or None,
+            user_id=str(customer_id or "").strip(),
+            text=str(text or "").strip() or None,
+        ), True
 
     def list_google_sheets_tab_names(
         self,
@@ -525,62 +512,11 @@ class ComposioService:
         spreadsheet_id: str,
         connected_account_id: str | None = None,
     ) -> dict[str, Any]:
-        safe_customer = str(customer_id or "").strip()
-        safe_spreadsheet_id = str(spreadsheet_id or "").strip()
-        if not safe_customer:
-            raise ValueError("customer_id is required")
-        if not safe_spreadsheet_id:
-            raise ValueError("spreadsheet_id is required")
-
-        candidate_slugs = ["GOOGLESHEETS_GET_SHEET_NAMES"]
-        try:
-            with_tool_search = self.search_tools(
-                query="list sheets in google spreadsheet",
-                toolkits=["googlesheets"],
-                limit=20,
-            )
-        except Exception:
-            with_tool_search = {}
-        for item in _safe_list(with_tool_search.get("items")):
-            slug = str(_safe_dict(item).get("slug", "") or "").strip()
-            upper_slug = slug.upper()
-            if slug and (
-                "GET_SHEET_NAMES" in upper_slug
-                or "GET_SPREADSHEET_INFO" in upper_slug
-            ):
-                candidate_slugs.append(slug)
-        candidate_slugs = _unique_strings(candidate_slugs)
-
-        last_error = ""
-        for slug in candidate_slugs:
-            for arguments in (
-                {"spreadsheetId": safe_spreadsheet_id},
-                {"spreadsheet_id": safe_spreadsheet_id},
-            ):
-                result = self.execute_tool(
-                    customer_id=safe_customer,
-                    tool_slug=slug,
-                    arguments=arguments,
-                    connected_account_id=connected_account_id,
-                )
-                if not bool(result.get("successful", False)):
-                    last_error = str(result.get("error") or "sheet metadata lookup failed")
-                    continue
-                sheet_names = _extract_google_sheet_names(result.get("data"))
-                if sheet_names:
-                    return {
-                        "ok": True,
-                        "spreadsheet_id": safe_spreadsheet_id,
-                        "sheet_names": sheet_names,
-                        "tool_slug": slug,
-                    }
-                last_error = f"{slug} returned no sheet names"
-        return {
-            "ok": False,
-            "spreadsheet_id": safe_spreadsheet_id,
-            "sheet_names": [],
-            "error": last_error or "unable to discover Google Sheets worksheet names",
-        }
+        return GoogleSheetsComposioAdapter(self).list_tab_names(
+            customer_id=customer_id,
+            spreadsheet_id=spreadsheet_id,
+            connected_account_id=connected_account_id,
+        )
 
     def inspect_instagram_reply_target(
         self,
@@ -591,50 +527,13 @@ class ComposioService:
         connected_account_id: str | None = None,
         scan_limit: int = 10,
     ) -> dict[str, Any]:
-        safe_customer = str(customer_id or "").strip()
-        safe_recipient = str(recipient_id or "").strip()
-        safe_conversation = str(conversation_id or "").strip()
-        safe_account = str(connected_account_id or "").strip() or None
-        if not safe_customer:
-            raise ValueError("customer_id is required")
-        if not safe_recipient and not safe_conversation:
-            raise ValueError("recipient_id or conversation_id is required")
-
-        conversation: dict[str, Any] | None = None
-        if safe_conversation:
-            conversation = self._fetch_instagram_conversation(
-                customer_id=safe_customer,
-                conversation_id=safe_conversation,
-                connected_account_id=safe_account,
-            )
-        else:
-            conversation = self._find_instagram_conversation_for_recipient(
-                customer_id=safe_customer,
-                recipient_id=safe_recipient,
-                connected_account_id=safe_account,
-                scan_limit=scan_limit,
-            )
-
-        if not conversation:
-            return {
-                "ok": True,
-                "customer_id": safe_customer,
-                "conversation_id": safe_conversation or None,
-                "recipient_id": safe_recipient or None,
-                "recipient_id_verified": False,
-                "matched": False,
-                "reply_window_status": "unconfirmed",
-                "reply_window_reason": "No Instagram conversation matching this target was found.",
-            }
-
-        summary = self._summarize_instagram_conversation(
-            conversation=conversation,
-            requested_recipient_id=safe_recipient or None,
+        return InstagramComposioAdapter(self).inspect_reply_target(
+            customer_id=customer_id,
+            recipient_id=recipient_id,
+            conversation_id=conversation_id,
+            connected_account_id=connected_account_id,
+            scan_limit=scan_limit,
         )
-        summary["ok"] = True
-        summary["customer_id"] = safe_customer
-        summary["connected_account_id"] = safe_account
-        return summary
 
     def list_instagram_conversations(
         self,
@@ -643,49 +542,11 @@ class ComposioService:
         connected_account_id: str | None = None,
         limit: int = 10,
     ) -> dict[str, Any]:
-        safe_customer = str(customer_id or "").strip()
-        if not safe_customer:
-            raise ValueError("customer_id is required")
-        safe_account = str(connected_account_id or "").strip() or None
-        response = self._sdk_execute_tool(
-            slug="INSTAGRAM_LIST_ALL_CONVERSATIONS",
-            arguments={"limit": max(1, min(int(limit), 25))},
-            connected_account_id=safe_account,
-            user_id=safe_customer,
+        return InstagramComposioAdapter(self).list_conversations(
+            customer_id=customer_id,
+            connected_account_id=connected_account_id,
+            limit=limit,
         )
-        if not bool(response.get("successful", False)):
-            raise RuntimeError(str(response.get("error") or "failed to list Instagram conversations"))
-        items = _safe_list(_safe_dict(response.get("data")).get("data"))
-        summaries: list[dict[str, Any]] = []
-        warnings: list[dict[str, str]] = []
-        for item in items:
-            conversation_id = str(_safe_dict(item).get("id", "") or "").strip()
-            if not conversation_id:
-                continue
-            try:
-                conversation = self._fetch_instagram_conversation(
-                    customer_id=safe_customer,
-                    conversation_id=conversation_id,
-                    connected_account_id=safe_account,
-                )
-            except Exception as exc:
-                warnings.append({"conversation_id": conversation_id, "error": str(exc)})
-                continue
-            summary = self._summarize_instagram_conversation(
-                conversation=conversation,
-                requested_recipient_id=None,
-            )
-            summary["ok"] = True
-            summary["customer_id"] = safe_customer
-            summary["connected_account_id"] = safe_account
-            summaries.append(summary)
-        return {
-            "ok": True,
-            "customer_id": safe_customer,
-            "connected_account_id": safe_account,
-            "items": summaries,
-            "warnings": warnings,
-        }
 
     def get_instagram_conversation(
         self,
@@ -694,32 +555,11 @@ class ComposioService:
         conversation_id: str,
         connected_account_id: str | None = None,
     ) -> dict[str, Any]:
-        safe_customer = str(customer_id or "").strip()
-        safe_conversation = str(conversation_id or "").strip()
-        safe_account = str(connected_account_id or "").strip() or None
-        if not safe_customer:
-            raise ValueError("customer_id is required")
-        if not safe_conversation:
-            raise ValueError("conversation_id is required")
-        conversation = self._fetch_instagram_conversation(
-            customer_id=safe_customer,
-            conversation_id=safe_conversation,
-            connected_account_id=safe_account,
+        return InstagramComposioAdapter(self).get_conversation(
+            customer_id=customer_id,
+            conversation_id=conversation_id,
+            connected_account_id=connected_account_id,
         )
-        summary = self._summarize_instagram_conversation(
-            conversation=conversation,
-            requested_recipient_id=None,
-        )
-        summary["ok"] = True
-        summary["customer_id"] = safe_customer
-        summary["connected_account_id"] = safe_account
-        return {
-            "ok": True,
-            "customer_id": safe_customer,
-            "connected_account_id": safe_account,
-            "conversation": conversation,
-            "summary": summary,
-        }
 
     def _sdk_execute_tool(
         self,
@@ -741,149 +581,6 @@ class ComposioService:
                 dangerously_skip_version_check=True,
             ),
         )
-
-    def _fetch_instagram_conversation(
-        self,
-        *,
-        customer_id: str,
-        conversation_id: str,
-        connected_account_id: str | None,
-    ) -> dict[str, Any]:
-        result = self._sdk_execute_tool(
-            slug="INSTAGRAM_GET_CONVERSATION",
-            arguments={"conversation_id": conversation_id},
-            connected_account_id=connected_account_id,
-            user_id=customer_id,
-        )
-        if not bool(result.get("successful", False)):
-            raise RuntimeError(str(result.get("error") or "failed to fetch Instagram conversation"))
-        payload = _safe_dict(result.get("data"))
-        return payload
-
-    def _find_instagram_conversation_for_recipient(
-        self,
-        *,
-        customer_id: str,
-        recipient_id: str,
-        connected_account_id: str | None,
-        scan_limit: int,
-    ) -> dict[str, Any] | None:
-        if not recipient_id:
-            return None
-        response = self._sdk_execute_tool(
-            slug="INSTAGRAM_LIST_ALL_CONVERSATIONS",
-            arguments={"limit": max(1, min(int(scan_limit), 25))},
-            connected_account_id=connected_account_id,
-            user_id=customer_id,
-        )
-        if not bool(response.get("successful", False)):
-            raise RuntimeError(str(response.get("error") or "failed to list Instagram conversations"))
-        items = _safe_list(_safe_dict(response.get("data")).get("data"))
-        for item in items:
-            conversation_id = str(_safe_dict(item).get("id", "") or "").strip()
-            if not conversation_id:
-                continue
-            conversation = self._fetch_instagram_conversation(
-                customer_id=customer_id,
-                conversation_id=conversation_id,
-                connected_account_id=connected_account_id,
-            )
-            participant_ids = {
-                str(_safe_dict(participant).get("id", "") or "").strip()
-                for participant in _safe_list(_safe_dict(conversation.get("participants")).get("data"))
-            }
-            if recipient_id in participant_ids:
-                return conversation
-        return None
-
-    @staticmethod
-    def _summarize_instagram_conversation(
-        *,
-        conversation: dict[str, Any],
-        requested_recipient_id: str | None,
-    ) -> dict[str, Any]:
-        payload = _safe_dict(conversation.get("data")) if "data" in conversation else conversation
-        participants = _safe_list(_safe_dict(payload.get("participants")).get("data"))
-        messages = _safe_list(_safe_dict(payload.get("messages")).get("data"))
-        participant_ids = [
-            str(_safe_dict(item).get("id", "") or "").strip()
-            for item in participants
-            if str(_safe_dict(item).get("id", "") or "").strip()
-        ]
-        participant_usernames = {
-            str(_safe_dict(item).get("id", "") or "").strip(): str(_safe_dict(item).get("username", "") or "").strip()
-            for item in participants
-            if str(_safe_dict(item).get("id", "") or "").strip()
-        }
-        verified_recipient = str(requested_recipient_id or "").strip() or None
-        if verified_recipient and verified_recipient not in participant_ids:
-            verified_recipient = None
-        if not verified_recipient and len(participant_ids) == 2:
-            verified_recipient = participant_ids[1]
-
-        own_participant_ids = [item for item in participant_ids if item != verified_recipient] if verified_recipient else []
-        normalized_messages: list[dict[str, Any]] = []
-        for item in messages:
-            msg = _safe_dict(item)
-            sender = _safe_dict(msg.get("from"))
-            recipients = _safe_list(_safe_dict(msg.get("to")).get("data"))
-            normalized_messages.append(
-                {
-                    "id": str(msg.get("id", "") or "").strip(),
-                    "created_time": str(msg.get("created_time", "") or "").strip(),
-                    "created_at": _parse_datetime(msg.get("created_time")),
-                    "message": str(msg.get("message", "") or "").strip(),
-                    "from_id": str(sender.get("id", "") or "").strip(),
-                    "from_username": str(sender.get("username", "") or "").strip(),
-                    "to_ids": [
-                        str(_safe_dict(recipient).get("id", "") or "").strip()
-                        for recipient in recipients
-                        if str(_safe_dict(recipient).get("id", "") or "").strip()
-                    ],
-                }
-            )
-        normalized_messages.sort(key=lambda item: item["created_at"] or datetime.min, reverse=True)
-
-        latest_message = normalized_messages[0] if normalized_messages else None
-        latest_inbound = None
-        latest_outbound = None
-        for item in normalized_messages:
-            sender_id = item["from_id"]
-            if verified_recipient and sender_id == verified_recipient and latest_inbound is None:
-                latest_inbound = item
-            if own_participant_ids and sender_id in own_participant_ids and latest_outbound is None:
-                latest_outbound = item
-            if latest_inbound is not None and (latest_outbound is not None or not own_participant_ids):
-                break
-
-        return {
-            "matched": True,
-            "conversation_id": str(payload.get("id", "") or "").strip() or None,
-            "conversation_updated_time": str(payload.get("updated_time", "") or "").strip() or None,
-            "participant_ids": participant_ids,
-            "participant_usernames": participant_usernames,
-            "recipient_id": verified_recipient or requested_recipient_id or None,
-            "recipient_id_verified": bool(verified_recipient),
-            "latest_message_id": latest_message["id"] if latest_message else None,
-            "latest_message_created_time": latest_message["created_time"] if latest_message else None,
-            "latest_message_sender_id": latest_message["from_id"] if latest_message else None,
-            "latest_message_sender_username": latest_message["from_username"] if latest_message else None,
-            "latest_message_text_preview": latest_message["message"][:280] if latest_message else None,
-            "latest_inbound_message_id": latest_inbound["id"] if latest_inbound else None,
-            "latest_inbound_message_created_time": latest_inbound["created_time"] if latest_inbound else None,
-            "latest_inbound_sender_id": latest_inbound["from_id"] if latest_inbound else None,
-            "latest_inbound_sender_username": latest_inbound["from_username"] if latest_inbound else None,
-            "latest_inbound_message_text_preview": latest_inbound["message"][:280] if latest_inbound else None,
-            "latest_outbound_message_id": latest_outbound["id"] if latest_outbound else None,
-            "latest_outbound_message_created_time": latest_outbound["created_time"] if latest_outbound else None,
-            "reply_window_status": "unconfirmed",
-            "reply_window_reason": (
-                "Exact thread verified and latest inbound timestamp captured, but Meta still decides whether the "
-                "reply window is open at send time."
-                if latest_inbound
-                else "Exact thread verified, but no inbound message timestamp was found on this thread."
-            ),
-        }
 
     @staticmethod
     def _serialize_connected_account(item: Any) -> dict[str, Any]:

--- a/src/opentulpa/integrations/composio.py
+++ b/src/opentulpa/integrations/composio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from opentulpa.core.public_urls import build_public_composio_callback_url
 
@@ -730,13 +730,16 @@ class ComposioService:
         user_id: str,
         text: str | None = None,
     ) -> dict[str, Any]:
-        return self._sdk().tools.execute(
-            slug=slug,
-            arguments=arguments,
-            connected_account_id=connected_account_id,
-            user_id=user_id,
-            text=text,
-            dangerously_skip_version_check=True,
+        return cast(
+            "dict[str, Any]",
+            self._sdk().tools.execute(
+                slug=slug,
+                arguments=arguments,
+                connected_account_id=connected_account_id,
+                user_id=user_id,
+                text=text,
+                dangerously_skip_version_check=True,
+            ),
         )
 
     def _fetch_instagram_conversation(
@@ -819,7 +822,7 @@ class ComposioService:
             verified_recipient = participant_ids[1]
 
         own_participant_ids = [item for item in participant_ids if item != verified_recipient] if verified_recipient else []
-        normalized_messages = []
+        normalized_messages: list[dict[str, Any]] = []
         for item in messages:
             msg = _safe_dict(item)
             sender = _safe_dict(msg.get("from"))

--- a/src/opentulpa/integrations/composio_google_sheets.py
+++ b/src/opentulpa/integrations/composio_google_sheets.py
@@ -1,0 +1,168 @@
+"""Google Sheets-specific Composio adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class GoogleSheetsComposioAdapter:
+    def __init__(self, core: Any) -> None:
+        self.core = core
+
+    def list_tab_names(
+        self,
+        *,
+        customer_id: str,
+        spreadsheet_id: str,
+        connected_account_id: str | None = None,
+    ) -> dict[str, Any]:
+        safe_customer = str(customer_id or "").strip()
+        safe_spreadsheet_id = str(spreadsheet_id or "").strip()
+        if not safe_customer:
+            raise ValueError("customer_id is required")
+        if not safe_spreadsheet_id:
+            raise ValueError("spreadsheet_id is required")
+
+        last_error = ""
+        for slug in self._candidate_sheet_metadata_tools():
+            for arguments in (
+                {"spreadsheetId": safe_spreadsheet_id},
+                {"spreadsheet_id": safe_spreadsheet_id},
+            ):
+                result = self.core.execute_tool(
+                    customer_id=safe_customer,
+                    tool_slug=slug,
+                    arguments=arguments,
+                    connected_account_id=connected_account_id,
+                )
+                if not bool(result.get("successful", False)):
+                    last_error = str(result.get("error") or "sheet metadata lookup failed")
+                    continue
+                sheet_names = _extract_google_sheet_names(result.get("data"))
+                if sheet_names:
+                    return {
+                        "ok": True,
+                        "spreadsheet_id": safe_spreadsheet_id,
+                        "sheet_names": sheet_names,
+                        "tool_slug": slug,
+                    }
+                last_error = f"{slug} returned no sheet names"
+        return {
+            "ok": False,
+            "spreadsheet_id": safe_spreadsheet_id,
+            "sheet_names": [],
+            "error": last_error or "unable to discover Google Sheets worksheet names",
+        }
+
+    def _candidate_sheet_metadata_tools(self) -> list[str]:
+        candidate_slugs = ["GOOGLESHEETS_GET_SHEET_NAMES"]
+        try:
+            with_tool_search = self.core.search_tools(
+                query="list sheets in google spreadsheet",
+                toolkits=["googlesheets"],
+                limit=20,
+            )
+        except Exception:
+            with_tool_search = {}
+        for item in _safe_list(with_tool_search.get("items")):
+            slug = str(_safe_dict(item).get("slug", "") or "").strip()
+            upper_slug = slug.upper()
+            if slug and (
+                "GET_SHEET_NAMES" in upper_slug or "GET_SPREADSHEET_INFO" in upper_slug
+            ):
+                candidate_slugs.append(slug)
+        return _unique_strings(candidate_slugs)
+
+
+def _extract_google_sheet_names(value: Any) -> list[str]:
+    names: list[Any] = []
+
+    def visit(node: Any, *, sheet_context: bool = False) -> None:
+        if isinstance(node, list):
+            _visit_sheet_list(node, names=names, sheet_context=sheet_context, visit=visit)
+            return
+        if not isinstance(node, dict):
+            return
+        _collect_sheet_name_keys(node, names=names)
+        _collect_sheet_container_keys(node, names=names, visit=visit)
+        for key in ("data", "result"):
+            raw = node.get(key)
+            if isinstance(raw, dict | list):
+                visit(raw, sheet_context=sheet_context)
+
+    visit(value)
+    return _unique_strings(names)
+
+
+def _visit_sheet_list(
+    node: list[Any],
+    *,
+    names: list[Any],
+    sheet_context: bool,
+    visit: Any,
+) -> None:
+    if all(isinstance(item, str) for item in node):
+        names.extend(node)
+        return
+    for item in node:
+        if isinstance(item, str) and sheet_context:
+            names.append(item)
+            continue
+        visit(item, sheet_context=sheet_context)
+
+
+def _collect_sheet_name_keys(node: dict[str, Any], *, names: list[Any]) -> None:
+    for key in ("sheet_names", "sheetNames", "worksheet_names", "worksheetNames"):
+        raw = node.get(key)
+        if isinstance(raw, list):
+            names.extend(raw)
+
+
+def _collect_sheet_container_keys(node: dict[str, Any], *, names: list[Any], visit: Any) -> None:
+    for key in ("sheets", "worksheets", "tabs"):
+        raw = node.get(key)
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, str):
+                names.append(item)
+            elif isinstance(item, dict):
+                candidate = _sheet_name_from_dict(item)
+                names.append(candidate) if candidate else visit(item, sheet_context=True)
+
+
+def _sheet_name_from_dict(item: dict[str, Any]) -> str:
+    props = _safe_dict(item.get("properties"))
+    candidate = (
+        item.get("sheetName")
+        or item.get("sheet_name")
+        or item.get("name")
+        or item.get("title")
+        or props.get("title")
+        or props.get("sheetName")
+        or props.get("name")
+    )
+    return str(candidate or "").strip()
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _unique_strings(values: list[Any]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        folded = text.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        out.append(text)
+    return out

--- a/src/opentulpa/integrations/composio_instagram.py
+++ b/src/opentulpa/integrations/composio_instagram.py
@@ -1,0 +1,410 @@
+"""Instagram-specific Composio adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+class InstagramComposioAdapter:
+    def __init__(self, core: Any) -> None:
+        self.core = core
+
+    def inspect_reply_target(
+        self,
+        *,
+        customer_id: str,
+        recipient_id: str | None = None,
+        conversation_id: str | None = None,
+        connected_account_id: str | None = None,
+        scan_limit: int = 10,
+    ) -> dict[str, Any]:
+        safe_customer = str(customer_id or "").strip()
+        safe_recipient = str(recipient_id or "").strip()
+        safe_conversation = str(conversation_id or "").strip()
+        safe_account = str(connected_account_id or "").strip() or None
+        if not safe_customer:
+            raise ValueError("customer_id is required")
+        if not safe_recipient and not safe_conversation:
+            raise ValueError("recipient_id or conversation_id is required")
+
+        conversation = self._target_conversation(
+            customer_id=safe_customer,
+            recipient_id=safe_recipient,
+            conversation_id=safe_conversation,
+            connected_account_id=safe_account,
+            scan_limit=scan_limit,
+        )
+        if not conversation:
+            return _missing_conversation_payload(
+                customer_id=safe_customer,
+                conversation_id=safe_conversation,
+                recipient_id=safe_recipient,
+            )
+        summary = _summarize_instagram_conversation(
+            conversation=conversation,
+            requested_recipient_id=safe_recipient or None,
+        )
+        summary["ok"] = True
+        summary["customer_id"] = safe_customer
+        summary["connected_account_id"] = safe_account
+        return summary
+
+    def list_conversations(
+        self,
+        *,
+        customer_id: str,
+        connected_account_id: str | None = None,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        safe_customer = str(customer_id or "").strip()
+        if not safe_customer:
+            raise ValueError("customer_id is required")
+        safe_account = str(connected_account_id or "").strip() or None
+        response = self.core._sdk_execute_tool(
+            slug="INSTAGRAM_LIST_ALL_CONVERSATIONS",
+            arguments={"limit": max(1, min(int(limit), 25))},
+            connected_account_id=safe_account,
+            user_id=safe_customer,
+        )
+        if not bool(response.get("successful", False)):
+            raise RuntimeError(str(response.get("error") or "failed to list Instagram conversations"))
+        return self._conversation_list_payload(
+            customer_id=safe_customer,
+            connected_account_id=safe_account,
+            items=_safe_list(_safe_dict(response.get("data")).get("data")),
+        )
+
+    def get_conversation(
+        self,
+        *,
+        customer_id: str,
+        conversation_id: str,
+        connected_account_id: str | None = None,
+    ) -> dict[str, Any]:
+        safe_customer = str(customer_id or "").strip()
+        safe_conversation = str(conversation_id or "").strip()
+        safe_account = str(connected_account_id or "").strip() or None
+        if not safe_customer:
+            raise ValueError("customer_id is required")
+        if not safe_conversation:
+            raise ValueError("conversation_id is required")
+        conversation = self._fetch_conversation(
+            customer_id=safe_customer,
+            conversation_id=safe_conversation,
+            connected_account_id=safe_account,
+        )
+        summary = _summarize_instagram_conversation(
+            conversation=conversation,
+            requested_recipient_id=None,
+        )
+        summary["ok"] = True
+        summary["customer_id"] = safe_customer
+        summary["connected_account_id"] = safe_account
+        return {
+            "ok": True,
+            "customer_id": safe_customer,
+            "connected_account_id": safe_account,
+            "conversation": conversation,
+            "summary": summary,
+        }
+
+    def _target_conversation(
+        self,
+        *,
+        customer_id: str,
+        recipient_id: str,
+        conversation_id: str,
+        connected_account_id: str | None,
+        scan_limit: int,
+    ) -> dict[str, Any] | None:
+        if conversation_id:
+            return self._fetch_conversation(
+                customer_id=customer_id,
+                conversation_id=conversation_id,
+                connected_account_id=connected_account_id,
+            )
+        return self._find_conversation_for_recipient(
+            customer_id=customer_id,
+            recipient_id=recipient_id,
+            connected_account_id=connected_account_id,
+            scan_limit=scan_limit,
+        )
+
+    def _conversation_list_payload(
+        self,
+        *,
+        customer_id: str,
+        connected_account_id: str | None,
+        items: list[Any],
+    ) -> dict[str, Any]:
+        summaries: list[dict[str, Any]] = []
+        warnings: list[dict[str, str]] = []
+        for item in items:
+            conversation_id = str(_safe_dict(item).get("id", "") or "").strip()
+            if not conversation_id:
+                continue
+            try:
+                conversation = self._fetch_conversation(
+                    customer_id=customer_id,
+                    conversation_id=conversation_id,
+                    connected_account_id=connected_account_id,
+                )
+            except Exception as exc:
+                warnings.append({"conversation_id": conversation_id, "error": str(exc)})
+                continue
+            summary = _summarize_instagram_conversation(
+                conversation=conversation,
+                requested_recipient_id=None,
+            )
+            summary["ok"] = True
+            summary["customer_id"] = customer_id
+            summary["connected_account_id"] = connected_account_id
+            summaries.append(summary)
+        return {
+            "ok": True,
+            "customer_id": customer_id,
+            "connected_account_id": connected_account_id,
+            "items": summaries,
+            "warnings": warnings,
+        }
+
+    def _fetch_conversation(
+        self,
+        *,
+        customer_id: str,
+        conversation_id: str,
+        connected_account_id: str | None,
+    ) -> dict[str, Any]:
+        result = self.core._sdk_execute_tool(
+            slug="INSTAGRAM_GET_CONVERSATION",
+            arguments={"conversation_id": conversation_id},
+            connected_account_id=connected_account_id,
+            user_id=customer_id,
+        )
+        if not bool(result.get("successful", False)):
+            raise RuntimeError(str(result.get("error") or "failed to fetch Instagram conversation"))
+        return _safe_dict(result.get("data"))
+
+    def _find_conversation_for_recipient(
+        self,
+        *,
+        customer_id: str,
+        recipient_id: str,
+        connected_account_id: str | None,
+        scan_limit: int,
+    ) -> dict[str, Any] | None:
+        if not recipient_id:
+            return None
+        response = self.core._sdk_execute_tool(
+            slug="INSTAGRAM_LIST_ALL_CONVERSATIONS",
+            arguments={"limit": max(1, min(int(scan_limit), 25))},
+            connected_account_id=connected_account_id,
+            user_id=customer_id,
+        )
+        if not bool(response.get("successful", False)):
+            raise RuntimeError(str(response.get("error") or "failed to list Instagram conversations"))
+        for item in _safe_list(_safe_dict(response.get("data")).get("data")):
+            conversation_id = str(_safe_dict(item).get("id", "") or "").strip()
+            if not conversation_id:
+                continue
+            conversation = self._fetch_conversation(
+                customer_id=customer_id,
+                conversation_id=conversation_id,
+                connected_account_id=connected_account_id,
+            )
+            if recipient_id in _participant_ids(conversation):
+                return conversation
+        return None
+
+
+def _missing_conversation_payload(
+    *,
+    customer_id: str,
+    conversation_id: str,
+    recipient_id: str,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "customer_id": customer_id,
+        "conversation_id": conversation_id or None,
+        "recipient_id": recipient_id or None,
+        "recipient_id_verified": False,
+        "matched": False,
+        "reply_window_status": "unconfirmed",
+        "reply_window_reason": "No Instagram conversation matching this target was found.",
+    }
+
+
+def _participant_ids(conversation: dict[str, Any]) -> set[str]:
+    return {
+        str(_safe_dict(participant).get("id", "") or "").strip()
+        for participant in _safe_list(_safe_dict(conversation.get("participants")).get("data"))
+    }
+
+
+def _summarize_instagram_conversation(
+    *,
+    conversation: dict[str, Any],
+    requested_recipient_id: str | None,
+) -> dict[str, Any]:
+    payload = _safe_dict(conversation.get("data")) if "data" in conversation else conversation
+    participants = _safe_list(_safe_dict(payload.get("participants")).get("data"))
+    messages = _normalized_messages(payload)
+    participant_ids = [
+        str(_safe_dict(item).get("id", "") or "").strip()
+        for item in participants
+        if str(_safe_dict(item).get("id", "") or "").strip()
+    ]
+    verified_recipient = _verified_recipient(
+        participant_ids=participant_ids,
+        requested_recipient_id=requested_recipient_id,
+    )
+    own_ids = [item for item in participant_ids if item != verified_recipient] if verified_recipient else []
+    latest_inbound, latest_outbound = _latest_directional_messages(
+        messages=messages,
+        verified_recipient=verified_recipient,
+        own_participant_ids=own_ids,
+    )
+    latest_message = messages[0] if messages else None
+    return _conversation_summary_payload(
+        payload=payload,
+        participant_ids=participant_ids,
+        participant_usernames=_participant_usernames(participants),
+        requested_recipient_id=requested_recipient_id,
+        verified_recipient=verified_recipient,
+        latest_message=latest_message,
+        latest_inbound=latest_inbound,
+        latest_outbound=latest_outbound,
+    )
+
+
+def _normalized_messages(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    messages = _safe_list(_safe_dict(payload.get("messages")).get("data"))
+    normalized: list[dict[str, Any]] = []
+    for item in messages:
+        msg = _safe_dict(item)
+        sender = _safe_dict(msg.get("from"))
+        recipients = _safe_list(_safe_dict(msg.get("to")).get("data"))
+        normalized.append(
+            {
+                "id": str(msg.get("id", "") or "").strip(),
+                "created_time": str(msg.get("created_time", "") or "").strip(),
+                "created_at": _parse_datetime(msg.get("created_time")),
+                "message": str(msg.get("message", "") or "").strip(),
+                "from_id": str(sender.get("id", "") or "").strip(),
+                "from_username": str(sender.get("username", "") or "").strip(),
+                "to_ids": [
+                    str(_safe_dict(recipient).get("id", "") or "").strip()
+                    for recipient in recipients
+                    if str(_safe_dict(recipient).get("id", "") or "").strip()
+                ],
+            }
+        )
+    normalized.sort(key=lambda item: item["created_at"] or datetime.min, reverse=True)
+    return normalized
+
+
+def _latest_directional_messages(
+    *,
+    messages: list[dict[str, Any]],
+    verified_recipient: str | None,
+    own_participant_ids: list[str],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    latest_inbound = None
+    latest_outbound = None
+    for item in messages:
+        sender_id = item["from_id"]
+        if verified_recipient and sender_id == verified_recipient and latest_inbound is None:
+            latest_inbound = item
+        if own_participant_ids and sender_id in own_participant_ids and latest_outbound is None:
+            latest_outbound = item
+        if latest_inbound is not None and (latest_outbound is not None or not own_participant_ids):
+            break
+    return latest_inbound, latest_outbound
+
+
+def _conversation_summary_payload(
+    *,
+    payload: dict[str, Any],
+    participant_ids: list[str],
+    participant_usernames: dict[str, str],
+    requested_recipient_id: str | None,
+    verified_recipient: str | None,
+    latest_message: dict[str, Any] | None,
+    latest_inbound: dict[str, Any] | None,
+    latest_outbound: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "matched": True,
+        "conversation_id": str(payload.get("id", "") or "").strip() or None,
+        "conversation_updated_time": str(payload.get("updated_time", "") or "").strip() or None,
+        "participant_ids": participant_ids,
+        "participant_usernames": participant_usernames,
+        "recipient_id": verified_recipient or requested_recipient_id or None,
+        "recipient_id_verified": bool(verified_recipient),
+        "latest_message_id": latest_message["id"] if latest_message else None,
+        "latest_message_created_time": latest_message["created_time"] if latest_message else None,
+        "latest_message_sender_id": latest_message["from_id"] if latest_message else None,
+        "latest_message_sender_username": latest_message["from_username"] if latest_message else None,
+        "latest_message_text_preview": latest_message["message"][:280] if latest_message else None,
+        "latest_inbound_message_id": latest_inbound["id"] if latest_inbound else None,
+        "latest_inbound_message_created_time": latest_inbound["created_time"] if latest_inbound else None,
+        "latest_inbound_sender_id": latest_inbound["from_id"] if latest_inbound else None,
+        "latest_inbound_sender_username": latest_inbound["from_username"] if latest_inbound else None,
+        "latest_inbound_message_text_preview": latest_inbound["message"][:280] if latest_inbound else None,
+        "latest_outbound_message_id": latest_outbound["id"] if latest_outbound else None,
+        "latest_outbound_message_created_time": latest_outbound["created_time"] if latest_outbound else None,
+        "reply_window_status": "unconfirmed",
+        "reply_window_reason": _reply_window_reason(latest_inbound),
+    }
+
+
+def _verified_recipient(
+    *,
+    participant_ids: list[str],
+    requested_recipient_id: str | None,
+) -> str | None:
+    verified = str(requested_recipient_id or "").strip() or None
+    if verified and verified not in participant_ids:
+        verified = None
+    if not verified and len(participant_ids) == 2:
+        verified = participant_ids[1]
+    return verified
+
+
+def _participant_usernames(participants: list[Any]) -> dict[str, str]:
+    return {
+        str(_safe_dict(item).get("id", "") or "").strip(): str(_safe_dict(item).get("username", "") or "").strip()
+        for item in participants
+        if str(_safe_dict(item).get("id", "") or "").strip()
+    }
+
+
+def _reply_window_reason(latest_inbound: dict[str, Any] | None) -> str:
+    if latest_inbound:
+        return (
+            "Exact thread verified and latest inbound timestamp captured, but Meta still decides whether the "
+            "reply window is open at send time."
+        )
+    return "Exact thread verified, but no inbound message timestamp was found on this thread."
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    for candidate in (text, text.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+    return None
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []

--- a/src/opentulpa/integrations/web_search.py
+++ b/src/opentulpa/integrations/web_search.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import os
 import re
+from collections.abc import Mapping
 from urllib.parse import urlparse
 
 import httpx
@@ -72,11 +73,11 @@ def _extract_url_from_item(item: object) -> str | None:
     if isinstance(item, str):
         value = item.strip()
         return value if value.startswith(("http://", "https://")) else None
-    if isinstance(item, dict):
+    if isinstance(item, Mapping):
         for key in ("url", "link", "uri", "source", "href"):
-            value = item.get(key)
-            if isinstance(value, str):
-                clean = value.strip()
+            candidate = item.get(key)
+            if isinstance(candidate, str):
+                clean = candidate.strip()
                 if clean.startswith(("http://", "https://")):
                     return clean
     return None

--- a/src/opentulpa/interfaces/telegram/chat_routing.py
+++ b/src/opentulpa/interfaces/telegram/chat_routing.py
@@ -72,4 +72,3 @@ class TelegramCommandRoute:
     @property
     def is_chat(self) -> bool:
         return self.kind == "chat"
-

--- a/src/opentulpa/interfaces/telegram/chat_routing.py
+++ b/src/opentulpa/interfaces/telegram/chat_routing.py
@@ -1,0 +1,75 @@
+"""Telegram chat access and command routing policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TelegramAccessDecision:
+    normal_allowed: bool
+    support_allowed: bool
+
+    @classmethod
+    def from_flags(
+        cls,
+        *,
+        normal_allowed: bool,
+        support_allowed: bool,
+    ) -> TelegramAccessDecision:
+        decision = cls(normal_allowed=bool(normal_allowed), support_allowed=bool(support_allowed))
+        assert decision.allowed == (decision.normal_allowed or decision.support_allowed)
+        return decision
+
+    @property
+    def allowed(self) -> bool:
+        return self.normal_allowed or self.support_allowed
+
+    @property
+    def restricted_reply(self) -> str | None:
+        if self.allowed:
+            return None
+        return "This bot is restricted and your Telegram account is not allowed."
+
+    @property
+    def should_auto_bind_allowed_username(self) -> bool:
+        return self.normal_allowed and not self.support_allowed
+
+    @property
+    def should_configure_support_commands(self) -> bool:
+        return self.support_allowed
+
+
+@dataclass(frozen=True)
+class TelegramCommandRoute:
+    command_name: str
+    kind: str
+
+    @classmethod
+    def from_command(
+        cls,
+        *,
+        command_name: str,
+        support_allowed: bool,
+        is_support_command: bool,
+    ) -> TelegramCommandRoute:
+        safe_command = str(command_name or "").strip().lower()
+        assert not safe_command or safe_command.startswith("/")
+        if is_support_command:
+            kind = "support_command" if support_allowed else "restricted_support_command"
+        elif safe_command in {"/start", "/help"}:
+            kind = "start_help"
+        elif safe_command == "/status":
+            kind = "status"
+        elif safe_command == "/fresh":
+            kind = "fresh"
+        elif safe_command == "/debug_logs":
+            kind = "debug_logs"
+        else:
+            kind = "chat"
+        return cls(command_name=safe_command, kind=kind)
+
+    @property
+    def is_chat(self) -> bool:
+        return self.kind == "chat"
+

--- a/src/opentulpa/interfaces/telegram/chat_service.py
+++ b/src/opentulpa/interfaces/telegram/chat_service.py
@@ -23,6 +23,10 @@ from opentulpa.interfaces.telegram.attachments import (
     extract_attachments,
     ingest_attachments,
 )
+from opentulpa.interfaces.telegram.chat_routing import (
+    TelegramAccessDecision,
+    TelegramCommandRoute,
+)
 from opentulpa.interfaces.telegram.client import TelegramClient, parse_telegram_update
 from opentulpa.interfaces.telegram.constants import STATE_PATH
 from opentulpa.interfaces.telegram.env_management import (
@@ -1275,9 +1279,13 @@ async def handle_telegram_text(
         support_user_ids_csv=support_user_ids_csv,
         support_usernames_csv=support_usernames_csv,
     )
-    if not normal_allowed and not support_allowed:
-        return "This bot is restricted and your Telegram account is not allowed."
-    if normal_allowed and not support_allowed:
+    access = TelegramAccessDecision.from_flags(
+        normal_allowed=normal_allowed,
+        support_allowed=support_allowed,
+    )
+    if access.restricted_reply is not None:
+        return access.restricted_reply
+    if access.should_auto_bind_allowed_username:
         _maybe_auto_bind_allowed_username(
             owner_customer_id=owner_customer_id,
             allowed_usernames_csv=allowed_usernames_csv,
@@ -1285,7 +1293,7 @@ async def handle_telegram_text(
             user_id=ctx.user_id,
             bind_telegram_customer_id=bind_telegram_customer_id,
         )
-    if support_allowed:
+    if access.should_configure_support_commands:
         await _maybe_configure_support_commands_for_chat(
             bot_token=bot_token,
             chat_id=ctx.chat_id,
@@ -1302,20 +1310,25 @@ async def handle_telegram_text(
     _ = int(admin_user_id) == int(ctx.user_id)
 
     command_name = _telegram_command_name(ctx.text)
-    if _is_support_command(command_name):
-        if not support_allowed:
-            return "This support command is restricted to configured support operators."
+    command_route = TelegramCommandRoute.from_command(
+        command_name=command_name,
+        support_allowed=support_allowed,
+        is_support_command=_is_support_command(command_name),
+    )
+    if command_route.kind == "restricted_support_command":
+        return "This support command is restricted to configured support operators."
+    if command_route.kind == "support_command":
         return await _handle_support_command(
             command_name=command_name,
             ctx=ctx,
             customer_listing=support_customer_listing,
         )
-    if command_name in {"/start", "/help"}:
+    if command_route.kind == "start_help":
         return _start_help_text()
-    if command_name == "/status":
+    if command_route.kind == "status":
         agent_up = bool(agent_runtime and getattr(agent_runtime, "healthy", lambda: False)())
         return status_text(agent_up)
-    if command_name == "/fresh":
+    if command_route.kind == "fresh":
         if support_allowed:
             binding = _current_support_binding(ctx.chat_id)
             bound_customer = str((binding or {}).get("bound_customer_id", "") or "").strip()
@@ -1355,7 +1368,7 @@ async def handle_telegram_text(
             f"New thread: {thread_id}. "
             "Your long-term memory is unchanged."
         )
-    if command_name == "/debug_logs":
+    if command_route.kind == "debug_logs":
         return await _send_debug_logs_file(chat_id=ctx.chat_id, bot_token=bot_token)
 
     support_binding = None

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -878,7 +878,10 @@ async def relay_event_via_main_agent(
     slots = owner_slots or slots[:1]
     if agent_runtime is None:
         raise RuntimeError("Agent runtime unavailable for wake relay")
-    routine_payload = payload.get("payload") if isinstance(payload.get("payload"), dict) else {}
+    raw_routine_payload = payload.get("payload")
+    routine_payload: dict[str, Any] = (
+        dict(raw_routine_payload) if isinstance(raw_routine_payload, dict) else {}
+    )
     routine_instruction = str(routine_payload.get("instruction", "")).strip()
     routine_name = str(payload.get("routine_name", "")).strip()
     proactive_heartbeat = bool(routine_payload.get("proactive_heartbeat", False))

--- a/src/opentulpa/interfaces/telegram/relay.py
+++ b/src/opentulpa/interfaces/telegram/relay.py
@@ -46,6 +46,46 @@ class _WorkflowSetupRun:
     delivery_task: asyncio.Task[None] | None = None
 
 
+@dataclass
+class _LiveStreamState:
+    last_streamed: str = ""
+    waiting_for_segment: bool = True
+    consecutive_timeouts: int = 0
+    final_reply: str | None = None
+    timeout_failed_without_reply: bool = False
+    timeout_failure_stage: str = ""
+    next_chunk_task: asyncio.Task[Any] | None = None
+
+
+@dataclass
+class _TelegramDeliveryState:
+    final_reply: str | None = None
+    delivered_any: bool = False
+    draft_enabled: bool = True
+    live_delivery_text: str = ""
+    live_delivery_at: float = 0.0
+    interim_status_sent: bool = False
+
+
+@dataclass
+class _TelegramStreamResources:
+    client: TelegramClient
+    delivery: _TelegramDeliveryState
+    typing_stop: asyncio.Event
+    typing_task: asyncio.Task[None]
+    draft_id: int
+    stream_started_at: float
+    observability_context: Any
+    observability_closed: bool = False
+
+    def close_observability_context(self) -> None:
+        if self.observability_closed:
+            return
+        self.observability_closed = True
+        with suppress(Exception):
+            self.observability_context.__exit__(None, None, None)
+
+
 _WORKFLOW_SETUP_RUNS: dict[str, _WorkflowSetupRun] = {}
 
 
@@ -140,6 +180,405 @@ async def _emit_typing_until_done(
             await client.send_chat_action(chat_id=chat_id, action="typing")
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(stop_event.wait(), timeout=4.0)
+
+
+async def _session_has_pending_items(
+    *,
+    interactive_session: Any | None,
+    chat_id: int,
+    thread_id: str,
+    customer_id: str,
+) -> bool:
+    if interactive_session is None or not hasattr(interactive_session, "has_pending_items"):
+        return False
+    try:
+        return bool(await interactive_session.has_pending_items())
+    except Exception:
+        logger.exception(
+            "telegram.stream pending_items_check_failed chat_id=%s thread_id=%s customer_id=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+        )
+        return False
+
+
+async def _recover_after_stream_timeout(
+    *,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    turn_mode: str,
+) -> str | None:
+    if not hasattr(agent_runtime, "ainvoke_text"):
+        return None
+    try:
+        recovered = await asyncio.wait_for(
+            agent_runtime.ainvoke_text(
+                thread_id=thread_id,
+                customer_id=customer_id,
+                text=text,
+                turn_mode=turn_mode,
+            ),
+            timeout=90.0,
+        )
+    except Exception:
+        return None
+    safe = str(recovered or "").strip()
+    if not safe or is_low_signal_reply(safe):
+        return None
+    return safe
+
+
+async def _send_llm_status_update(
+    *,
+    agent_runtime: Any,
+    client: TelegramClient,
+    customer_id: str,
+    thread_id: str,
+    chat_id: int,
+    text: str,
+    turn_mode: str,
+    stage: str,
+) -> bool:
+    status_text = await generate_llm_status_message(
+        runtime=agent_runtime,
+        customer_id=customer_id,
+        thread_id=thread_id,
+        context={
+            "event": "telegram_owner_stream_waiting",
+            "stage": stage,
+            "turn_mode": normalize_turn_mode(turn_mode),
+            "latest_user_message": str(text or "").strip()[:1000],
+            "latest_user_message_usage": (
+                "Background context only. Use it to understand why the turn may be slow, "
+                "but do not quote, paraphrase, summarize, or mention it in the status text."
+            ),
+            "status_goal": (
+                "Send a generic progress update that says the assistant is still checking "
+                "or preparing the answer."
+            ),
+        },
+        language="Russian",
+    )
+    if not status_text:
+        logger.warning(
+            "telegram.stream status_generation_skipped chat_id=%s thread_id=%s customer_id=%s stage=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+            stage,
+        )
+        return False
+    sent = await client.send_message(chat_id=chat_id, text=status_text, parse_mode="HTML")
+    if not sent:
+        return False
+    append_web_event(
+        customer_id=customer_id,
+        thread_id=thread_id,
+        source="chat",
+        kind="status",
+        text=status_text,
+        metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
+    )
+    logger.info(
+        "telegram.stream status_generation_sent chat_id=%s thread_id=%s customer_id=%s stage=%s chars=%s",
+        chat_id,
+        thread_id,
+        customer_id,
+        stage,
+        len(status_text),
+    )
+    return True
+
+
+async def _send_status_once(
+    *,
+    delivery: _TelegramDeliveryState,
+    agent_runtime: Any,
+    client: TelegramClient,
+    customer_id: str,
+    thread_id: str,
+    chat_id: int,
+    text: str,
+    turn_mode: str,
+    stage: str,
+) -> None:
+    if delivery.interim_status_sent:
+        return
+    sent = await _send_llm_status_update(
+        agent_runtime=agent_runtime,
+        client=client,
+        customer_id=customer_id,
+        thread_id=thread_id,
+        chat_id=chat_id,
+        text=text,
+        turn_mode=turn_mode,
+        stage=stage,
+    )
+    if sent:
+        delivery.delivered_any = True
+        delivery.interim_status_sent = True
+
+
+async def _send_draft_reply(
+    *,
+    delivery: _TelegramDeliveryState,
+    client: TelegramClient,
+    typing_stop: asyncio.Event,
+    interactive_session: Any | None,
+    chat_id: int,
+    thread_id: str,
+    customer_id: str,
+    draft_id: int,
+    stream_started_at: float,
+    text: str,
+    force: bool = False,
+) -> None:
+    current = str(text or "").strip()
+    if not current:
+        return
+    if await _session_has_pending_items(
+        interactive_session=interactive_session,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        customer_id=customer_id,
+    ):
+        return
+    delivery.final_reply = current
+    if current == delivery.live_delivery_text and not force:
+        return
+    if not delivery.draft_enabled:
+        return
+    now = time.monotonic()
+    earliest_publish_at = _draft_earliest_publish_at(
+        delivery=delivery,
+        stream_started_at=stream_started_at,
+        force=force,
+    )
+    if now < earliest_publish_at:
+        return
+    if await client.send_message_draft(
+        chat_id=chat_id,
+        draft_id=draft_id,
+        text=current,
+        parse_mode="HTML",
+    ):
+        _record_draft_delivery(
+            delivery=delivery,
+            typing_stop=typing_stop,
+            text=current,
+            delivered_at=now,
+        )
+        return
+    delivery.draft_enabled = False
+    if not typing_stop.is_set():
+        typing_stop.set()
+    logger.warning(
+        "telegram.stream draft_disabled chat_id=%s thread_id=%s customer_id=%s",
+        chat_id,
+        thread_id,
+        customer_id,
+    )
+
+
+def _draft_earliest_publish_at(
+    *,
+    delivery: _TelegramDeliveryState,
+    stream_started_at: float,
+    force: bool,
+) -> float:
+    if force:
+        return 0.0
+    if not delivery.delivered_any:
+        return stream_started_at + DRAFT_INITIAL_PUBLISH_DELAY_SECONDS
+    return delivery.live_delivery_at + DRAFT_PUBLISH_MIN_INTERVAL_SECONDS
+
+
+def _record_draft_delivery(
+    *,
+    delivery: _TelegramDeliveryState,
+    typing_stop: asyncio.Event,
+    text: str,
+    delivered_at: float,
+) -> None:
+    if not typing_stop.is_set():
+        typing_stop.set()
+    delivery.delivered_any = True
+    delivery.live_delivery_text = text
+    delivery.live_delivery_at = delivered_at
+
+
+async def _cancel_stream_task(task: asyncio.Task[Any] | None) -> None:
+    if task is None or task.done():
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError, Exception):
+        async with asyncio.timeout(1.0):
+            await task
+
+
+async def _pump_stream_to_queue(
+    *,
+    stream: Any,
+    stream_queue: asyncio.Queue[tuple[str, Any]],
+    done_marker: object,
+) -> None:
+    try:
+        async for partial in stream:
+            await stream_queue.put(("chunk", partial))
+    except BaseException as exc:
+        await stream_queue.put(("error", exc))
+    else:
+        await stream_queue.put(("done", done_marker))
+
+
+def _stream_timeout_seconds(state: _LiveStreamState) -> float:
+    if not state.last_streamed:
+        return 90.0 if state.consecutive_timeouts == 0 else 180.0
+    return 180.0 if state.consecutive_timeouts == 0 else 240.0
+
+
+async def _handle_stream_timeout(
+    *,
+    state: _LiveStreamState,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    turn_mode: str,
+    chat_id: int,
+    send_status_once: Callable[..., Any],
+) -> bool:
+    state.consecutive_timeouts += 1
+    stage = "first_token" if not state.last_streamed else "idle"
+    if state.consecutive_timeouts < 2:
+        logger.warning(
+            "telegram.stream timeout_retry chat_id=%s thread_id=%s customer_id=%s stage=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+            stage,
+        )
+        if not state.last_streamed:
+            await send_status_once(stage=stage)
+        return False
+    await _cancel_stream_task(state.next_chunk_task)
+    state.next_chunk_task = None
+    recovered_text = await _recover_after_stream_timeout(
+        agent_runtime=agent_runtime,
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        turn_mode=turn_mode,
+    )
+    if recovered_text:
+        logger.warning(
+            "telegram.stream timeout_recovered chat_id=%s thread_id=%s customer_id=%s stage=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+            stage,
+        )
+        state.final_reply = recovered_text
+        return True
+    state.timeout_failed_without_reply = True
+    state.timeout_failure_stage = stage
+    logger.error(
+        "telegram.stream timeout_fail chat_id=%s thread_id=%s customer_id=%s stage=%s",
+        chat_id,
+        thread_id,
+        customer_id,
+        stage,
+    )
+    return True
+
+
+async def _apply_stream_payload(
+    *,
+    state: _LiveStreamState,
+    payload: Any,
+    send_draft_reply: Callable[..., Any],
+) -> None:
+    progress_text = payload if isinstance(payload, str) else ""
+    if progress_text and _is_progress_signal(progress_text):
+        if not state.waiting_for_segment:
+            state.waiting_for_segment = True
+            state.last_streamed = ""
+        return
+    if not isinstance(payload, str):
+        return
+    state.consecutive_timeouts = 0
+    current = payload.strip()
+    if not current or is_low_signal_reply(current) or current == state.last_streamed:
+        return
+    if state.last_streamed and not current.startswith(state.last_streamed):
+        state.waiting_for_segment = True
+        state.last_streamed = ""
+    if state.waiting_for_segment:
+        state.waiting_for_segment = False
+    state.last_streamed = current
+    await send_draft_reply(current)
+
+
+async def _run_live_stream_loop(
+    *,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    turn_mode: str,
+    chat_id: int,
+    send_draft_reply: Callable[..., Any],
+    send_status_once: Callable[..., Any],
+) -> _LiveStreamState:
+    stream = agent_runtime.astream_text(
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        turn_mode=turn_mode,
+    )
+    stream_done = object()
+    stream_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+    state = _LiveStreamState(
+        next_chunk_task=asyncio.create_task(
+            _pump_stream_to_queue(stream=stream, stream_queue=stream_queue, done_marker=stream_done)
+        )
+    )
+    while True:
+        try:
+            stream_status, stream_payload = await asyncio.wait_for(
+                stream_queue.get(),
+                timeout=_stream_timeout_seconds(state),
+            )
+        except TimeoutError:
+            if await _handle_stream_timeout(
+                state=state,
+                agent_runtime=agent_runtime,
+                thread_id=thread_id,
+                customer_id=customer_id,
+                text=text,
+                turn_mode=turn_mode,
+                chat_id=chat_id,
+                send_status_once=send_status_once,
+            ):
+                break
+            continue
+        if stream_status == "done":
+            state.next_chunk_task = None
+            break
+        if stream_status == "error":
+            state.next_chunk_task = None
+            if isinstance(stream_payload, BaseException):
+                raise stream_payload
+            raise RuntimeError(str(stream_payload))
+        await _apply_stream_payload(
+            state=state,
+            payload=stream_payload,
+            send_draft_reply=send_draft_reply,
+        )
+    return state
 
 
 async def _classify_workflow_setup_interruption(
@@ -314,462 +753,186 @@ def _ensure_workflow_setup_delivery_task(
     )
 
 
-async def stream_langgraph_reply_to_telegram(
+async def _existing_workflow_setup_reply(
+    *,
+    run: _WorkflowSetupRun,
+    agent_runtime: Any,
+    text: str,
+    chat_id: int,
+    thread_id: str,
+    customer_id: str,
+) -> str:
+    queued = False
+    status = {
+        "state": "workflow_setup_running",
+        "current_status": "The workflow setup/preflight/proposal run is still active.",
+        "pending_setup_updates": len(run.pending_texts),
+        "reply_if_status_nudge": WORKFLOW_SETUP_BUSY_REPLY,
+        "reply_if_setup_input": WORKFLOW_SETUP_QUEUED_REPLY,
+    }
+    decision = await _classify_workflow_setup_interruption(
+        agent_runtime=agent_runtime,
+        text=text,
+        status=status,
+    )
+    if str(decision.get("kind", "") or "") == "status_nudge":
+        final_reply = str(decision.get("status_reply", "") or "").strip()
+        if not final_reply:
+            final_reply = WORKFLOW_SETUP_BUSY_REPLY
+    else:
+        safe_text = str(text or "").strip()
+        if safe_text:
+            run.pending_texts.append(safe_text)
+            queued = True
+        final_reply = WORKFLOW_SETUP_QUEUED_REPLY
+    logger.info(
+        "telegram.stream workflow_setup_existing_run chat_id=%s thread_id=%s customer_id=%s kind=%s queued=%s pending_count=%s",
+        chat_id,
+        thread_id,
+        customer_id,
+        str(decision.get("kind", "") or ""),
+        queued,
+        len(run.pending_texts),
+    )
+    return final_reply
+
+
+async def _new_workflow_setup_reply(
+    *,
+    run_key: str,
+    run: _WorkflowSetupRun,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    turn_mode: str,
+    bot_token: str,
+    chat_id: int,
+    final_reply_callback: Callable[[str], Any] | None,
+) -> str | None:
+    try:
+        recovered = await asyncio.wait_for(
+            asyncio.shield(run.task),
+            timeout=WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning(
+            "telegram.stream workflow_setup_backgrounded chat_id=%s thread_id=%s customer_id=%s turn_mode=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+            turn_mode,
+        )
+        _ensure_workflow_setup_delivery_task(
+            run_key=run_key,
+            run=run,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            turn_mode=turn_mode,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            final_reply_callback=final_reply_callback,
+        )
+        return WORKFLOW_SETUP_BUSY_REPLY
+    except asyncio.CancelledError:
+        _ensure_workflow_setup_delivery_task(
+            run_key=run_key,
+            run=run,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            turn_mode=turn_mode,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            final_reply_callback=final_reply_callback,
+        )
+        raise
+    except Exception:
+        if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
+            _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+        raise
+    if run.pending_texts:
+        _ensure_workflow_setup_delivery_task(
+            run_key=run_key,
+            run=run,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            turn_mode=turn_mode,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            final_reply_callback=final_reply_callback,
+        )
+        return WORKFLOW_SETUP_QUEUED_REPLY
+    if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
+        _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+    safe = str(recovered or "").strip()
+    return safe if safe and not is_low_signal_reply(safe) else None
+
+
+async def _workflow_setup_reply(
     *,
     agent_runtime: Any,
     thread_id: str,
     customer_id: str,
     text: str,
+    turn_mode: str,
     bot_token: str,
     chat_id: int,
-    turn_mode: str = "interactive",
-    interactive_session: Any | None = None,
-    final_reply_callback: Callable[[str], Any] | None = None,
-) -> tuple[str | None, bool]:
-    last_streamed = ""
-    final_reply = None
-    delivered_any = False
-    live_delivery_text = ""
-    live_delivery_at = 0.0
-    client = TelegramClient(bot_token)
-    draft_id = (
-        zlib.crc32(f"{thread_id}:{customer_id}:{chat_id}:{new_short_id('dft')}".encode()) or 1
+    final_reply_callback: Callable[[str], Any] | None,
+) -> str | None:
+    run_key = _workflow_setup_run_key(customer_id=customer_id, thread_id=thread_id)
+    existing_run = _WORKFLOW_SETUP_RUNS.get(run_key)
+    if existing_run is not None and not _workflow_setup_run_active(existing_run):
+        _WORKFLOW_SETUP_RUNS.pop(run_key, None)
+        existing_run = None
+    if existing_run is not None:
+        return await _existing_workflow_setup_reply(
+            run=existing_run,
+            agent_runtime=agent_runtime,
+            text=text,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            customer_id=customer_id,
+        )
+    run = _WorkflowSetupRun(
+        task=_start_workflow_setup_task(
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            text=text,
+            turn_mode=turn_mode,
+        ),
+        pending_texts=[],
     )
-    draft_enabled = chat_id > 0
-    waiting_for_segment = True
-    typing_stop = asyncio.Event()
-    typing_task = asyncio.create_task(
-        _emit_typing_until_done(client=client, chat_id=chat_id, stop_event=typing_stop)
-    )
-    suppressed = False
-    first_token_timeout_s = 90.0
-    first_token_retry_timeout_s = 180.0
-    stream_idle_timeout_s = 180.0
-    stream_idle_retry_timeout_s = 240.0
-    consecutive_timeouts = 0
-    max_consecutive_timeouts = 2
-    timeout_failed_without_reply = False
-    timeout_failure_stage = ""
-    interim_status_sent = False
-    stream_started_at = time.monotonic()
-    final_only = normalize_turn_mode(turn_mode) == "workflow_setup"
-    next_chunk_task: asyncio.Task[Any] | None = None
-    logger.info(
-        "telegram.stream start chat_id=%s thread_id=%s customer_id=%s text_chars=%s",
-        chat_id,
-        thread_id,
-        customer_id,
-        len(str(text or "")),
-    )
-    observability_context = _telegram_observability_context(
+    _WORKFLOW_SETUP_RUNS[run_key] = run
+    return await _new_workflow_setup_reply(
+        run_key=run_key,
+        run=run,
         agent_runtime=agent_runtime,
         thread_id=thread_id,
         customer_id=customer_id,
-        text=text,
-        chat_id=chat_id,
         turn_mode=turn_mode,
+        bot_token=bot_token,
+        chat_id=chat_id,
+        final_reply_callback=final_reply_callback,
     )
-    observability_context.__enter__()
-    observability_closed = False
 
-    def _close_observability_context() -> None:
-        nonlocal observability_closed
-        if observability_closed:
-            return
-        observability_closed = True
-        with suppress(Exception):
-            observability_context.__exit__(None, None, None)
 
-    async def _session_has_pending_items() -> bool:
-        if interactive_session is None or not hasattr(interactive_session, "has_pending_items"):
-            return False
-        try:
-            return bool(await interactive_session.has_pending_items())
-        except Exception:
-            logger.exception(
-                "telegram.stream pending_items_check_failed chat_id=%s thread_id=%s customer_id=%s",
-                chat_id,
-                thread_id,
-                customer_id,
-            )
-            return False
-
-    async def _recover_after_stream_timeout() -> str | None:
-        if not hasattr(agent_runtime, "ainvoke_text"):
-            return None
-        try:
-            recovered = await asyncio.wait_for(
-                agent_runtime.ainvoke_text(
-                    thread_id=thread_id,
-                    customer_id=customer_id,
-                    text=text,
-                    turn_mode=turn_mode,
-                ),
-                timeout=90.0,
-            )
-        except Exception:
-            return None
-        safe = str(recovered or "").strip()
-        if not safe or is_low_signal_reply(safe):
-            return None
-        return safe
-
-    async def _send_draft_reply(text: str, *, force: bool = False) -> None:
-        nonlocal delivered_any, draft_enabled, final_reply, live_delivery_text, live_delivery_at
-        current = str(text or "").strip()
-        if not current:
-            return
-        if await _session_has_pending_items():
-            return
-        final_reply = current
-        if current == live_delivery_text and not force:
-            return
-        if not draft_enabled:
-            return
-        now = time.monotonic()
-        if not force:
-            earliest_publish_at = (
-                stream_started_at + DRAFT_INITIAL_PUBLISH_DELAY_SECONDS
-                if not delivered_any
-                else live_delivery_at + DRAFT_PUBLISH_MIN_INTERVAL_SECONDS
-            )
-            if now < earliest_publish_at:
-                return
-        if not await client.send_message_draft(
-            chat_id=chat_id,
-            draft_id=draft_id,
-            text=current,
-            parse_mode="HTML",
-        ):
-            draft_enabled = False
-            if not typing_stop.is_set():
-                typing_stop.set()
-            logger.warning(
-                "telegram.stream draft_disabled chat_id=%s thread_id=%s customer_id=%s",
-                chat_id,
-                thread_id,
-                customer_id,
-            )
-            return
-        if not typing_stop.is_set():
-            typing_stop.set()
-        delivered_any = True
-        live_delivery_text = current
-        live_delivery_at = now
-
-    async def _send_llm_status_update(*, stage: str) -> None:
-        nonlocal delivered_any, interim_status_sent
-        if interim_status_sent or last_streamed:
-            return
-        status_text = await generate_llm_status_message(
-            runtime=agent_runtime,
-            customer_id=customer_id,
-            thread_id=thread_id,
-            context={
-                "event": "telegram_owner_stream_waiting",
-                "stage": stage,
-                "turn_mode": normalize_turn_mode(turn_mode),
-                "latest_user_message": str(text or "").strip()[:1000],
-                "latest_user_message_usage": (
-                    "Background context only. Use it to understand why the turn may be slow, "
-                    "but do not quote, paraphrase, summarize, or mention it in the status text."
-                ),
-                "status_goal": (
-                    "Send a generic progress update that says the assistant is still checking "
-                    "or preparing the answer."
-                ),
-            },
-            language="Russian",
-        )
-        if not status_text:
-            logger.warning(
-                "telegram.stream status_generation_skipped chat_id=%s thread_id=%s customer_id=%s stage=%s",
-                chat_id,
-                thread_id,
-                customer_id,
-                stage,
-            )
-            return
-        sent = await client.send_message(
-            chat_id=chat_id,
-            text=status_text,
-            parse_mode="HTML",
-        )
-        if sent:
-            delivered_any = True
-            interim_status_sent = True
-            append_web_event(
-                customer_id=customer_id,
-                thread_id=thread_id,
-                source="chat",
-                kind="status",
-                text=status_text,
-                metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
-            )
-            logger.info(
-                "telegram.stream status_generation_sent chat_id=%s thread_id=%s customer_id=%s stage=%s chars=%s",
-                chat_id,
-                thread_id,
-                customer_id,
-                stage,
-                len(status_text),
-            )
-
-    try:
-        if final_only:
-            draft_enabled = False
-            run_key = _workflow_setup_run_key(customer_id=customer_id, thread_id=thread_id)
-            existing_run = _WORKFLOW_SETUP_RUNS.get(run_key)
-            if existing_run is not None and not _workflow_setup_run_active(existing_run):
-                _WORKFLOW_SETUP_RUNS.pop(run_key, None)
-                existing_run = None
-            if existing_run is not None:
-                queued = False
-                status = {
-                    "state": "workflow_setup_running",
-                    "current_status": "The workflow setup/preflight/proposal run is still active.",
-                    "pending_setup_updates": len(existing_run.pending_texts),
-                    "reply_if_status_nudge": WORKFLOW_SETUP_BUSY_REPLY,
-                    "reply_if_setup_input": WORKFLOW_SETUP_QUEUED_REPLY,
-                }
-                decision = await _classify_workflow_setup_interruption(
-                    agent_runtime=agent_runtime,
-                    text=text,
-                    status=status,
-                )
-                if str(decision.get("kind", "") or "") == "status_nudge":
-                    final_reply = str(decision.get("status_reply", "") or "").strip()
-                    if not final_reply:
-                        final_reply = WORKFLOW_SETUP_BUSY_REPLY
-                else:
-                    safe_text = str(text or "").strip()
-                    if safe_text:
-                        existing_run.pending_texts.append(safe_text)
-                        queued = True
-                    final_reply = WORKFLOW_SETUP_QUEUED_REPLY
-                logger.info(
-                    "telegram.stream workflow_setup_existing_run chat_id=%s thread_id=%s customer_id=%s kind=%s queued=%s pending_count=%s",
-                    chat_id,
-                    thread_id,
-                    customer_id,
-                    str(decision.get("kind", "") or ""),
-                    queued,
-                    len(existing_run.pending_texts),
-                )
-            else:
-                run = _WorkflowSetupRun(
-                    task=_start_workflow_setup_task(
-                        agent_runtime=agent_runtime,
-                        thread_id=thread_id,
-                        customer_id=customer_id,
-                        text=text,
-                        turn_mode=turn_mode,
-                    ),
-                    pending_texts=[],
-                )
-                _WORKFLOW_SETUP_RUNS[run_key] = run
-                try:
-                    recovered = await asyncio.wait_for(
-                        asyncio.shield(run.task),
-                        timeout=WORKFLOW_SETUP_FINAL_REPLY_TIMEOUT_SECONDS,
-                    )
-                except TimeoutError:
-                    logger.warning(
-                        "telegram.stream workflow_setup_backgrounded chat_id=%s thread_id=%s customer_id=%s turn_mode=%s",
-                        chat_id,
-                        thread_id,
-                        customer_id,
-                        turn_mode,
-                    )
-                    _ensure_workflow_setup_delivery_task(
-                        run_key=run_key,
-                        run=run,
-                        agent_runtime=agent_runtime,
-                        thread_id=thread_id,
-                        customer_id=customer_id,
-                        turn_mode=turn_mode,
-                        bot_token=bot_token,
-                        chat_id=chat_id,
-                        final_reply_callback=final_reply_callback,
-                    )
-                    final_reply = WORKFLOW_SETUP_BUSY_REPLY
-                except asyncio.CancelledError:
-                    _ensure_workflow_setup_delivery_task(
-                        run_key=run_key,
-                        run=run,
-                        agent_runtime=agent_runtime,
-                        thread_id=thread_id,
-                        customer_id=customer_id,
-                        turn_mode=turn_mode,
-                        bot_token=bot_token,
-                        chat_id=chat_id,
-                        final_reply_callback=final_reply_callback,
-                    )
-                    raise
-                except Exception:
-                    if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
-                        _WORKFLOW_SETUP_RUNS.pop(run_key, None)
-                    raise
-                else:
-                    if run.pending_texts:
-                        _ensure_workflow_setup_delivery_task(
-                            run_key=run_key,
-                            run=run,
-                            agent_runtime=agent_runtime,
-                            thread_id=thread_id,
-                            customer_id=customer_id,
-                            turn_mode=turn_mode,
-                            bot_token=bot_token,
-                            chat_id=chat_id,
-                            final_reply_callback=final_reply_callback,
-                        )
-                        final_reply = WORKFLOW_SETUP_QUEUED_REPLY
-                    else:
-                        if _WORKFLOW_SETUP_RUNS.get(run_key) is run:
-                            _WORKFLOW_SETUP_RUNS.pop(run_key, None)
-                        safe = str(recovered or "").strip()
-                        if safe and not is_low_signal_reply(safe):
-                            final_reply = safe
-        else:
-            stream = agent_runtime.astream_text(
-                thread_id=thread_id,
-                customer_id=customer_id,
-                text=text,
-                turn_mode=turn_mode,
-            )
-            stream_done = object()
-            stream_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
-
-            async def _pump_stream() -> None:
-                try:
-                    async for partial in stream:
-                        await stream_queue.put(("chunk", partial))
-                except BaseException as exc:
-                    await stream_queue.put(("error", exc))
-                else:
-                    await stream_queue.put(("done", stream_done))
-
-            next_chunk_task = asyncio.create_task(_pump_stream())
-            while True:
-                if not last_streamed:
-                    timeout_s = (
-                        first_token_timeout_s
-                        if consecutive_timeouts == 0
-                        else first_token_retry_timeout_s
-                    )
-                else:
-                    timeout_s = (
-                        stream_idle_timeout_s
-                        if consecutive_timeouts == 0
-                        else stream_idle_retry_timeout_s
-                    )
-                try:
-                    stream_status, stream_payload = await asyncio.wait_for(
-                        stream_queue.get(),
-                        timeout=timeout_s,
-                    )
-                except TimeoutError:
-                    consecutive_timeouts += 1
-                    if consecutive_timeouts < max_consecutive_timeouts:
-                        stage = "first_token" if not last_streamed else "idle"
-                        logger.warning(
-                            "telegram.stream timeout_retry chat_id=%s thread_id=%s customer_id=%s stage=%s",
-                            chat_id,
-                            thread_id,
-                            customer_id,
-                            stage,
-                        )
-                        if not last_streamed:
-                            await _send_llm_status_update(stage=stage)
-                        continue
-                    if next_chunk_task is not None and not next_chunk_task.done():
-                        next_chunk_task.cancel()
-                        with suppress(asyncio.CancelledError, Exception):
-                            async with asyncio.timeout(1.0):
-                                await next_chunk_task
-                    next_chunk_task = None
-                    recovered_text = await _recover_after_stream_timeout()
-                    if recovered_text:
-                        logger.warning(
-                            "telegram.stream timeout_recovered chat_id=%s thread_id=%s customer_id=%s stage=%s",
-                            chat_id,
-                            thread_id,
-                            customer_id,
-                            "first_token" if not last_streamed else "idle",
-                        )
-                        final_reply = recovered_text
-                        break
-                    timeout_failed_without_reply = True
-                    timeout_failure_stage = "first_token" if not last_streamed else "idle"
-                    logger.error(
-                        "telegram.stream timeout_fail chat_id=%s thread_id=%s customer_id=%s stage=%s",
-                        chat_id,
-                        thread_id,
-                        customer_id,
-                        timeout_failure_stage,
-                    )
-                    break
-                if stream_status == "done":
-                    next_chunk_task = None
-                    break
-                if stream_status == "error":
-                    next_chunk_task = None
-                    if isinstance(stream_payload, BaseException):
-                        raise stream_payload
-                    raise RuntimeError(str(stream_payload))
-                partial = stream_payload
-                progress_text = partial if isinstance(partial, str) else ""
-                if progress_text and _is_progress_signal(progress_text):
-                    if not waiting_for_segment:
-                        waiting_for_segment = True
-                        last_streamed = ""
-                    continue
-                if not isinstance(partial, str):
-                    continue
-                consecutive_timeouts = 0
-                current = partial.strip()
-                if not current or is_low_signal_reply(current) or current == last_streamed:
-                    continue
-                # Defensive boundary handling for streams that reset partial text without explicit signal.
-                if last_streamed and not current.startswith(last_streamed):
-                    waiting_for_segment = True
-                    last_streamed = ""
-                if waiting_for_segment:
-                    waiting_for_segment = False
-                last_streamed = current
-                await _send_draft_reply(current)
-    except MergedInputSuppressedError:
-        logger.info(
-            "telegram.stream suppressed_by_merge chat_id=%s thread_id=%s customer_id=%s",
-            chat_id,
-            thread_id,
-            customer_id,
-        )
-        suppressed = True
-    except Exception:
-        if next_chunk_task is not None and not next_chunk_task.done():
-            next_chunk_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                async with asyncio.timeout(1.0):
-                    await next_chunk_task
-        if not typing_stop.is_set():
-            typing_stop.set()
-        with suppress(Exception):
-            await typing_task
-        if hasattr(client, "aclose"):
-            with suppress(Exception):
-                await client.aclose()
-        _close_observability_context()
-        raise
-    if next_chunk_task is not None and not next_chunk_task.done():
-        next_chunk_task.cancel()
-        with suppress(asyncio.CancelledError, Exception):
-            async with asyncio.timeout(1.0):
-                await next_chunk_task
-    if not typing_stop.is_set():
-        typing_stop.set()
-    with suppress(Exception):
-        await typing_task
+async def _finalize_telegram_stream_reply(
+    *,
+    delivery: _TelegramDeliveryState,
+    client: TelegramClient,
+    interactive_session: Any | None,
+    customer_id: str,
+    thread_id: str,
+    chat_id: int,
+    turn_mode: str,
+    suppressed: bool,
+    timeout_failed_without_reply: bool,
+    timeout_failure_stage: str,
+) -> tuple[str | None, bool]:
+    final_reply = delivery.final_reply
     if not suppressed and not final_reply and timeout_failed_without_reply:
         logger.error(
             "telegram.stream timeout_without_final_reply chat_id=%s thread_id=%s customer_id=%s stage=%s "
@@ -778,8 +941,8 @@ async def stream_langgraph_reply_to_telegram(
             thread_id,
             customer_id,
             timeout_failure_stage,
-            interim_status_sent,
-            delivered_any,
+            delivery.interim_status_sent,
+            delivery.delivered_any,
         )
         final_reply = (
             "I couldn't finish that step before the reply timeout. "
@@ -796,33 +959,228 @@ async def stream_langgraph_reply_to_telegram(
             "I couldn't produce a visible user-facing reply for that step "
             "(the model/tool loop ended without displayable output)."
         )
-    if not suppressed and await _session_has_pending_items():
+    if not suppressed and await _session_has_pending_items(
+        interactive_session=interactive_session,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        customer_id=customer_id,
+    ):
         logger.info(
             "telegram.stream suppressed_by_interactive_pending chat_id=%s thread_id=%s customer_id=%s",
             chat_id,
             thread_id,
             customer_id,
         )
-        suppressed = True
-        final_reply = None
+        return None, True
     if not suppressed and final_reply:
-        sent = await client.send_message(
+        final_reply = await _send_final_telegram_reply(
+            client=client,
+            customer_id=customer_id,
+            thread_id=thread_id,
             chat_id=chat_id,
-            text=final_reply,
-            parse_mode="HTML",
+            turn_mode=turn_mode,
+            final_reply=final_reply,
         )
-        if sent:
-            delivered_any = True
-            append_web_event(
-                customer_id=customer_id,
-                thread_id=thread_id,
-                source="chat",
-                kind="assistant_message",
-                text=final_reply,
-                metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
-            )
-        else:
-            final_reply = None
+    return final_reply, suppressed
+
+
+async def _send_final_telegram_reply(
+    *,
+    client: TelegramClient,
+    customer_id: str,
+    thread_id: str,
+    chat_id: int,
+    turn_mode: str,
+    final_reply: str,
+) -> str | None:
+    sent = await client.send_message(chat_id=chat_id, text=final_reply, parse_mode="HTML")
+    if not sent:
+        return None
+    append_web_event(
+        customer_id=customer_id,
+        thread_id=thread_id,
+        source="chat",
+        kind="assistant_message",
+        text=final_reply,
+        metadata_json=json.dumps({"turn_mode": normalize_turn_mode(turn_mode)}),
+    )
+    return final_reply
+
+
+def _start_telegram_stream_resources(
+    *,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    bot_token: str,
+    chat_id: int,
+    turn_mode: str,
+) -> _TelegramStreamResources:
+    client = TelegramClient(bot_token)
+    draft_id = (
+        zlib.crc32(f"{thread_id}:{customer_id}:{chat_id}:{new_short_id('dft')}".encode()) or 1
+    )
+    typing_stop = asyncio.Event()
+    typing_task = asyncio.create_task(
+        _emit_typing_until_done(client=client, chat_id=chat_id, stop_event=typing_stop)
+    )
+    observability_context = _telegram_observability_context(
+        agent_runtime=agent_runtime,
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        chat_id=chat_id,
+        turn_mode=turn_mode,
+    )
+    observability_context.__enter__()
+    return _TelegramStreamResources(
+        client=client,
+        delivery=_TelegramDeliveryState(draft_enabled=chat_id > 0),
+        typing_stop=typing_stop,
+        typing_task=typing_task,
+        draft_id=draft_id,
+        stream_started_at=time.monotonic(),
+        observability_context=observability_context,
+    )
+
+
+async def _stop_telegram_stream_typing(
+    *,
+    resources: _TelegramStreamResources,
+    next_chunk_task: asyncio.Task[Any] | None,
+) -> None:
+    await _cancel_stream_task(next_chunk_task)
+    if not resources.typing_stop.is_set():
+        resources.typing_stop.set()
+    with suppress(Exception):
+        await resources.typing_task
+
+
+async def _close_telegram_stream_resources(resources: _TelegramStreamResources) -> None:
+    if hasattr(resources.client, "aclose"):
+        with suppress(Exception):
+            await resources.client.aclose()
+    resources.close_observability_context()
+
+
+async def _run_telegram_stream_delivery(
+    *,
+    resources: _TelegramStreamResources,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    bot_token: str,
+    chat_id: int,
+    turn_mode: str,
+    interactive_session: Any | None,
+    final_reply_callback: Callable[[str], Any] | None,
+) -> _LiveStreamState:
+    if normalize_turn_mode(turn_mode) == "workflow_setup":
+        return await _run_workflow_setup_stream_delivery(
+            resources=resources,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            text=text,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            turn_mode=turn_mode,
+            final_reply_callback=final_reply_callback,
+        )
+
+    async def _draft_reply(value: str, *, force: bool = False) -> None:
+        await _send_draft_reply(
+            delivery=resources.delivery,
+            client=resources.client,
+            typing_stop=resources.typing_stop,
+            interactive_session=interactive_session,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            draft_id=resources.draft_id,
+            stream_started_at=resources.stream_started_at,
+            text=value,
+            force=force,
+        )
+
+    async def _status_once(*, stage: str) -> None:
+        await _send_status_once(
+            delivery=resources.delivery,
+            agent_runtime=agent_runtime,
+            client=resources.client,
+            customer_id=customer_id,
+            thread_id=thread_id,
+            chat_id=chat_id,
+            text=text,
+            turn_mode=turn_mode,
+            stage=stage,
+        )
+
+    return await _run_live_stream_loop(
+        agent_runtime=agent_runtime,
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        turn_mode=turn_mode,
+        chat_id=chat_id,
+        send_draft_reply=_draft_reply,
+        send_status_once=_status_once,
+    )
+
+
+async def _run_workflow_setup_stream_delivery(
+    *,
+    resources: _TelegramStreamResources,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    bot_token: str,
+    chat_id: int,
+    turn_mode: str,
+    final_reply_callback: Callable[[str], Any] | None,
+) -> _LiveStreamState:
+    resources.delivery.draft_enabled = False
+    resources.delivery.final_reply = await _workflow_setup_reply(
+        agent_runtime=agent_runtime,
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        turn_mode=turn_mode,
+        bot_token=bot_token,
+        chat_id=chat_id,
+        final_reply_callback=final_reply_callback,
+    )
+    return _LiveStreamState(final_reply=resources.delivery.final_reply)
+
+
+async def _complete_telegram_stream(
+    *,
+    resources: _TelegramStreamResources,
+    next_chunk_task: asyncio.Task[Any] | None,
+    live_state: _LiveStreamState,
+    interactive_session: Any | None,
+    customer_id: str,
+    thread_id: str,
+    chat_id: int,
+    turn_mode: str,
+    suppressed: bool,
+) -> tuple[str | None, bool]:
+    await _stop_telegram_stream_typing(resources=resources, next_chunk_task=next_chunk_task)
+    final_reply, suppressed = await _finalize_telegram_stream_reply(
+        delivery=resources.delivery,
+        client=resources.client,
+        interactive_session=interactive_session,
+        customer_id=customer_id,
+        thread_id=thread_id,
+        chat_id=chat_id,
+        turn_mode=turn_mode,
+        suppressed=suppressed,
+        timeout_failed_without_reply=live_state.timeout_failed_without_reply,
+        timeout_failure_stage=live_state.timeout_failure_stage,
+    )
     logger.info(
         "telegram.stream complete chat_id=%s thread_id=%s customer_id=%s suppressed=%s final_chars=%s",
         chat_id,
@@ -831,11 +1189,80 @@ async def stream_langgraph_reply_to_telegram(
         suppressed,
         len(str(final_reply or "")),
     )
-    if hasattr(client, "aclose"):
-        with suppress(Exception):
-            await client.aclose()
-    _close_observability_context()
+    await _close_telegram_stream_resources(resources)
     return final_reply, suppressed
+
+
+async def stream_langgraph_reply_to_telegram(
+    *,
+    agent_runtime: Any,
+    thread_id: str,
+    customer_id: str,
+    text: str,
+    bot_token: str,
+    chat_id: int,
+    turn_mode: str = "interactive",
+    interactive_session: Any | None = None,
+    final_reply_callback: Callable[[str], Any] | None = None,
+) -> tuple[str | None, bool]:
+    resources = _start_telegram_stream_resources(
+        agent_runtime=agent_runtime,
+        thread_id=thread_id,
+        customer_id=customer_id,
+        text=text,
+        bot_token=bot_token,
+        chat_id=chat_id,
+        turn_mode=turn_mode,
+    )
+    suppressed = False
+    live_state = _LiveStreamState()
+    next_chunk_task: asyncio.Task[Any] | None = None
+    logger.info(
+        "telegram.stream start chat_id=%s thread_id=%s customer_id=%s text_chars=%s",
+        chat_id,
+        thread_id,
+        customer_id,
+        len(str(text or "")),
+    )
+
+    try:
+        live_state = await _run_telegram_stream_delivery(
+            resources=resources,
+            agent_runtime=agent_runtime,
+            thread_id=thread_id,
+            customer_id=customer_id,
+            text=text,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            turn_mode=turn_mode,
+            interactive_session=interactive_session,
+            final_reply_callback=final_reply_callback,
+        )
+        resources.delivery.final_reply = live_state.final_reply or resources.delivery.final_reply
+        next_chunk_task = live_state.next_chunk_task
+    except MergedInputSuppressedError:
+        logger.info(
+            "telegram.stream suppressed_by_merge chat_id=%s thread_id=%s customer_id=%s",
+            chat_id,
+            thread_id,
+            customer_id,
+        )
+        suppressed = True
+    except Exception:
+        await _stop_telegram_stream_typing(resources=resources, next_chunk_task=next_chunk_task)
+        await _close_telegram_stream_resources(resources)
+        raise
+    return await _complete_telegram_stream(
+        resources=resources,
+        next_chunk_task=next_chunk_task,
+        live_state=live_state,
+        interactive_session=interactive_session,
+        customer_id=customer_id,
+        thread_id=thread_id,
+        chat_id=chat_id,
+        turn_mode=turn_mode,
+        suppressed=suppressed,
+    )
 
 
 async def relay_task_event_via_main_agent(
@@ -860,6 +1287,178 @@ async def relay_task_event_via_main_agent(
         find_session_slots=find_session_slots,
         agent_runtime=agent_runtime,
     )
+
+
+@dataclass(frozen=True)
+class _WakeSlotState:
+    chat_id: int
+    chat_key: str
+    last_user_at: str
+    last_assistant_at: str
+    user_idle_hours: str
+    assistant_idle_hours: str
+
+
+def _wake_slot_state(slot: dict[str, Any], *, now_utc: datetime) -> _WakeSlotState:
+    chat_id = int(slot["chat_id"])
+    last_user_at = str(slot.get("last_user_message_at", "")).strip()
+    last_assistant_at = str(slot.get("last_assistant_message_at", "")).strip()
+    return _WakeSlotState(
+        chat_id=chat_id,
+        chat_key=str(chat_id),
+        last_user_at=last_user_at,
+        last_assistant_at=last_assistant_at,
+        user_idle_hours=_idle_hours_since(last_user_at, now_utc=now_utc),
+        assistant_idle_hours=_idle_hours_since(last_assistant_at, now_utc=now_utc),
+    )
+
+
+def _idle_hours_since(value: str, *, now_utc: datetime) -> str:
+    if not value:
+        return "unknown"
+    with suppress(Exception):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return f"{max(0.0, (now_utc - parsed).total_seconds() / 3600.0):.2f}"
+    return "unknown"
+
+
+async def _routine_wake_should_notify(
+    *,
+    agent_runtime: Any,
+    customer_id: str,
+    event_label: str,
+    routine_name: str,
+    routine_payload: dict[str, Any],
+    slot_state: _WakeSlotState,
+) -> bool:
+    if not hasattr(agent_runtime, "classify_wake_event"):
+        return True
+    precheck_payload = {
+        "event_label": event_label,
+        "routine_name": routine_name,
+        "routine_payload": routine_payload,
+        "last_user_message_at_utc": slot_state.last_user_at or "unknown",
+        "last_assistant_message_at_utc": slot_state.last_assistant_at or "unknown",
+        "user_idle_hours": slot_state.user_idle_hours,
+        "assistant_idle_hours": slot_state.assistant_idle_hours,
+    }
+    decision = {"notify_user": True}
+    with suppress(Exception):
+        decision = await agent_runtime.classify_wake_event(
+            customer_id=customer_id,
+            event_label="routine/heartbeat_precheck",
+            payload=precheck_payload,
+        )
+    return bool(decision.get("notify_user", False))
+
+
+def _build_wake_instruction(
+    *,
+    event_label: str,
+    payload: dict[str, Any],
+    routine_name: str,
+    routine_instruction: str,
+    slot_state: _WakeSlotState,
+    now_utc: datetime,
+) -> str:
+    if str(event_label).startswith("routine/"):
+        return (
+            "System update: a scheduled routine woke you.\n"
+            "Decide if the user should be messaged right now.\n"
+            f"- event: {event_label}\n"
+            f"- routine_name: {routine_name or 'unnamed'}\n"
+            f"- routine_instruction: {routine_instruction[:3000] or '(none)'}\n"
+            f"- last_user_message_at_utc: {slot_state.last_user_at or 'unknown'}\n"
+            f"- user_idle_hours: {slot_state.user_idle_hours}\n"
+            f"- last_assistant_message_at_utc: {slot_state.last_assistant_at or 'unknown'}\n"
+            f"- assistant_idle_hours: {slot_state.assistant_idle_hours}\n"
+            f"- now_utc: {now_utc.isoformat()}\n"
+            f"- payload: {json.dumps(payload, ensure_ascii=False)[:4000]}\n\n"
+            f"If you decide to skip messaging this run, reply exactly: {NO_NOTIFY_TOKEN}\n"
+            "If you decide to message, send one concise, natural message (no rigid status template)."
+        )
+    return (
+        "System update: a background event occurred.\n"
+        "Respond with concise plain-language status, what happened, and next action.\n"
+        f"- event: {event_label}\n"
+        f"- payload: {json.dumps(payload, ensure_ascii=False)[:4000]}"
+    )
+
+
+def _ensure_wake_thread_id(state: dict[str, Any], *, chat_key: str) -> str:
+    sessions = state.get("sessions")
+    if not isinstance(sessions, dict):
+        sessions = {}
+    raw_slot = sessions.get(chat_key)
+    if not isinstance(raw_slot, dict):
+        raw_slot = {}
+    wake_thread_id = _clean_thread_id(raw_slot.get("wake_thread_id"))
+    if not wake_thread_id or not wake_thread_id.lower().startswith("wake_"):
+        wake_thread_id = new_short_id("wake")
+        raw_slot["wake_thread_id"] = wake_thread_id
+        sessions[chat_key] = raw_slot
+        state["sessions"] = sessions
+    return wake_thread_id
+
+
+async def _relay_wake_slot_via_main_agent(
+    *,
+    slot: dict[str, Any],
+    customer_id: str,
+    event_label: str,
+    payload: dict[str, Any],
+    routine_payload: dict[str, Any],
+    routine_instruction: str,
+    routine_name: str,
+    proactive_heartbeat: bool,
+    now_utc: datetime,
+    state_store: Any,
+    agent_runtime: Any,
+) -> dict[str, Any] | None:
+    slot_state = _wake_slot_state(slot, now_utc=now_utc)
+    if (
+        str(event_label).startswith("routine/")
+        and proactive_heartbeat
+        and not await _routine_wake_should_notify(
+            agent_runtime=agent_runtime,
+            customer_id=customer_id,
+            event_label=event_label,
+            routine_name=routine_name,
+            routine_payload=routine_payload,
+            slot_state=slot_state,
+        )
+    ):
+        return None
+    instruction = _build_wake_instruction(
+        event_label=event_label,
+        payload=payload,
+        routine_name=routine_name,
+        routine_instruction=routine_instruction,
+        slot_state=slot_state,
+        now_utc=now_utc,
+    )
+    wake_thread_id = state_store.update(
+        lambda state, chat_key=slot_state.chat_key: _ensure_wake_thread_id(
+            state, chat_key=chat_key
+        )
+    )
+    text = await agent_runtime.ainvoke_text(
+        thread_id=wake_thread_id,
+        customer_id=customer_id,
+        text=instruction,
+        turn_mode="event_notification",
+        include_pending_context=False,
+        recursion_limit_override=36 if proactive_heartbeat else None,
+    )
+    safe = str(text or "").strip()
+    if not safe:
+        return None
+    return {
+        "chat_id": slot_state.chat_id,
+        "text": NO_NOTIFY_TOKEN if safe == NO_NOTIFY_TOKEN else safe,
+    }
 
 
 async def relay_event_via_main_agent(
@@ -888,107 +1487,22 @@ async def relay_event_via_main_agent(
     now_utc = datetime.now(UTC)
     replies: list[dict[str, Any]] = []
     for slot in slots:
-        chat_id = int(slot["chat_id"])
-        chat_key = str(chat_id)
-        last_user_at = str(slot.get("last_user_message_at", "")).strip()
-        last_assistant_at = str(slot.get("last_assistant_message_at", "")).strip()
-        user_idle_hours = "unknown"
-        assistant_idle_hours = "unknown"
-        if last_user_at:
-            with suppress(Exception):
-                parsed = datetime.fromisoformat(last_user_at.replace("Z", "+00:00"))
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=UTC)
-                user_idle_hours = f"{max(0.0, (now_utc - parsed).total_seconds() / 3600.0):.2f}"
-        if last_assistant_at:
-            with suppress(Exception):
-                parsed = datetime.fromisoformat(last_assistant_at.replace("Z", "+00:00"))
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=UTC)
-                assistant_idle_hours = (
-                    f"{max(0.0, (now_utc - parsed).total_seconds() / 3600.0):.2f}"
-                )
-
-        if (
-            str(event_label).startswith("routine/")
-            and proactive_heartbeat
-            and hasattr(agent_runtime, "classify_wake_event")
-        ):
-            precheck_payload = {
-                "event_label": event_label,
-                "routine_name": routine_name,
-                "routine_payload": routine_payload,
-                "last_user_message_at_utc": last_user_at or "unknown",
-                "last_assistant_message_at_utc": last_assistant_at or "unknown",
-                "user_idle_hours": user_idle_hours,
-                "assistant_idle_hours": assistant_idle_hours,
-            }
-            decision = {"notify_user": True}
-            with suppress(Exception):
-                decision = await agent_runtime.classify_wake_event(
-                    customer_id=customer_id,
-                    event_label="routine/heartbeat_precheck",
-                    payload=precheck_payload,
-                )
-            if not bool(decision.get("notify_user", False)):
-                continue
-
-        if str(event_label).startswith("routine/"):
-            instruction = (
-                "System update: a scheduled routine woke you.\n"
-                "Decide if the user should be messaged right now.\n"
-                f"- event: {event_label}\n"
-                f"- routine_name: {routine_name or 'unnamed'}\n"
-                f"- routine_instruction: {routine_instruction[:3000] or '(none)'}\n"
-                f"- last_user_message_at_utc: {last_user_at or 'unknown'}\n"
-                f"- user_idle_hours: {user_idle_hours}\n"
-                f"- last_assistant_message_at_utc: {last_assistant_at or 'unknown'}\n"
-                f"- assistant_idle_hours: {assistant_idle_hours}\n"
-                f"- now_utc: {now_utc.isoformat()}\n"
-                f"- payload: {json.dumps(payload, ensure_ascii=False)[:4000]}\n\n"
-                f"If you decide to skip messaging this run, reply exactly: {NO_NOTIFY_TOKEN}\n"
-                "If you decide to message, send one concise, natural message (no rigid status template)."
-            )
-        else:
-            instruction = (
-                "System update: a background event occurred.\n"
-                "Respond with concise plain-language status, what happened, and next action.\n"
-                f"- event: {event_label}\n"
-                f"- payload: {json.dumps(payload, ensure_ascii=False)[:4000]}"
-            )
-
-        def _ensure_wake_thread_id(state: dict[str, Any], _chat_key: str = chat_key) -> str:
-            sessions = state.get("sessions")
-            if not isinstance(sessions, dict):
-                sessions = {}
-            raw_slot = sessions.get(_chat_key)
-            if not isinstance(raw_slot, dict):
-                raw_slot = {}
-            wake_thread_id = _clean_thread_id(raw_slot.get("wake_thread_id"))
-            if not wake_thread_id or not wake_thread_id.lower().startswith("wake_"):
-                wake_thread_id = new_short_id("wake")
-                raw_slot["wake_thread_id"] = wake_thread_id
-                sessions[_chat_key] = raw_slot
-                state["sessions"] = sessions
-            return wake_thread_id
-
-        wake_thread_id = state_store.update(_ensure_wake_thread_id)
         try:
-            text = await agent_runtime.ainvoke_text(
-                thread_id=wake_thread_id,
+            reply = await _relay_wake_slot_via_main_agent(
+                slot=slot,
                 customer_id=customer_id,
-                text=instruction,
-                turn_mode="event_notification",
-                include_pending_context=False,
-                recursion_limit_override=36 if proactive_heartbeat else None,
+                event_label=event_label,
+                payload=payload,
+                routine_payload=routine_payload,
+                routine_instruction=routine_instruction,
+                routine_name=routine_name,
+                proactive_heartbeat=proactive_heartbeat,
+                now_utc=now_utc,
+                state_store=state_store,
+                agent_runtime=agent_runtime,
             )
-            safe = str(text or "").strip()
-            if not safe:
-                continue
-            if safe == NO_NOTIFY_TOKEN:
-                replies.append({"chat_id": chat_id, "text": NO_NOTIFY_TOKEN})
-                continue
-            replies.append({"chat_id": chat_id, "text": safe})
         except Exception:
             continue
+        if reply is not None:
+            replies.append(reply)
     return replies

--- a/src/opentulpa/interfaces/telegram/state_store.py
+++ b/src/opentulpa/interfaces/telegram/state_store.py
@@ -30,7 +30,8 @@ class TelegramStateStore:
         if not self.state_path.exists():
             return self._default_state()
         try:
-            return json.loads(self.state_path.read_text(encoding="utf-8"))
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else self._default_state()
         except Exception:
             return self._default_state()
 

--- a/src/opentulpa/logging/langfuse.py
+++ b/src/opentulpa/logging/langfuse.py
@@ -193,6 +193,12 @@ def _usage_details(record: dict[str, Any]) -> dict[str, int]:
                 details.setdefault("cache_read_input_tokens", cached)
             if cache_write is not None:
                 details.setdefault("cache_write_input_tokens", cache_write)
+        native_cached = _int_value(usage.get("prompt_cache_hit_tokens"))
+        native_miss = _int_value(usage.get("prompt_cache_miss_tokens"))
+        if native_cached is not None:
+            details.setdefault("cache_read_input_tokens", native_cached)
+        if native_miss is not None:
+            details.setdefault("cache_write_input_tokens", native_miss)
         completion_details = usage.get("completion_tokens_details")
         if isinstance(completion_details, dict):
             reasoning = _int_value(completion_details.get("reasoning_tokens"))

--- a/src/opentulpa/logging/langfuse.py
+++ b/src/opentulpa/logging/langfuse.py
@@ -11,7 +11,7 @@ import re
 import time
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, cast
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class _NoopContext:
     def __enter__(self) -> Any:
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
         return False
 
 
@@ -306,10 +306,10 @@ class _TraceUsageAccumulator:
     cost: dict[str, float] = field(default_factory=dict)
 
     def add(self, *, usage: dict[str, int], cost: dict[str, float]) -> None:
-        for key, value in usage.items():
-            self.usage[key] = int(self.usage.get(key, 0)) + int(value)
-        for key, value in cost.items():
-            self.cost[key] = float(self.cost.get(key, 0.0)) + float(value)
+        for key, usage_value in usage.items():
+            self.usage[key] = int(self.usage.get(key, 0)) + int(usage_value)
+        for key, cost_value in cost.items():
+            self.cost[key] = float(self.cost.get(key, 0.0)) + float(cost_value)
 
 
 @dataclass
@@ -361,7 +361,7 @@ class _LangfuseToolSpan:
             self._observation = self._ctx.__enter__()
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
         if exc is not None:
             self._status = "error"
             self._result = {"error": f"{type(exc).__name__}: {exc}"}
@@ -513,7 +513,7 @@ class LangfuseTracer:
             or None,
         }
         base.update(dict(metadata or {}))
-        return _json_safe(base)
+        return cast("dict[str, Any]", _json_safe(base))
 
     def tags(self, tags: list[str] | tuple[str, ...] | None = None) -> list[str]:
         resolved = ["opentulpa"]

--- a/src/opentulpa/memory/service.py
+++ b/src/opentulpa/memory/service.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import Any
 
-from mem0 import Memory
+from mem0 import Memory  # type: ignore[import-untyped]
 
 _MEM0_NOOP_MESSAGES = frozenset(
     {
@@ -176,8 +176,8 @@ class MemoryService:
             text = item.strip()
             if not text:
                 return None
-            metadata: dict[str, Any] = {}
-            kind = cls._infer_memory_kind(text=text, metadata=metadata) or "thread_context_rollup"
+            string_metadata: dict[str, Any] = {}
+            kind = cls._infer_memory_kind(text=text, metadata=string_metadata) or "thread_context_rollup"
             return {
                 "id": "",
                 "text": text,
@@ -193,8 +193,8 @@ class MemoryService:
             }
         if not isinstance(item, dict):
             return None
-        metadata = item.get("metadata")
-        metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        raw_metadata = item.get("metadata")
+        metadata: dict[str, Any] = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
         text = str(
             item.get("memory")
             or item.get("text")
@@ -256,7 +256,7 @@ class MemoryService:
         priority = MEMORY_KIND_PRIORITY.get(kind, 50)
         raw_score = record.get("score")
         try:
-            score = float(raw_score)
+            score = float(raw_score) if raw_score is not None else 0.0
         except (TypeError, ValueError):
             score = 0.0
         return priority, -score

--- a/src/opentulpa/persistence/__init__.py
+++ b/src/opentulpa/persistence/__init__.py
@@ -1,5 +1,9 @@
 """Persistence helpers shared across OpenTulpa runtime stores."""
 
-from opentulpa.persistence.sqlite import SQLITE_BUSY_TIMEOUT_MS, SQLITE_CONNECT_TIMEOUT_SECONDS, connect_sqlite
+from opentulpa.persistence.sqlite import (
+    SQLITE_BUSY_TIMEOUT_MS,
+    SQLITE_CONNECT_TIMEOUT_SECONDS,
+    connect_sqlite,
+)
 
 __all__ = ["connect_sqlite", "SQLITE_BUSY_TIMEOUT_MS", "SQLITE_CONNECT_TIMEOUT_SECONDS"]

--- a/src/opentulpa/scheduler/service.py
+++ b/src/opentulpa/scheduler/service.py
@@ -3,8 +3,6 @@
 import json
 import logging
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -12,10 +10,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.date import DateTrigger
+from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-untyped]
+from apscheduler.triggers.cron import CronTrigger  # type: ignore[import-untyped]
+from apscheduler.triggers.date import DateTrigger  # type: ignore[import-untyped]
 
+from opentulpa.persistence.sqlite import connect_sqlite
 from opentulpa.scheduler.models import Routine
 
 logger = logging.getLogger(__name__)

--- a/src/opentulpa/skills/service.py
+++ b/src/opentulpa/skills/service.py
@@ -10,14 +10,17 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from opentulpa.persistence.sqlite import connect_sqlite
 
 try:
-    import fcntl
+    import fcntl as _fcntl
 except ImportError:  # pragma: no cover
-    fcntl = None
+    _fcntl_module: Any = None
+else:
+    _fcntl_module = _fcntl
+fcntl: Any = _fcntl_module
 
 _DEFAULT_SKILL_CREATOR_DESCRIPTION = (
     "Use this skill when the user asks for recurring behavior/capabilities so the "
@@ -404,14 +407,17 @@ class SkillStoreService:
         customer_id: str,
         name: str,
     ) -> sqlite3.Row | None:
-        return conn.execute(
-            f"""
-            SELECT {_SKILL_ROW_COLUMNS}
-            FROM skills
-            WHERE scope=? AND customer_id=? AND name=?
-            """,
-            (scope, customer_id, name),
-        ).fetchone()
+        return cast(
+            "sqlite3.Row | None",
+            conn.execute(
+                f"""
+                SELECT {_SKILL_ROW_COLUMNS}
+                FROM skills
+                WHERE scope=? AND customer_id=? AND name=?
+                """,
+                (scope, customer_id, name),
+            ).fetchone(),
+        )
 
     def _fetch_listing_rows(
         self,
@@ -478,8 +484,11 @@ class SkillStoreService:
 
     @staticmethod
     def _should_prefer_item(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
-        return (candidate["scope"] == "user" and current["scope"] == "global") or (
-            candidate["updated_at"] > current["updated_at"]
+        return (
+            str(candidate.get("scope", "")) == "user"
+            and str(current.get("scope", "")) == "global"
+        ) or (
+            str(candidate.get("updated_at", "")) > str(current.get("updated_at", ""))
         )
 
     @staticmethod

--- a/src/opentulpa/tasks/sandbox.py
+++ b/src/opentulpa/tasks/sandbox.py
@@ -11,7 +11,7 @@ import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
@@ -321,7 +321,8 @@ def get_tulpa_catalog() -> dict[str, Any]:
     if not CATALOG_PATH.exists():
         _write_catalog(_default_catalog())
     try:
-        return json_load(CATALOG_PATH.read_text(encoding="utf-8"))
+        data = json_load(CATALOG_PATH.read_text(encoding="utf-8"))
+        return cast("dict[str, Any]", data) if isinstance(data, dict) else _default_catalog()
     except Exception:
         return _default_catalog()
 

--- a/src/opentulpa/tasks/service.py
+++ b/src/opentulpa/tasks/service.py
@@ -7,8 +7,6 @@ import contextlib
 import json
 import logging
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -16,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from opentulpa.core.ids import new_short_id
+from opentulpa.persistence.sqlite import connect_sqlite
 from opentulpa.tasks.sandbox import (
     append_task_event_log,
     list_artifacts,

--- a/src/opentulpa/tasks/service.py
+++ b/src/opentulpa/tasks/service.py
@@ -158,43 +158,15 @@ class TaskService:
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         async with self._lock:
-            with self._conn() as conn:
-                if idempotency_key:
-                    existing = conn.execute(
-                        "SELECT * FROM tasks WHERE customer_id=? AND idempotency_key=?",
-                        (customer_id, idempotency_key),
-                    ).fetchone()
-                    if existing:
-                        return self._row_to_task(existing)
-
-                task_id = new_short_id("task")
-                now = _utc_now()
-                conn.execute(
-                    """
-                    INSERT INTO tasks (
-                        id, customer_id, goal, status, risk_level, payload_json,
-                        requires_user_input, final_summary, idempotency_key, created_at, updated_at
-                    ) VALUES (?, ?, ?, 'queued', ?, ?, 0, NULL, ?, ?, ?)
-                    """,
-                    (
-                        task_id,
-                        customer_id,
-                        goal,
-                        risk_level,
-                        json.dumps(payload),
-                        idempotency_key,
-                        now,
-                        now,
-                    ),
-                )
-                conn.execute(
-                    """
-                    INSERT INTO task_runs (task_id, attempt_no, trigger_reason, result_status, created_at, finished_at)
-                    VALUES (?, 1, 'initial', NULL, ?, NULL)
-                    """,
-                    (task_id, now),
-                )
-                conn.commit()
+            existing_task, task_id = self._insert_task_if_absent(
+                customer_id=customer_id,
+                goal=goal,
+                payload=payload,
+                risk_level=risk_level,
+                idempotency_key=idempotency_key,
+            )
+            if existing_task is not None:
+                return existing_task
 
         await self._emit_event(task_id, "queued", {"goal": goal})
         # region agent log
@@ -214,6 +186,54 @@ class TaskService:
         # endregion
         self._spawn_runner(task_id)
         return self.get_task(task_id)
+
+    def _insert_task_if_absent(
+        self,
+        *,
+        customer_id: str,
+        goal: str,
+        payload: dict[str, Any],
+        risk_level: str,
+        idempotency_key: str | None,
+    ) -> tuple[dict[str, Any] | None, str]:
+        with self._conn() as conn:
+            if idempotency_key:
+                existing = conn.execute(
+                    "SELECT * FROM tasks WHERE customer_id=? AND idempotency_key=?",
+                    (customer_id, idempotency_key),
+                ).fetchone()
+                if existing:
+                    return self._row_to_task(existing), str(existing["id"])
+
+            task_id = new_short_id("task")
+            now = _utc_now()
+            conn.execute(
+                """
+                INSERT INTO tasks (
+                    id, customer_id, goal, status, risk_level, payload_json,
+                    requires_user_input, final_summary, idempotency_key, created_at, updated_at
+                ) VALUES (?, ?, ?, 'queued', ?, ?, 0, NULL, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    customer_id,
+                    goal,
+                    risk_level,
+                    json.dumps(payload),
+                    idempotency_key,
+                    now,
+                    now,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO task_runs (task_id, attempt_no, trigger_reason, result_status, created_at, finished_at)
+                VALUES (?, 1, 'initial', NULL, ?, NULL)
+                """,
+                (task_id, now),
+            )
+            conn.commit()
+        return None, task_id
 
     def get_task(self, task_id: str) -> dict[str, Any]:
         with self._conn() as conn:
@@ -330,119 +350,11 @@ class TaskService:
             await self._set_status(task_id, "running")
             await self._emit_event(task_id, "running", {"step_count": len(steps)})
             artifact_dir = task_artifact_dir(task_id)
-
-            if not steps:
-                await self._set_status(task_id, "needs_input", requires_user_input=True)
-                await self._emit_event(
-                    task_id,
-                    "needs_input",
-                    {"reason": "No executable steps provided in payload."},
-                )
+            if not await self._run_task_steps(task_id=task_id, steps=steps, artifact_dir=artifact_dir):
                 return
-
-            for idx, step in enumerate(steps):
-                self._heartbeats[task_id] = time.monotonic()
-                await self._emit_event(task_id, "step_started", {"index": idx, "step": step})
-                if not isinstance(step, dict):
-                    # region agent log
-                    _debug_log(
-                        hypothesis_id="tasks",
-                        location="tasks/service.py:_run_task",
-                        message="invalid_step_schema",
-                        data={
-                            "task_id": task_id,
-                            "index": idx,
-                            "received_type": type(step).__name__,
-                        },
-                    )
-                    # endregion
-                    await self._set_status(
-                        task_id,
-                        "needs_input",
-                        requires_user_input=True,
-                        summary="Task steps must be objects with a 'type' field.",
-                    )
-                    await self._emit_event(
-                        task_id,
-                        "needs_input",
-                        {
-                            "reason": "Invalid task step schema.",
-                            "index": idx,
-                            "expected": "step object like {'type': 'run_terminal', ...}",
-                            "received_type": type(step).__name__,
-                        },
-                    )
-                    return
-                step_type = step.get("type")
-
-                if step_type == "write_file":
-                    target = write_file(step.get("path", ""), step.get("content", ""))
-                    await self._emit_event(
-                        task_id,
-                        "step_done",
-                        {"index": idx, "type": step_type, "path": str(target)},
-                    )
-                elif step_type == "run_terminal":
-                    extra_env = {"TASK_ARTIFACT_DIR": str(artifact_dir)}
-                    result = run_terminal(
-                        command=step.get("command", ""),
-                        working_dir=step.get("working_dir", "tulpa_stuff"),
-                        timeout_seconds=int(step.get("timeout_seconds", 90)),
-                        extra_env=extra_env,
-                    )
-                    await self._emit_event(
-                        task_id,
-                        "step_done",
-                        {
-                            "index": idx,
-                            "type": step_type,
-                            "ok": result["ok"],
-                            "returncode": result["returncode"],
-                            "stdout": result["stdout"],
-                            "stderr": result["stderr"],
-                            "cwd": result["cwd"],
-                        },
-                    )
-                    if not result["ok"]:
-                        await self._handle_failure(task_id, "command_failed", result)
-                        return
-                elif step_type == "sleep":
-                    await asyncio.sleep(float(step.get("seconds", 1)))
-                    await self._emit_event(task_id, "step_done", {"index": idx, "type": step_type})
-                elif step_type == "reload_tulpa":
-                    # Worker can ask main agent to call reload; mark advisory event.
-                    await self._emit_event(
-                        task_id,
-                        "step_done",
-                        {"index": idx, "type": step_type, "note": "Call tulpa_reload tool now."},
-                    )
-                else:
-                    await self._handle_failure(task_id, "unknown_step_type", {"step": step})
-                    return
-
-            # Optional low-risk tests.
             tests = payload.get("tests", [])
-            for test in tests:
-                result = run_terminal(
-                    command=test.get("command", ""),
-                    working_dir=test.get("working_dir", "tulpa_stuff"),
-                    timeout_seconds=int(test.get("timeout_seconds", 90)),
-                    extra_env={"TASK_ARTIFACT_DIR": str(artifact_dir)},
-                )
-                await self._emit_event(
-                    task_id,
-                    "test_result",
-                    {
-                        "ok": result["ok"],
-                        "returncode": result["returncode"],
-                        "stdout": result["stdout"],
-                        "stderr": result["stderr"],
-                        "command": test.get("command", ""),
-                    },
-                )
-                if not result["ok"]:
-                    await self._handle_failure(task_id, "test_failed", result)
-                    return
+            if not await self._run_task_tests(task_id=task_id, tests=tests, artifact_dir=artifact_dir):
+                return
 
             artifacts = list_artifacts(task_id)
             await self._set_status(task_id, "done", summary="Task finished successfully.")
@@ -473,6 +385,122 @@ class TaskService:
         finally:
             self._heartbeats.pop(task_id, None)
             self._running_tasks.pop(task_id, None)
+
+    async def _run_task_steps(self, *, task_id: str, steps: Any, artifact_dir: Any) -> bool:
+        if not steps:
+            await self._set_status(task_id, "needs_input", requires_user_input=True)
+            await self._emit_event(
+                task_id,
+                "needs_input",
+                {"reason": "No executable steps provided in payload."},
+            )
+            return False
+        for idx, step in enumerate(steps):
+            if not await self._run_one_task_step(
+                task_id=task_id,
+                index=idx,
+                step=step,
+                artifact_dir=artifact_dir,
+            ):
+                return False
+        return True
+
+    async def _run_one_task_step(
+        self,
+        *,
+        task_id: str,
+        index: int,
+        step: Any,
+        artifact_dir: Any,
+    ) -> bool:
+        self._heartbeats[task_id] = time.monotonic()
+        await self._emit_event(task_id, "step_started", {"index": index, "step": step})
+        if not isinstance(step, dict):
+            await self._handle_invalid_step(task_id=task_id, index=index, step=step)
+            return False
+        step_type = step.get("type")
+        if step_type == "write_file":
+            target = write_file(step.get("path", ""), step.get("content", ""))
+            await self._emit_event(task_id, "step_done", {"index": index, "type": step_type, "path": str(target)})
+            return True
+        if step_type == "run_terminal":
+            return await self._run_terminal_step(
+                task_id=task_id,
+                index=index,
+                step=step,
+                artifact_dir=artifact_dir,
+            )
+        if step_type == "sleep":
+            await asyncio.sleep(float(step.get("seconds", 1)))
+            await self._emit_event(task_id, "step_done", {"index": index, "type": step_type})
+            return True
+        if step_type == "reload_tulpa":
+            await self._emit_event(
+                task_id,
+                "step_done",
+                {"index": index, "type": step_type, "note": "Call tulpa_reload tool now."},
+            )
+            return True
+        await self._handle_failure(task_id, "unknown_step_type", {"step": step})
+        return False
+
+    async def _handle_invalid_step(self, *, task_id: str, index: int, step: Any) -> None:
+        _debug_log(
+            hypothesis_id="tasks",
+            location="tasks/service.py:_run_task",
+            message="invalid_step_schema",
+            data={"task_id": task_id, "index": index, "received_type": type(step).__name__},
+        )
+        await self._set_status(
+            task_id,
+            "needs_input",
+            requires_user_input=True,
+            summary="Task steps must be objects with a 'type' field.",
+        )
+        await self._emit_event(
+            task_id,
+            "needs_input",
+            {
+                "reason": "Invalid task step schema.",
+                "index": index,
+                "expected": "step object like {'type': 'run_terminal', ...}",
+                "received_type": type(step).__name__,
+            },
+        )
+
+    async def _run_terminal_step(
+        self,
+        *,
+        task_id: str,
+        index: int,
+        step: dict[str, Any],
+        artifact_dir: Any,
+    ) -> bool:
+        result = run_terminal(
+            command=step.get("command", ""),
+            working_dir=step.get("working_dir", "tulpa_stuff"),
+            timeout_seconds=int(step.get("timeout_seconds", 90)),
+            extra_env={"TASK_ARTIFACT_DIR": str(artifact_dir)},
+        )
+        await self._emit_event(task_id, "step_done", _terminal_step_payload(index=index, result=result))
+        if result["ok"]:
+            return True
+        await self._handle_failure(task_id, "command_failed", result)
+        return False
+
+    async def _run_task_tests(self, *, task_id: str, tests: Any, artifact_dir: Any) -> bool:
+        for test in tests:
+            result = run_terminal(
+                command=test.get("command", ""),
+                working_dir=test.get("working_dir", "tulpa_stuff"),
+                timeout_seconds=int(test.get("timeout_seconds", 90)),
+                extra_env={"TASK_ARTIFACT_DIR": str(artifact_dir)},
+            )
+            await self._emit_event(task_id, "test_result", _test_result_payload(test=test, result=result))
+            if not result["ok"]:
+                await self._handle_failure(task_id, "test_failed", result)
+                return False
+        return True
 
     async def _handle_failure(self, task_id: str, reason: str, data: dict[str, Any]) -> None:
         task = self.get_task(task_id)
@@ -627,3 +655,25 @@ class TaskService:
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
         }
+
+
+def _terminal_step_payload(*, index: int, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "index": index,
+        "type": "run_terminal",
+        "ok": result["ok"],
+        "returncode": result["returncode"],
+        "stdout": result["stdout"],
+        "stderr": result["stderr"],
+        "cwd": result["cwd"],
+    }
+
+
+def _test_result_payload(*, test: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ok": result["ok"],
+        "returncode": result["returncode"],
+        "stdout": result["stdout"],
+        "stderr": result["stderr"],
+        "command": test.get("command", ""),
+    }

--- a/src/opentulpa/tasks/wake_queue.py
+++ b/src/opentulpa/tasks/wake_queue.py
@@ -7,12 +7,12 @@ import contextlib
 import json
 import logging
 import sqlite3
-
-from opentulpa.persistence.sqlite import connect_sqlite
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+from opentulpa.persistence.sqlite import connect_sqlite
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class WakeQueueService:
                 (json.dumps(payload), now, now, now),
             )
             conn.commit()
-            return int(cur.lastrowid)
+            return int(cur.lastrowid or 0)
 
     def stats(self) -> dict[str, Any]:
         with self._conn() as conn:
@@ -167,7 +167,7 @@ class WakeQueueService:
                 (now, row["id"]),
             )
             conn.commit()
-            return row
+            return cast("sqlite3.Row | None", row)
 
     def _mark_done(self, item_id: int) -> None:
         with self._conn() as conn:

--- a/tests/e2e/scenarios/test_google_sheets_sink_resolution.py
+++ b/tests/e2e/scenarios/test_google_sheets_sink_resolution.py
@@ -76,6 +76,36 @@ def _list_workflows(harness: E2EHarness, *, customer_id: str) -> list[dict[str, 
     return workflows if isinstance(workflows, list) else []
 
 
+def _telegram_owner_thread_id(*, chat_id: int) -> str:
+    from opentulpa.interfaces.telegram import chat_service as chat_module
+
+    state = chat_module.STATE_STORE.load()
+    sessions = state.get("sessions") if isinstance(state, dict) else {}
+    slot = sessions.get(str(chat_id)) if isinstance(sessions, dict) else {}
+    if not isinstance(slot, dict):
+        return ""
+    return str(slot.get("thread_id", "") or "").strip()
+
+
+def _workflow_setup_has_proposal(
+    harness: E2EHarness,
+    *,
+    customer_id: str,
+    thread_id: str,
+) -> bool:
+    response = harness.client.post(
+        "/internal/intake/setup/get",
+        json={"customer_id": customer_id, "thread_id": thread_id, "include_paused": True},
+    )
+    if response.status_code != 200:
+        return False
+    payload = response.json()
+    session = payload.get("session")
+    if not isinstance(session, dict):
+        return False
+    return bool(str(session.get("last_proposed_draft_hash", "") or "").strip())
+
+
 def _first_sheet_row(write: dict[str, Any]) -> dict[str, Any]:
     normalized = write.get("normalized_rows")
     if isinstance(normalized, list) and normalized and isinstance(normalized[0], dict):
@@ -286,13 +316,45 @@ def test_live_llm_telegram_business_intake_upserts_partial_identity_then_final_r
         lambda: len(e2e_harness.telegram_client.sent_messages) > owner_message_count,
         timeout_seconds=90.0,
     )
+    owner_thread_id = _telegram_owner_thread_id(chat_id=owner_chat_id)
+    assert owner_thread_id
+    if not _wait_until(
+        lambda: _workflow_setup_has_proposal(
+            e2e_harness,
+            customer_id=customer_id,
+            thread_id=owner_thread_id,
+        ),
+        timeout_seconds=90.0,
+    ):
+        assert (
+            e2e_harness.post_telegram(
+                body=_telegram_message(
+                    chat_id=owner_chat_id,
+                    user_id=owner_user_id,
+                    message_id=102,
+                    text=(
+                        "Use the workflow setup tools now: persist that exact draft, run preflight, "
+                        "mark it proposed, and wait for my confirmation before saving."
+                    ),
+                )
+            )
+            == 200
+        )
+        assert _wait_until(
+            lambda: _workflow_setup_has_proposal(
+                e2e_harness,
+                customer_id=customer_id,
+                thread_id=owner_thread_id,
+            ),
+            timeout_seconds=90.0,
+        )
     assert _list_workflows(e2e_harness, customer_id=customer_id) == []
     assert (
         e2e_harness.post_telegram(
             body=_telegram_message(
                 chat_id=owner_chat_id,
                 user_id=owner_user_id,
-                message_id=102,
+                message_id=103,
                 text="Looks correct. Save and activate this workflow now exactly as proposed.",
             )
         )

--- a/tests/e2e/scenarios/test_telegram_intake_workflow_real_chat.py
+++ b/tests/e2e/scenarios/test_telegram_intake_workflow_real_chat.py
@@ -172,6 +172,8 @@ def _looks_like_owner_proposal_message(item: dict[str, Any]) -> bool:
             "confirm",
             "save",
             "activate",
+            "commit",
+            "looks good",
             "подтверж",
             "сохран",
             "активир",
@@ -435,6 +437,10 @@ def _csv_rows_for_relative_path(
             {str(key): str(value or "") for key, value in row.items()}
             for row in csv.DictReader(handle)
         ]
+
+
+def _booking_category(row: dict[str, str]) -> str:
+    return str(row.get("service_category") or row.get("category") or "").strip().lower()
 
 
 def _lead_source_messages(
@@ -1924,13 +1930,13 @@ def test_live_ai_owner_creates_autospa_business_knowledge_workflow_and_simulated
         wash_row = by_conversation.get("39101") or {}
         tire_row = by_conversation.get("39102") or {}
         assert str(wash_row.get("status", "")).strip().lower() == "completed"
-        assert str(wash_row.get("service_category", "")).strip().lower() == "мойка"
+        assert _booking_category(wash_row) == "мойка"
         assert "2х-фазная" in str(wash_row.get("service_name", "")).lower()
         assert str(wash_row.get("quoted_price", "")).strip()
         assert str(wash_row.get("lead_name", "")).strip().lower() == "алексей"
         assert str(wash_row.get("phone", "")).strip() == "+79990001001"
         assert str(tire_row.get("status", "")).strip().lower() == "completed"
-        assert str(tire_row.get("service_category", "")).strip().lower() == "шиномонтаж"
+        assert _booking_category(tire_row) == "шиномонтаж"
         tire_service_text = (
             f"{tire_row.get('service_name', '')} {tire_row.get('vehicle_type', '')}".lower()
         )

--- a/tests/e2e/scenarios/test_telegram_interactive_owner_update.py
+++ b/tests/e2e/scenarios/test_telegram_interactive_owner_update.py
@@ -252,6 +252,7 @@ def _build_deterministic_runtime() -> tuple[OpenTulpaLangGraphRuntime, list[list
     runtime.register_links_from_text = lambda **kwargs: []  # type: ignore[assignment]
     runtime.expand_link_aliases = lambda **kwargs: str(kwargs.get("text", ""))  # type: ignore[assignment]
     runtime.ainvoke_model = _ainvoke_model  # type: ignore[method-assign]
+    runtime.astream_model = _ainvoke_model  # type: ignore[method-assign]
     runtime.model_with_tools_for_turn_mode = lambda turn_mode: runtime._model_with_tools  # type: ignore[assignment]
     runtime.log_behavior_event = lambda **kwargs: behavior_events.append(kwargs)  # type: ignore[assignment]
 
@@ -542,7 +543,7 @@ def test_live_telegram_interactive_chat_remembers_and_honors_style_preference(
         assert "Markdown" in stored_text or "markdown" in stored_text
         assert "natur" in stored_text.lower() or "естествен" in stored_text.lower()
         assert any(
-            item.get("path") == "/internal/memory/add"
+            item.get("path") in {"/internal/memory/add", "/internal/directive/set"}
             for item in harness.internal_api_calls_since(internal_start)
         )
 

--- a/tests/e2e/scenarios/test_telegram_user_context_real_files.py
+++ b/tests/e2e/scenarios/test_telegram_user_context_real_files.py
@@ -375,13 +375,22 @@ def test_live_telegram_chat_uploads_real_files_then_queries_user_context(
             if item.get("path") == "/internal/user_context/add_files"
         ]
 
-    assert _wait_until(lambda: bool(add_file_calls()), timeout_seconds=240.0), add_file_calls()
-    added_file_ids = [
-        file_id
-        for call in add_file_calls()
-        for file_id in call.get("json_body", {}).get("file_ids", [])
-    ]
-    assert len(set(added_file_ids)) == 2, add_file_calls()
+    def added_file_ids() -> list[str]:
+        return [
+            file_id
+            for call in add_file_calls()
+            for file_id in call.get("json_body", {}).get("file_ids", [])
+        ]
+
+    assert _wait_until(lambda: len(set(added_file_ids())) == 2, timeout_seconds=240.0), add_file_calls()
+    collected_file_ids = added_file_ids()
+    assert len(set(collected_file_ids)) == 2, add_file_calls()
+    assert _wait_until(
+        lambda: bool(
+            _messages_for_chat(e2e_harness, chat_id=owner_chat_id, start_index=upload_start)
+        ),
+        timeout_seconds=180.0,
+    )
     upload_messages = _messages_for_chat(e2e_harness, chat_id=owner_chat_id, start_index=upload_start)
     assert upload_messages
 
@@ -826,33 +835,6 @@ def test_live_telegram_chat_recalls_image_and_video_user_context(
         timeout_seconds=180.0,
     )
 
-    image_status = e2e_harness.post_telegram(
-        body=_telegram_photo_message(
-            chat_id=owner_chat_id,
-            user_id=owner_user_id,
-            username=username,
-            message_id=2002,
-            file_id="tg_blog_sprint_cta",
-            file_unique_id="blog_sprint_cta_unique",
-            file_size=int(image_tg["file_size"]),
-        )
-    )
-    video_status = e2e_harness.post_telegram(
-        body=_telegram_video_message(
-            chat_id=owner_chat_id,
-            user_id=owner_user_id,
-            username=username,
-            message_id=2003,
-            file_id="tg_retention_loop_video",
-            file_unique_id="retention_loop_unique",
-            file_name="retention_loop.mp4",
-            mime_type=str(video_tg["mime_type"]),
-            file_size=int(video_tg["file_size"]),
-        )
-    )
-    assert image_status == 200
-    assert video_status == 200
-
     def add_file_calls() -> list[dict[str, Any]]:
         return [
             item
@@ -866,6 +848,35 @@ def test_live_telegram_chat_recalls_image_and_video_user_context(
             for call in add_file_calls()
             for file_id in call.get("json_body", {}).get("file_ids", [])
         ]
+
+    image_status = e2e_harness.post_telegram(
+        body=_telegram_photo_message(
+            chat_id=owner_chat_id,
+            user_id=owner_user_id,
+            username=username,
+            message_id=2002,
+            file_id="tg_blog_sprint_cta",
+            file_unique_id="blog_sprint_cta_unique",
+            file_size=int(image_tg["file_size"]),
+        )
+    )
+    assert image_status == 200
+    assert _wait_until(lambda: len(set(added_file_ids())) == 1, timeout_seconds=240.0), add_file_calls()
+
+    video_status = e2e_harness.post_telegram(
+        body=_telegram_video_message(
+            chat_id=owner_chat_id,
+            user_id=owner_user_id,
+            username=username,
+            message_id=2003,
+            file_id="tg_retention_loop_video",
+            file_unique_id="retention_loop_unique",
+            file_name="retention_loop.mp4",
+            mime_type=str(video_tg["mime_type"]),
+            file_size=int(video_tg["file_size"]),
+        )
+    )
+    assert video_status == 200
 
     assert _wait_until(lambda: len(set(added_file_ids())) == 2, timeout_seconds=360.0), add_file_calls()
     assert len(set(added_file_ids())) == 2, add_file_calls()

--- a/tests/test_api_app_runtime_services.py
+++ b/tests/test_api_app_runtime_services.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from opentulpa.api.app import create_app
+from opentulpa.intake.service import IntakeWorkflowService
+from opentulpa.scheduler.service import SchedulerService
+from opentulpa.skills.service import SkillStoreService
+
+
+class _DisabledComposio:
+    enabled = False
+
+    def status(self) -> dict[str, object]:
+        return {"ok": True, "enabled": False}
+
+
+class _RuntimeWithPublicServiceConfigurer:
+    def __init__(self) -> None:
+        self.configured: list[dict[str, Any]] = []
+
+    def configure_api_services(
+        self,
+        *,
+        link_alias_service: Any,
+        composio_service: Any,
+        workflow_setup_service: Any,
+    ) -> None:
+        self.configured.append(
+            {
+                "link_alias_service": link_alias_service,
+                "composio_service": composio_service,
+                "workflow_setup_service": workflow_setup_service,
+            }
+        )
+
+
+def test_create_app_wires_runtime_services_through_public_configurer(tmp_path: Path) -> None:
+    runtime = _RuntimeWithPublicServiceConfigurer()
+    scheduler = SchedulerService(db_path=tmp_path / "scheduler.db")
+    skills = SkillStoreService(
+        db_path=tmp_path / "skills.db",
+        root_dir=tmp_path / "skills",
+    )
+    composio: Any = _DisabledComposio()
+
+    create_app(
+        agent_runtime=runtime,
+        scheduler=scheduler,
+        skill_store_service=skills,
+        intake_workflow_service=IntakeWorkflowService(
+            db_path=tmp_path / "intake.db",
+            project_root=tmp_path,
+            scheduler=scheduler,
+            skill_store=skills,
+            composio=composio,
+        ),
+        composio_service=composio,
+    )
+
+    assert len(runtime.configured) == 1
+    configured = runtime.configured[0]
+    assert configured["composio_service"] is composio
+    assert hasattr(configured["link_alias_service"], "register_links_from_text")
+    assert hasattr(configured["workflow_setup_service"], "get_thread_session")
+    assert not hasattr(runtime, "_link_alias_service")
+    assert not hasattr(runtime, "_composio_service")
+    assert not hasattr(runtime, "_workflow_setup_service")

--- a/tests/test_api_route_use_cases.py
+++ b/tests/test_api_route_use_cases.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opentulpa.api.routes.file_use_cases import FileRouteUseCases
+from opentulpa.api.routes.intake_use_cases import workflow_upsert_kwargs
+from opentulpa.api.routes.user_context_use_cases import needs_model_processing
+
+
+class _Vault:
+    def __init__(self) -> None:
+        self.record = {
+            "id": "file_1",
+            "original_filename": "report.txt",
+            "kind": "document",
+            "mime_type": "text/plain",
+        }
+        self.summary: tuple[str, str, str] | None = None
+
+    def search(self, customer_id: str, *, query: str, limit: int) -> list[dict[str, Any]]:
+        assert customer_id == "cust_1"
+        assert query == "report"
+        assert limit == 2
+        return [self.record]
+
+    def get_file(self, customer_id: str, file_id: str) -> dict[str, Any] | None:
+        assert customer_id == "cust_1"
+        return self.record if file_id == "file_1" else None
+
+    def read_file_bytes(self, customer_id: str, file_id: str) -> bytes | None:
+        assert customer_id == "cust_1"
+        return b"hello" if file_id == "file_1" else None
+
+    def set_ai_summary(self, customer_id: str, file_id: str, summary: str) -> dict[str, Any]:
+        self.summary = (customer_id, file_id, summary)
+        return {**self.record, "summary": summary}
+
+
+class _TelegramChat:
+    def find_session_slots(self, customer_id: str) -> list[dict[str, Any]]:
+        assert customer_id == "cust_1"
+        return [{"chat_id": 123}]
+
+
+class _TelegramClient:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_file(self, **kwargs: Any) -> bool:
+        self.sent.append(kwargs)
+        return True
+
+
+class _Runtime:
+    async def analyze_uploaded_file(self, **kwargs: Any) -> dict[str, Any]:
+        assert kwargs["raw_bytes"] == b"hello"
+        return {"analysis": "short summary"}
+
+
+@pytest.mark.asyncio
+async def test_file_route_use_cases_send_uses_vault_and_telegram() -> None:
+    vault = _Vault()
+    telegram = _TelegramClient()
+    use_cases = FileRouteUseCases(
+        get_file_vault=lambda: vault,
+        get_telegram_chat=_TelegramChat,
+        get_telegram_client=lambda: telegram,
+        get_agent_runtime=_Runtime,
+        telegram_enabled=True,
+    )
+
+    response = await use_cases.send({"customer_id": "cust_1", "file_id": "file_1"})
+
+    assert response["ok"] is True
+    assert response["chat_id"] == 123
+    assert telegram.sent[0]["filename"] == "report.txt"
+
+
+@pytest.mark.asyncio
+async def test_file_route_use_cases_analyze_updates_summary_without_question() -> None:
+    vault = _Vault()
+    use_cases = FileRouteUseCases(
+        get_file_vault=lambda: vault,
+        get_telegram_chat=_TelegramChat,
+        get_telegram_client=_TelegramClient,
+        get_agent_runtime=_Runtime,
+        telegram_enabled=True,
+    )
+
+    response = await use_cases.analyze({"customer_id": "cust_1", "file_id": "file_1"})
+
+    assert response["analysis"] == "short summary"
+    assert vault.summary == ("cust_1", "file_1", "short summary")
+
+
+def test_workflow_upsert_kwargs_preserves_internal_schedule_none_quirk() -> None:
+    kwargs = workflow_upsert_kwargs(
+        {
+            "name": "Lead intake",
+            "intent_description": "Book visits",
+            "required_fields": ["date"],
+            "sink_type": "local_csv",
+            "sink_config": {"file_path": "tulpa_stuff/leads.csv"},
+            "schedule": None,
+        },
+        customer_id="cust_1",
+    )
+
+    assert kwargs["schedule"] == "None"
+
+
+def test_needs_model_processing_detects_media_and_pdf_only() -> None:
+    assert needs_model_processing({"kind": "photo"})
+    assert needs_model_processing({"mime_type": "application/pdf"})
+    assert not needs_model_processing({"original_filename": "notes.txt", "mime_type": "text/plain"})

--- a/tests/test_browser_use_local_manager.py
+++ b/tests/test_browser_use_local_manager.py
@@ -12,6 +12,10 @@ from opentulpa.integrations.browser_use_local import (
     BrowserUseLocalManager,
     _BrowserUseTaskState,
 )
+from opentulpa.integrations.browser_use_session_registry import (
+    BrowserUseSessionRegistry,
+    BrowserUseSessionState,
+)
 
 
 class _FakeBrowserSession:
@@ -91,6 +95,39 @@ async def _no_preflight() -> str | None:
 
 def _fake_browser_use_components() -> tuple[None, None, type[_FakeBrowserSession]]:
     return None, None, _FakeBrowserSession
+
+
+def test_browser_use_session_registry_tracks_active_and_reusable_sessions() -> None:
+    registry = BrowserUseSessionRegistry()
+    registry.set_session(
+        BrowserUseSessionState(
+            session=object(),
+            customer_id="cust_1",
+            session_id="shared",
+            updated_monotonic=10.0,
+        )
+    )
+    registry.set_task(
+        _BrowserUseTaskState(
+            task_id="task_running",
+            customer_id="cust_1",
+            session_id="shared",
+            task="open page",
+            llm="model",
+            status="running",
+            updated_monotonic=11.0,
+        )
+    )
+
+    active_task = registry.active_task_for_session(customer_id="cust_1", session_id="shared")
+
+    assert active_task is not None
+    assert active_task.task_id == "task_running"
+    assert registry.pick_reusable_session_id("cust_1") is None
+    registry.tasks["task_running"].status = "finished"
+
+    assert registry.active_task_for_session(customer_id="cust_1", session_id="shared") is None
+    assert registry.pick_reusable_session_id("cust_1") == "shared"
 
 
 @pytest.mark.asyncio

--- a/tests/test_business_knowledge_service.py
+++ b/tests/test_business_knowledge_service.py
@@ -386,7 +386,7 @@ def test_oracle_client_posts_default_model_with_openrouter_attribution(
         captured.update(kwargs)
         return _Response()
 
-    monkeypatch.setattr("opentulpa.business_knowledge.service.httpx.post", _post)
+    monkeypatch.setattr("opentulpa.business_knowledge.oracle_client.httpx.post", _post)
 
     client = OpenAICompatibleKnowledgeOracleClient(
         api_key="test-key",
@@ -438,7 +438,7 @@ def test_oracle_client_traces_intent_extraction(
     def _post(url: str, **kwargs: Any) -> _Response:
         return _Response()
 
-    monkeypatch.setattr("opentulpa.business_knowledge.service.httpx.post", _post)
+    monkeypatch.setattr("opentulpa.business_knowledge.oracle_client.httpx.post", _post)
 
     client = OpenAICompatibleKnowledgeOracleClient(
         api_key="test-key",
@@ -699,7 +699,7 @@ def test_business_knowledge_configures_sqlite_for_concurrent_server_use(tmp_path
     vault = _vault(tmp_path)
     knowledge = _knowledge(tmp_path, vault)
 
-    with knowledge._conn() as conn:
+    with knowledge.repository.conn() as conn:
         journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
         busy_timeout = int(conn.execute("PRAGMA busy_timeout").fetchone()[0])
         synchronous = int(conn.execute("PRAGMA synchronous").fetchone()[0])

--- a/tests/test_intake_workflow_service.py
+++ b/tests/test_intake_workflow_service.py
@@ -15,6 +15,11 @@ from opentulpa.business_knowledge.service import BusinessKnowledgeService
 from opentulpa.context.file_vault import FileVaultService
 from opentulpa.intake import service as intake_service_module
 from opentulpa.intake.service import IntakeWorkflowService
+from opentulpa.intake.workflow_boundaries import (
+    ConversationCursorSignals,
+    DecisionActions,
+    WorkflowRunAccumulator,
+)
 from opentulpa.interfaces.telegram.business import TelegramBusinessService
 from opentulpa.interfaces.telegram.relay import NO_NOTIFY_TOKEN
 from opentulpa.scheduler.service import SchedulerService
@@ -113,6 +118,85 @@ class _FakeRuntime:
         if customer_id:
             fields.setdefault("customer_id", customer_id)
         self.log_behavior_event(event=event, **fields)
+
+
+def test_decision_actions_normalize_and_validate_supported_decision() -> None:
+    actions = DecisionActions.from_decision(
+        {
+            "booking_action": " CREATE_NEW_BOOKING ",
+            "ready_to_save": True,
+            "reply_action": " SEND_REPLY ",
+            "reply_text": " Booked. ",
+            "sink_action": " UPSERT_PARTIAL ",
+            "sink_payload": {"name": "Alice"},
+        }
+    )
+
+    assert actions.booking_action == "create_new_booking"
+    assert actions.ready_to_save is True
+    assert actions.reply_action == "send_reply"
+    assert actions.reply_text == "Booked."
+    assert actions.sink_action == "upsert_partial"
+    assert actions.sink_payload == {"name": "Alice"}
+    assert actions.validation_error() is None
+
+
+def test_decision_actions_preserve_existing_validation_errors() -> None:
+    unsupported_sink = DecisionActions.from_decision({"sink_action": "delete"})
+    unsupported_booking = DecisionActions.from_decision({"booking_action": "reschedule"})
+    sink_without_booking = DecisionActions.from_decision(
+        {"booking_action": "ignore", "sink_action": "upsert_partial"}
+    )
+
+    assert unsupported_sink.validation_error() == "unsupported sink_action=delete"
+    assert unsupported_booking.validation_error() == "unsupported booking_action=reschedule"
+    assert sink_without_booking.validation_error() == "sink_action requires an active booking action"
+
+
+def test_conversation_cursor_signals_normalize_cursor_fields() -> None:
+    signals = ConversationCursorSignals.from_summary(
+        {
+            "conversation_id": " conv_1 ",
+            "latest_inbound_message_id": " msg_1 ",
+            "latest_inbound_message_created_time": " 2026-04-07T08:00:00+00:00 ",
+            "conversation_updated_time": " 2026-04-07T08:00:30+00:00 ",
+            "latest_outbound_message_id": " out_1 ",
+        }
+    )
+
+    assert signals.conversation_id == "conv_1"
+    assert signals.latest_inbound_message_id == "msg_1"
+    assert signals.latest_inbound_message_time == "2026-04-07T08:00:00+00:00"
+    assert signals.conversation_updated_time == "2026-04-07T08:00:30+00:00"
+    assert signals.latest_outbound_message_id == "out_1"
+
+
+def test_workflow_run_accumulator_preserves_response_summary_precedence() -> None:
+    accumulator = WorkflowRunAccumulator(
+        processed=2,
+        matched=1,
+        saved_notifications=["saved booking"],
+        errors=["conv_2: failed"],
+        result_items=[{"conversation_id": "conv_1"}],
+    )
+
+    response = accumulator.build_response(
+        workflow={"name": "Car Wash"},
+        workflow_id="wf_1",
+        event_type="manual",
+        source_warnings=[{"warning": "slow"}],
+        empty_summary_token=NO_NOTIFY_TOKEN,
+    )
+
+    assert response["ok"] is False
+    assert response["workflow_id"] == "wf_1"
+    assert response["event_type"] == "manual"
+    assert response["processed_conversations"] == 2
+    assert response["matched_conversations"] == 1
+    assert response["results"] == [{"conversation_id": "conv_1"}]
+    assert response["errors"] == ["conv_2: failed"]
+    assert response["source_warnings"] == [{"warning": "slow"}]
+    assert response["summary"] == "Workflow Car Wash hit errors: conv_2: failed"
 
 
 class _DelayedRuntime(_FakeRuntime):
@@ -558,6 +642,45 @@ def _mk_service(
         get_agent_runtime=lambda: runtime,
     )
     return service, scheduler, skills, telegram_business, file_vault
+
+
+def test_resolve_booking_target_promotes_new_booking_to_active_update(tmp_path: Path) -> None:
+    summary = {
+        "conversation_id": "conv_1",
+        "recipient_id": "cust_1",
+        "latest_inbound_message_id": "msg_1",
+        "latest_inbound_message_created_time": "2026-04-07T08:00:00+00:00",
+    }
+    conversation = _instagram_conversation(
+        conversation_id="conv_1",
+        latest_message_id="msg_1",
+        latest_message_text="Need a car wash tomorrow 3pm.",
+        latest_message_time="2026-04-07T08:00:00+00:00",
+    )
+    service, _, _, _, _ = _mk_service(
+        tmp_path,
+        runtime=_FakeRuntime([]),
+        composio=_FakeComposio(summary, conversation),
+    )
+    active_booking = {
+        "booking_id": "bkg_active",
+        "workflow_id": "wf_1",
+        "customer_id": "telegram_123",
+        "conversation_id": "conv_1",
+        "extracted_fields": {"service": "wash"},
+    }
+
+    target = service._resolve_booking_target(  # noqa: SLF001
+        workflow={"workflow_id": "wf_1", "customer_id": "telegram_123"},
+        conversation_summary={"conversation_id": "conv_1"},
+        booking_action="create_new_booking",
+        active_booking=active_booking,
+        recent_completed_booking=None,
+    )
+
+    assert target.booking_action == "update_active"
+    assert target.booking == active_booking
+    assert target.booking is not active_booking
 
 
 def _telegram_business_inbound(

--- a/tests/test_internal_tool_http.py
+++ b/tests/test_internal_tool_http.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from opentulpa.agent.tools.internal_http import InternalToolHTTPClient
+
+
+class _Response:
+    def __init__(self, *, status_code: int, payload: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _Runtime:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _request_with_backoff(self, method: str, path: str, **kwargs: Any) -> _Response:
+        self.calls.append((method, path, kwargs))
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_internal_tool_http_success_projects_item() -> None:
+    runtime = _Runtime(_Response(status_code=200, payload={"items": [{"id": "one"}]}))
+    result = await InternalToolHTTPClient(runtime).request_item(
+        "tool_list",
+        "GET",
+        "/internal/items",
+        "items",
+        default=[],
+        params={"limit": 1},
+    )
+
+    assert result == [{"id": "one"}]
+    assert runtime.calls == [("GET", "/internal/items", {"params": {"limit": 1}, "timeout": 20.0})]
+
+
+@pytest.mark.asyncio
+async def test_internal_tool_http_non_200_marks_retryable() -> None:
+    runtime = _Runtime(_Response(status_code=503, text="try later"))
+    result = await InternalToolHTTPClient(runtime).request("tool_run", "POST", "/internal/run")
+
+    assert result["error"] == "tool_run failed: try later"
+    assert result["status_code"] == 503
+    assert result["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_internal_tool_http_invalid_json_is_error() -> None:
+    runtime = _Runtime(_Response(status_code=200, payload=ValueError("bad"), text="not-json"))
+    result = await InternalToolHTTPClient(runtime).request("tool_run", "GET", "/internal/run")
+
+    assert result["error"] == "tool_run failed: invalid JSON response"
+    assert result["response"] == "not-json"

--- a/tests/test_langfuse_logging.py
+++ b/tests/test_langfuse_logging.py
@@ -285,6 +285,42 @@ def test_record_generation_captures_usage_and_cost() -> None:
     assert observation.kwargs["cost_details"] == {"input": 0.01, "output": 0.02, "total": 0.03}
 
 
+def test_record_generation_maps_native_deepseek_cache_usage() -> None:
+    client = _FakeLangfuseClient()
+    tracer = LangfuseTracer(
+        public_key="pk",
+        secret_key="sk",
+        base_url="https://cloud.langfuse.com",
+        client=client,
+    )
+
+    tracer.record_generation(
+        {
+            "model_name": "deepseek/deepseek-v4-pro",
+            "call_site": "graph_agent",
+            "trace_id": "turn_1",
+            "prompt_messages": [{"role": "user", "text": "hi"}],
+            "response_text": "hello",
+            "usage": {
+                "prompt_tokens": 10124,
+                "completion_tokens": 5,
+                "total_tokens": 10129,
+                "prompt_cache_hit_tokens": 10112,
+                "prompt_cache_miss_tokens": 12,
+            },
+        }
+    )
+
+    observation = client.observations[0]
+    assert observation.kwargs["usage_details"] == {
+        "input": 10124,
+        "output": 5,
+        "total": 10129,
+        "cache_read_input_tokens": 10112,
+        "cache_write_input_tokens": 12,
+    }
+
+
 def test_trace_context_rolls_up_child_generation_usage_and_cost() -> None:
     client = _FakeLangfuseClient()
     tracer = LangfuseTracer(

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -564,6 +564,35 @@ def test_model_request_attempts_are_default_for_deepseek_v4_pro_on_openrouter() 
     assert attempts == [{"name": "default", "invoke_extras": {}, "call_context": {}}]
 
 
+def test_extract_response_usage_fields_normalizes_native_deepseek_cache_usage() -> None:
+    rt = OpenTulpaLangGraphRuntime(
+        app_url="http://127.0.0.1:8000",
+        openrouter_api_key="k",
+        model_name="deepseek/deepseek-v4-pro",
+        checkpoint_db_path=".opentulpa/test-prompt-cache.sqlite",
+        prompt_caching_enabled=True,
+    )
+
+    class _UsageResponse:
+        content = "ok"
+        usage = {
+            "prompt_tokens": 10124,
+            "completion_tokens": 5,
+            "total_tokens": 10129,
+            "prompt_cache_hit_tokens": 10112,
+            "prompt_cache_miss_tokens": 12,
+        }
+
+    assert rt.extract_response_usage_fields(_UsageResponse()) == {
+        "native_tokens_prompt": 10124,
+        "native_tokens_completion": 5,
+        "native_tokens_total": 10129,
+        "native_tokens_cached": 10112,
+        "cache_hit": True,
+        "native_tokens_cache_write": 12,
+    }
+
+
 def test_extract_response_usage_fields_normalizes_openrouter_usage() -> None:
     rt = OpenTulpaLangGraphRuntime(
         app_url="http://127.0.0.1:8000",

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -7,12 +7,15 @@ import pytest
 from opentulpa.agent.graph_builder import (
     _build_connected_composio_toolkits_context,
     _build_late_turn_control_text,
-    _qwen_cache_safe_history_count,
-    _split_qwen_cacheable_history,
-    _tail_sized_history_message_count,
 )
 from opentulpa.agent.lc_messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from opentulpa.agent.model_pool import prompt_cache_breakpoint_message_index
+from opentulpa.agent.prompt_cache_policy import (
+    build_prompt_cache_plan,
+    qwen_cache_safe_history_count,
+    split_qwen_cacheable_history,
+    tail_sized_history_message_count,
+)
 from opentulpa.agent.prompt_policy import build_system_prompt_message
 from opentulpa.agent.prompt_sections import PROMPT_DYNAMIC_BOUNDARY
 from opentulpa.agent.runtime import OpenTulpaLangGraphRuntime
@@ -320,14 +323,14 @@ def test_prompt_cache_breakpoint_index_matches_actual_cacheable_message() -> Non
 
 
 def test_qwen_tail_sized_history_count_keeps_only_small_suffix_volatile() -> None:
-    assert _tail_sized_history_message_count([]) == 0
-    assert _tail_sized_history_message_count([120, 120]) == 0
-    assert _tail_sized_history_message_count([1000, 1000, 1000, 150, 120]) == 3
-    assert _tail_sized_history_message_count([5000, 1000]) == 2
+    assert tail_sized_history_message_count([]) == 0
+    assert tail_sized_history_message_count([120, 120]) == 0
+    assert tail_sized_history_message_count([1000, 1000, 1000, 150, 120]) == 3
+    assert tail_sized_history_message_count([5000, 1000]) == 2
 
 
 def test_qwen_history_split_keeps_current_user_in_frontier() -> None:
-    cacheable, frontier, mode = _split_qwen_cacheable_history(
+    cacheable, frontier, mode = split_qwen_cacheable_history(
         older_history_messages=[],
         latest_turn_messages=[HumanMessage(content="Current user turn")],
     )
@@ -346,7 +349,7 @@ def test_qwen_history_split_caches_workflow_tool_loop_head() -> None:
         ToolMessage(content="{\"ok\": true, \"result\": \"" + ("preflight " * 1200) + "\"}", tool_call_id="call_2"),
     ]
 
-    cacheable, frontier, mode = _split_qwen_cacheable_history(
+    cacheable, frontier, mode = split_qwen_cacheable_history(
         older_history_messages=[],
         latest_turn_messages=latest_turn,
     )
@@ -367,7 +370,7 @@ def test_qwen_history_split_does_not_end_cacheable_prefix_on_pending_tool_call()
         AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_2"}]),
     ]
 
-    cacheable, frontier, mode = _split_qwen_cacheable_history(
+    cacheable, frontier, mode = split_qwen_cacheable_history(
         older_history_messages=[],
         latest_turn_messages=latest_turn,
         target_tail_tokens=0,
@@ -388,8 +391,45 @@ def test_qwen_safe_history_count_rolls_back_pending_tool_call() -> None:
         AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_2"}]),
     ]
 
-    assert _qwen_cache_safe_history_count(latest_turn, 4) == 3
-    assert _qwen_cache_safe_history_count(latest_turn, 2) == 1
+    assert qwen_cache_safe_history_count(latest_turn, 4) == 3
+    assert qwen_cache_safe_history_count(latest_turn, 2) == 1
+
+
+def test_prompt_cache_plan_encapsulates_qwen_message_order_and_counts() -> None:
+    prefix = [
+        SystemMessage(content="Stable system prompt"),
+        HumanMessage(content="OpenTulpa cache anchor v1"),
+    ]
+    older = [HumanMessage(content="older " * 900)]
+    latest = [
+        HumanMessage(content="INTERNAL_ONBOARDING_SEED. " + ("setup facts " * 900)),
+        AIMessage(content="", tool_calls=[{"name": "tool_group_exec", "args": {}, "id": "call_1"}]),
+    ]
+    dynamic = [SystemMessage(content="dynamic late")]
+
+    plan = build_prompt_cache_plan(
+        prefix_messages=prefix,
+        older_history_messages=older,
+        frozen_late_messages=[],
+        latest_turn_messages=latest,
+        dynamic_late_messages=dynamic,
+        cache_profile={"strategy": "explicit_committed_breakpoint", "supports_breakpoints": True},
+    )
+
+    assert plan.model_messages[:2] == prefix
+    assert plan.requested_cacheable_prefix_count == 3
+    assert plan.cacheable_prefix_count == 3
+    assert plan.cache_breakpoint_index == 2
+    assert plan.cacheable_prefix_mode == "committed_tail_sized_history"
+    assert len(plan.cacheable_history_messages) == 1
+    assert str(plan.cacheable_history_messages[0].content).startswith(
+        "QWEN_CACHEABLE_COMMITTED_HISTORY"
+    )
+    assert str(plan.frontier_history_messages[0].content).startswith(
+        "QWEN_VOLATILE_RECENT_HISTORY"
+    )
+    assert plan.frontier_history_messages[1:] == latest[1:]
+    assert plan.model_messages[-1] == dynamic[0]
 
 
 class _CaptureResponse:

--- a/tests/test_prompt_cache_split.py
+++ b/tests/test_prompt_cache_split.py
@@ -44,6 +44,10 @@ class _PromptComposioRuntime:
     def __init__(self, composio: _PromptComposio | None) -> None:
         self._composio_service = composio
 
+    @property
+    def composio_service(self) -> _PromptComposio | None:
+        return self._composio_service
+
 
 def test_prompt_dynamic_boundary_marker_is_single_line_prefix() -> None:
     assert PROMPT_DYNAMIC_BOUNDARY.startswith("[OPENTULPA_PROMPT_DYNAMIC_BOUNDARY]")

--- a/tests/test_runtime_reasoning_effort.py
+++ b/tests/test_runtime_reasoning_effort.py
@@ -177,6 +177,10 @@ def test_runtime_uses_openrouter_adapter_for_deepseek_reasoning(monkeypatch) -> 
     assert deepseek_call["api_key"] == "test-key"
     assert deepseek_call["base_url"] == "https://openrouter.ai/api/v1"
     assert deepseek_call["reasoning"] == {"effort": "high", "exclude": False}
+    assert deepseek_call["openrouter_provider"] == {
+        "order": ["DeepSeek"],
+        "allow_fallbacks": False,
+    }
     assert deepseek_call["streaming"] is True
     assert deepseek_call["app_url"] == "https://github.com/kvyb/opentulpa"
     assert deepseek_call["app_title"] == "OpenTulpa"
@@ -221,6 +225,7 @@ def test_runtime_uses_openrouter_adapter_for_qwen_prompt_cache(monkeypatch) -> N
     assert qwen_call["app_url"] == "https://github.com/kvyb/opentulpa"
     assert qwen_call["app_title"] == "OpenTulpa"
     assert "reasoning" not in qwen_call
+    assert "openrouter_provider" not in qwen_call
     assert all(call["model"] != "qwen/qwen3.7-max" for call in init_calls)
 
 
@@ -245,6 +250,10 @@ def test_runtime_uses_openrouter_adapter_to_disable_deepseek_reasoning(monkeypat
 
     assert openrouter_calls
     assert openrouter_calls[0]["reasoning"] == {"effort": "none", "exclude": False}
+    assert openrouter_calls[0]["openrouter_provider"] == {
+        "order": ["DeepSeek"],
+        "allow_fallbacks": False,
+    }
 
 
 def test_openrouter_deepseek_adapter_replays_reasoning_details_for_tool_turns() -> None:

--- a/tests/test_telegram_chat_routing.py
+++ b/tests/test_telegram_chat_routing.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from opentulpa.interfaces.telegram.chat_routing import (
+    TelegramAccessDecision,
+    TelegramCommandRoute,
+)
+
+
+def test_telegram_access_decision_separates_owner_and_support_permissions() -> None:
+    owner = TelegramAccessDecision.from_flags(normal_allowed=True, support_allowed=False)
+    support = TelegramAccessDecision.from_flags(normal_allowed=False, support_allowed=True)
+    blocked = TelegramAccessDecision.from_flags(normal_allowed=False, support_allowed=False)
+
+    assert owner.restricted_reply is None
+    assert owner.should_auto_bind_allowed_username is True
+    assert owner.should_configure_support_commands is False
+    assert support.restricted_reply is None
+    assert support.should_auto_bind_allowed_username is False
+    assert support.should_configure_support_commands is True
+    assert blocked.restricted_reply == "This bot is restricted and your Telegram account is not allowed."
+
+
+def test_telegram_command_route_classifies_commands_without_transport_state() -> None:
+    assert (
+        TelegramCommandRoute.from_command(
+            command_name="/support_bind",
+            support_allowed=False,
+            is_support_command=True,
+        ).kind
+        == "restricted_support_command"
+    )
+    assert (
+        TelegramCommandRoute.from_command(
+            command_name="/support_bind",
+            support_allowed=True,
+            is_support_command=True,
+        ).kind
+        == "support_command"
+    )
+    assert (
+        TelegramCommandRoute.from_command(
+            command_name="/fresh",
+            support_allowed=False,
+            is_support_command=False,
+        ).kind
+        == "fresh"
+    )
+    assert TelegramCommandRoute.from_command(
+        command_name="",
+        support_allowed=False,
+        is_support_command=False,
+    ).is_chat

--- a/tests/test_tool_execution_policy.py
+++ b/tests/test_tool_execution_policy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from opentulpa.agent.lc_messages import HumanMessage
+from opentulpa.agent.tool_execution_policy import ToolExecutionPolicy
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _Runtime:
+    def tools_for_turn_mode(self, turn_mode: str) -> list[_Tool]:
+        assert turn_mode == "interactive"
+        return [_Tool("allowed_tool")]
+
+
+def test_tool_execution_policy_rejects_unbound_tool() -> None:
+    policy = ToolExecutionPolicy.from_runtime_state(
+        runtime=_Runtime(),
+        state={"turn_mode": "interactive", "thread_id": "thread_1", "customer_id": "telegram_1"},
+    )
+
+    with pytest.raises(ValueError, match="not bound in this turn"):
+        policy.validate_call(call_name="missing_tool", customer_scoped_tools=set())
+
+
+def test_tool_execution_policy_requires_customer_scope() -> None:
+    policy = ToolExecutionPolicy.from_runtime_state(
+        runtime=object(),
+        state={"turn_mode": "interactive", "thread_id": "thread_1", "customer_id": ""},
+    )
+
+    with pytest.raises(ValueError, match="requires customer scope"):
+        policy.validate_call(call_name="customer_tool", customer_scoped_tools={"customer_tool"})
+
+
+def test_tool_execution_policy_adds_execution_origin_to_routine_create() -> None:
+    policy = ToolExecutionPolicy.from_runtime_state(
+        runtime=object(),
+        state={"turn_mode": "interactive", "thread_id": "thread_1", "customer_id": "telegram_1"},
+    )
+
+    args = policy.prepare_args(
+        call_name="routine_create",
+        args={"schedule": "* * * * *"},
+        messages=[HumanMessage(content="remind me in 5 minutes")],
+    )
+
+    assert args["thread_id"] == "thread_1"
+    assert args["execution_origin"] == "interactive"
+    assert "T" in args["schedule"]


### PR DESCRIPTION
## Summary

Combines the five Refactor Opentulpa branches into one merge branch and adds the follow-up thermonuclear refactor tasks on the same combo branch.

- OPE-149 through OPE-153: original combo refactors preserved on top of `main`.
- OPE-161: split API route orchestration into use-case modules.
- OPE-162: split business knowledge service into planner, repository, indexer, and oracle client modules.
- OPE-163: decomposed Telegram relay streaming/workflow/wake orchestration and removed stale inline wake/thread code.
- OPE-164: centralized internal HTTP tool request handling.
- OPE-165: split Composio Google Sheets and Instagram adapter logic out of the main service.
- OPE-166: split task runner and wake orchestrator monolith paths, with dead/stale inline code removed.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest` -> 714 passed, 40 skipped, 19 warnings
- `git diff --check`
- Thermonuclear changed-file review: no behavior regressions found; large service hot paths decomposed, remaining long decorator registration shells are framework/tool registration surfaces rather than single-flow business logic.