### PR TITLE
OPE-189: Add Telegram webhook readiness status

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -21,23 +21,13 @@ from opentulpa.core.config import get_openai_compatible_api_key_from_env, get_se
 from opentulpa.core.debug_logs import install_process_output_log_capture
 from opentulpa.core.public_urls import resolve_public_base_url
 from opentulpa.interfaces.telegram.chat_service import support_bot_commands
+from opentulpa.interfaces.telegram.constants import TELEGRAM_WEBHOOK_ALLOWED_UPDATES
 from opentulpa.interfaces.telegram.security import parse_csv_set
 from opentulpa.logging import create_langfuse_tracer
 from opentulpa.memory.service import MemoryService
 from opentulpa.scheduler.service import SchedulerService
 from opentulpa.skills.service import SkillStoreService
 from opentulpa.tasks.service import TaskService
-
-TELEGRAM_WEBHOOK_ALLOWED_UPDATES = [
-    "message",
-    "edited_message",
-    "callback_query",
-    "my_chat_member",
-    "business_connection",
-    "business_message",
-    "edited_business_message",
-    "deleted_business_messages",
-]
 
 
 async def _wake_callback(payload: dict) -> None:

--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -29,6 +29,7 @@ from opentulpa.api.routes import (
     register_system_routes,
     register_task_routes,
     register_telegram_business_routes,
+    register_telegram_webhook_health_routes,
     register_telegram_webhook_routes,
     register_tulpa_routes,
     register_user_context_routes,
@@ -597,6 +598,7 @@ def create_app(
             and not path.startswith("/web/intake/workflows")
             and not path.startswith("/web/files/")
             and not path.startswith("/web/local-files/")
+            and path != "/web/telegram/status"
             and path not in public_health_paths
         ):
             return JSONResponse(status_code=403, content={"detail": "forbidden public endpoint"})
@@ -687,6 +689,12 @@ def create_app(
         app,
         get_telegram_business=get_telegram_business,
         resolve_customer_id=profile_service.resolve_customer_id,
+    )
+    register_telegram_webhook_health_routes(
+        app,
+        settings=settings,
+        get_telegram_client=get_telegram_client,
+        web_token=settings.opentulpa_web_token,
     )
     register_system_routes(app)
     register_composio_routes(

--- a/src/opentulpa/api/routes/__init__.py
+++ b/src/opentulpa/api/routes/__init__.py
@@ -21,6 +21,7 @@ _ROUTE_IMPORTS = {
     "register_system_routes": "opentulpa.api.routes.system",
     "register_task_routes": "opentulpa.api.routes.tasks",
     "register_telegram_business_routes": "opentulpa.api.routes.telegram_business",
+    "register_telegram_webhook_health_routes": "opentulpa.api.routes.telegram_webhook_health",
     "register_telegram_webhook_routes": "opentulpa.api.routes.telegram_webhook",
     "register_tulpa_routes": "opentulpa.api.routes.tulpa",
     "register_user_context_routes": "opentulpa.api.routes.user_context",

--- a/src/opentulpa/api/routes/generic_chat.py
+++ b/src/opentulpa/api/routes/generic_chat.py
@@ -8,7 +8,6 @@ import mimetypes
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
-from hmac import compare_digest
 from typing import Annotated, Any
 from urllib.parse import quote
 
@@ -19,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from opentulpa.agent.runtime import STREAM_PROGRESS_PREFIX, STREAM_WAIT_SIGNAL, AgentStreamEvent
 from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
 from opentulpa.api.file_helpers import sanitize_uploaded_file_record
+from opentulpa.api.web_auth import web_auth_error
 from opentulpa.context.uploaded_files import (
     build_uploaded_files_context,
     should_skip_auto_summary_for_upload,
@@ -55,19 +55,6 @@ class WebFileResponse(BaseModel):
     file: dict[str, Any]
 
 
-def _bearer_token(request: Request) -> str:
-    header = str(request.headers.get("authorization") or "").strip()
-    scheme, _, token = header.partition(" ")
-    if scheme.lower() != "bearer":
-        return ""
-    return token.strip()
-
-
-def _authorized(request: Request, expected_secret: str) -> bool:
-    token = _bearer_token(request)
-    return bool(token and compare_digest(token, expected_secret))
-
-
 def _sse(event: str, payload: dict[str, Any]) -> str:
     return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
@@ -101,14 +88,9 @@ def register_generic_chat_routes(
         responses={200: {"content": {"text/event-stream": {}}}},
     )
     async def web_chat_turn(payload: WebChatTurnRequest, request: Request) -> Any:
-        secret = str(web_token or "").strip()
-        if not secret:
-            return JSONResponse(
-                status_code=503,
-                content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
-            )
-        if not _authorized(request, secret):
-            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
 
         runtime = get_agent_runtime()
         if runtime is None or not (hasattr(runtime, "ainvoke_text") or hasattr(runtime, "astream_text")):
@@ -142,14 +124,9 @@ def register_generic_chat_routes(
         kind: Annotated[str, Form()] = "document",
         caption: Annotated[str | None, Form()] = None,
     ) -> Any:
-        secret = str(web_token or "").strip()
-        if not secret:
-            return JSONResponse(
-                status_code=503,
-                content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
-            )
-        if not _authorized(request, secret):
-            return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
         safe_customer_id = _resolve_customer_id(customer_id)
         safe_thread_id = str(thread_id or "").strip()
         safe_kind = str(kind or "document").strip() or "document"
@@ -197,9 +174,9 @@ def register_generic_chat_routes(
         request: Request,
         customer_id: Annotated[str, Query(min_length=1)],
     ) -> Any:
-        auth = _authorized_web_request(request, web_token)
-        if auth is not None:
-            return auth
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
         record = get_file_vault().get_file(_resolve_customer_id(customer_id), file_id)
         if not record:
             return JSONResponse(status_code=404, content={"detail": "file not found"})
@@ -211,9 +188,9 @@ def register_generic_chat_routes(
         request: Request,
         customer_id: Annotated[str, Query(min_length=1)],
     ) -> Any:
-        auth = _authorized_web_request(request, web_token)
-        if auth is not None:
-            return auth
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
         safe_customer_id = _resolve_customer_id(customer_id)
         vault = get_file_vault()
         record = vault.get_file(safe_customer_id, file_id)
@@ -235,9 +212,9 @@ def register_generic_chat_routes(
         request: Request,
         local_path: Annotated[str, Query(alias="path", min_length=1)],
     ) -> Any:
-        auth = _authorized_web_request(request, web_token)
-        if auth is not None:
-            return auth
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
         safe_local_path = local_path.strip()
         if not safe_local_path:
             return JSONResponse(status_code=400, content={"detail": "path is required"})
@@ -438,18 +415,6 @@ async def _stream_turn(
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
-
-
-def _authorized_web_request(request: Request, web_token: str | None) -> JSONResponse | None:
-    secret = str(web_token or "").strip()
-    if not secret:
-        return JSONResponse(
-            status_code=503,
-            content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
-        )
-    if not _authorized(request, secret):
-        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
-    return None
 
 
 async def _postprocess_uploaded_file(

--- a/src/opentulpa/api/routes/intake.py
+++ b/src/opentulpa/api/routes/intake.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hmac
 from collections.abc import Callable
 from typing import Any
 
@@ -14,6 +13,7 @@ from opentulpa.api.routes.intake_use_cases import (
     workflow_upsert_kwargs,
     workflow_with_knowledge_files,
 )
+from opentulpa.api.web_auth import authorized_web_request
 
 
 def register_intake_workflow_routes(
@@ -28,12 +28,7 @@ def register_intake_workflow_routes(
     """Register internal intake workflow endpoints."""
 
     def _authorized_web_request(request: Request) -> bool:
-        expected = str(web_token or "").strip()
-        if not expected:
-            return False
-        header = str(request.headers.get("authorization", "") or "").strip()
-        scheme, _, token = header.partition(" ")
-        return scheme.lower() == "bearer" and hmac.compare_digest(token.strip(), expected)
+        return authorized_web_request(request, web_token)
 
     def _web_customer_id(request: Request) -> str:
         raw = str(request.query_params.get("customer_id", "") or "").strip()

--- a/src/opentulpa/api/routes/telegram_webhook_health.py
+++ b/src/opentulpa/api/routes/telegram_webhook_health.py
@@ -1,0 +1,136 @@
+"""Telegram webhook readiness routes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict
+from hmac import compare_digest
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from opentulpa.interfaces.telegram.webhook_health import (
+    TelegramWebhookInfo,
+    build_runtime_config,
+    evaluate_webhook_readiness,
+    telegram_webhook_info_from_result,
+)
+
+
+class TelegramWebhookInfoResponse(BaseModel):
+    available: bool
+    url: str
+    pending_update_count: int
+    allowed_updates: list[str]
+    last_error_date: int | None = None
+    last_error_message: str | None = None
+    max_connections: int | None = None
+    raw_error: str | None = None
+
+
+class TelegramWebhookStatusResponse(BaseModel):
+    configured: bool
+    public_url: str
+    expected_webhook_url: str
+    telegram_webhook_url: str
+    ready: bool
+    requires_webhook_reset: bool
+    last_error_message: str | None
+    reasons: list[str]
+    telegram: TelegramWebhookInfoResponse
+
+
+def register_telegram_webhook_health_routes(
+    app: FastAPI,
+    *,
+    settings: Any,
+    get_telegram_client: Callable[[], Any],
+    web_token: str | None,
+) -> None:
+    """Register side-effect-free Telegram webhook readiness checks."""
+
+    @app.get(
+        "/internal/telegram/status",
+        response_model=TelegramWebhookStatusResponse,
+    )
+    async def internal_telegram_status() -> TelegramWebhookStatusResponse:
+        return await _telegram_status_response(
+            settings=settings,
+            get_telegram_client=get_telegram_client,
+        )
+
+    @app.get(
+        "/web/telegram/status",
+        response_model=TelegramWebhookStatusResponse,
+    )
+    async def web_telegram_status(request: Request) -> Any:
+        auth_error = _web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
+        return await _telegram_status_response(
+            settings=settings,
+            get_telegram_client=get_telegram_client,
+        )
+
+
+async def _telegram_status_response(
+    *,
+    settings: Any,
+    get_telegram_client: Callable[[], Any],
+) -> TelegramWebhookStatusResponse:
+    runtime = build_runtime_config(settings)
+    telegram = telegram_webhook_info_from_result(None)
+
+    if runtime.bot_token_configured:
+        try:
+            client = get_telegram_client()
+            get_webhook_info = getattr(client, "get_webhook_info", None)
+            if callable(get_webhook_info):
+                telegram = telegram_webhook_info_from_result(await get_webhook_info())
+        except Exception as exc:
+            telegram = _telegram_status_error(exc, settings=settings)
+
+    readiness = evaluate_webhook_readiness(runtime=runtime, telegram=telegram)
+    return TelegramWebhookStatusResponse(
+        **asdict(readiness),
+        telegram=TelegramWebhookInfoResponse.model_validate(asdict(telegram)),
+    )
+
+
+def _web_auth_error(request: Request, expected_token: str | None) -> JSONResponse | None:
+    secret = str(expected_token or "").strip()
+    if not secret:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
+        )
+    incoming = str(request.headers.get("authorization", "") or "").strip()
+    scheme, _, token = incoming.partition(" ")
+    if scheme.lower() != "bearer" or not compare_digest(token.strip(), secret):
+        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+    return None
+
+
+def _telegram_status_error(exc: Exception, *, settings: Any) -> TelegramWebhookInfo:
+    return TelegramWebhookInfo(
+        available=False,
+        url="",
+        pending_update_count=0,
+        allowed_updates=(),
+        raw_error=_sanitize_telegram_error(exc, settings=settings),
+    )
+
+
+def _sanitize_telegram_error(exc: Exception, *, settings: Any) -> str:
+    message = " ".join(str(exc).split()) or exc.__class__.__name__
+    for secret_name in (
+        "telegram_bot_token",
+        "telegram_webhook_secret",
+        "opentulpa_web_token",
+    ):
+        secret = str(getattr(settings, secret_name, "") or "").strip()
+        if secret:
+            message = message.replace(secret, "[redacted]")
+    return f"{exc.__class__.__name__}: {message[:160]}"

--- a/src/opentulpa/api/routes/telegram_webhook_health.py
+++ b/src/opentulpa/api/routes/telegram_webhook_health.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import asdict
-from hmac import compare_digest
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from opentulpa.api.web_auth import web_auth_error
 from opentulpa.interfaces.telegram.webhook_health import (
     TelegramWebhookInfo,
     build_runtime_config,
@@ -66,7 +65,7 @@ def register_telegram_webhook_health_routes(
         response_model=TelegramWebhookStatusResponse,
     )
     async def web_telegram_status(request: Request) -> Any:
-        auth_error = _web_auth_error(request, web_token)
+        auth_error = web_auth_error(request, web_token)
         if auth_error is not None:
             return auth_error
         return await _telegram_status_response(
@@ -97,20 +96,6 @@ async def _telegram_status_response(
         **asdict(readiness),
         telegram=TelegramWebhookInfoResponse.model_validate(asdict(telegram)),
     )
-
-
-def _web_auth_error(request: Request, expected_token: str | None) -> JSONResponse | None:
-    secret = str(expected_token or "").strip()
-    if not secret:
-        return JSONResponse(
-            status_code=503,
-            content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
-        )
-    incoming = str(request.headers.get("authorization", "") or "").strip()
-    scheme, _, token = incoming.partition(" ")
-    if scheme.lower() != "bearer" or not compare_digest(token.strip(), secret):
-        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
-    return None
 
 
 def _telegram_status_error(exc: Exception, *, settings: Any) -> TelegramWebhookInfo:

--- a/src/opentulpa/api/web_auth.py
+++ b/src/opentulpa/api/web_auth.py
@@ -1,0 +1,41 @@
+"""Shared bearer auth helpers for web-facing API routes."""
+
+from __future__ import annotations
+
+from hmac import compare_digest
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+def bearer_token(request: Request) -> str:
+    header = str(request.headers.get("authorization") or "").strip()
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def authorized_web_request(request: Request, expected_token: str | None) -> bool:
+    secret = str(expected_token or "").strip()
+    if not secret:
+        return False
+    token = bearer_token(request)
+    return bool(token and compare_digest(token, secret))
+
+
+def web_auth_error(
+    request: Request,
+    expected_token: str | None,
+    *,
+    missing_status_code: int = 503,
+) -> JSONResponse | None:
+    secret = str(expected_token or "").strip()
+    if not secret:
+        return JSONResponse(
+            status_code=missing_status_code,
+            content={"detail": "OPENTULPA_WEB_TOKEN is not configured"},
+        )
+    if not authorized_web_request(request, secret):
+        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+    return None

--- a/src/opentulpa/interfaces/telegram/client.py
+++ b/src/opentulpa/interfaces/telegram/client.py
@@ -291,6 +291,11 @@ class TelegramClient:
         result = data.get("result") if isinstance(data, dict) else None
         return result if isinstance(result, dict) else None
 
+    async def get_webhook_info(self) -> dict[str, Any] | None:
+        data = await self._post("getWebhookInfo", {})
+        result = data.get("result") if isinstance(data, dict) else None
+        return result if isinstance(result, dict) else None
+
     async def download_file(self, *, file_id: str) -> dict[str, Any] | None:
         info = await self._post("getFile", {"file_id": file_id})
         if not info:

--- a/src/opentulpa/interfaces/telegram/constants.py
+++ b/src/opentulpa/interfaces/telegram/constants.py
@@ -8,6 +8,17 @@ PROJECT_ROOT = Path(__file__).resolve().parents[4]
 STATE_PATH = PROJECT_ROOT / ".opentulpa" / "telegram_state.json"
 DEBUG_LOG_PATH = PROJECT_ROOT / ".cursor" / "debug.log"
 
+TELEGRAM_WEBHOOK_ALLOWED_UPDATES = (
+    "message",
+    "edited_message",
+    "callback_query",
+    "my_chat_member",
+    "business_connection",
+    "business_message",
+    "edited_business_message",
+    "deleted_business_messages",
+)
+
 LOW_SIGNAL_REPLIES = {
     "i see",
     "understood",

--- a/src/opentulpa/interfaces/telegram/webhook_health.py
+++ b/src/opentulpa/interfaces/telegram/webhook_health.py
@@ -1,0 +1,158 @@
+"""Side-effect-free Telegram webhook readiness checks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from opentulpa.core.public_urls import resolve_public_base_url
+from opentulpa.interfaces.telegram.constants import TELEGRAM_WEBHOOK_ALLOWED_UPDATES
+
+TELEGRAM_WEBHOOK_PATH = "/webhook/telegram"
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramWebhookRuntimeConfig:
+    bot_token_configured: bool
+    webhook_secret_configured: bool
+    public_url: str
+    expected_webhook_url: str
+    allowed_updates: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramWebhookInfo:
+    available: bool
+    url: str
+    pending_update_count: int
+    allowed_updates: tuple[str, ...]
+    last_error_date: int | None = None
+    last_error_message: str | None = None
+    max_connections: int | None = None
+    raw_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramWebhookReadiness:
+    configured: bool
+    public_url: str
+    expected_webhook_url: str
+    telegram_webhook_url: str
+    ready: bool
+    requires_webhook_reset: bool
+    last_error_message: str | None
+    reasons: tuple[str, ...]
+
+
+def build_runtime_config(
+    settings: Any,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> TelegramWebhookRuntimeConfig:
+    public_url = resolve_public_base_url(env)
+    bot_token = str(getattr(settings, "telegram_bot_token", "") or "").strip()
+    webhook_secret = str(getattr(settings, "telegram_webhook_secret", "") or "").strip()
+    expected_webhook_url = f"{public_url}{TELEGRAM_WEBHOOK_PATH}" if public_url else ""
+
+    return TelegramWebhookRuntimeConfig(
+        bot_token_configured=bool(bot_token),
+        webhook_secret_configured=bool(webhook_secret),
+        public_url=public_url,
+        expected_webhook_url=expected_webhook_url,
+        allowed_updates=tuple(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+    )
+
+
+def telegram_webhook_info_from_result(result: Mapping[str, Any] | None) -> TelegramWebhookInfo:
+    if not isinstance(result, Mapping):
+        return TelegramWebhookInfo(
+            available=False,
+            url="",
+            pending_update_count=0,
+            allowed_updates=(),
+            raw_error="telegram getWebhookInfo returned no result",
+        )
+
+    return TelegramWebhookInfo(
+        available=True,
+        url=str(result.get("url", "") or "").strip(),
+        pending_update_count=_safe_int(result.get("pending_update_count")),
+        allowed_updates=_string_tuple(result.get("allowed_updates")),
+        last_error_date=_optional_int(result.get("last_error_date")),
+        last_error_message=_optional_str(result.get("last_error_message")),
+        max_connections=_optional_int(result.get("max_connections")),
+    )
+
+
+def evaluate_webhook_readiness(
+    *,
+    runtime: TelegramWebhookRuntimeConfig,
+    telegram: TelegramWebhookInfo,
+) -> TelegramWebhookReadiness:
+    reasons: list[str] = []
+    requires_webhook_reset = False
+
+    if not runtime.bot_token_configured:
+        reasons.append("telegram_bot_token_missing")
+    if not runtime.webhook_secret_configured:
+        reasons.append("telegram_webhook_secret_missing")
+    if not runtime.public_url or not runtime.expected_webhook_url:
+        reasons.append("public_base_url_missing")
+
+    configured = not reasons
+    if configured:
+        if not telegram.available:
+            reasons.append("telegram_webhook_status_unavailable")
+        elif not telegram.url:
+            reasons.append("telegram_webhook_url_missing")
+            requires_webhook_reset = True
+        elif telegram.url != runtime.expected_webhook_url:
+            reasons.append("telegram_webhook_url_mismatch")
+            requires_webhook_reset = True
+
+        if telegram.available:
+            if not telegram.allowed_updates:
+                reasons.append("telegram_allowed_updates_missing")
+                requires_webhook_reset = True
+            elif set(telegram.allowed_updates) != set(runtime.allowed_updates):
+                reasons.append("telegram_allowed_updates_mismatch")
+                requires_webhook_reset = True
+            if telegram.last_error_message:
+                reasons.append("telegram_last_error_present")
+
+    ready = configured and not reasons
+    assert not (ready and requires_webhook_reset)
+    return TelegramWebhookReadiness(
+        configured=configured,
+        public_url=runtime.public_url,
+        expected_webhook_url=runtime.expected_webhook_url,
+        telegram_webhook_url=telegram.url,
+        ready=ready,
+        requires_webhook_reset=requires_webhook_reset,
+        last_error_message=telegram.last_error_message,
+        reasons=tuple(dict.fromkeys(reasons)),
+    )
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
+
+
+def _optional_str(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> int:
+    parsed = _optional_int(value)
+    return max(0, parsed or 0)

--- a/src/opentulpa/interfaces/telegram/webhook_health.py
+++ b/src/opentulpa/interfaces/telegram/webhook_health.py
@@ -118,8 +118,6 @@ def evaluate_webhook_readiness(
             elif set(telegram.allowed_updates) != set(runtime.allowed_updates):
                 reasons.append("telegram_allowed_updates_mismatch")
                 requires_webhook_reset = True
-            if telegram.last_error_message:
-                reasons.append("telegram_last_error_present")
 
     ready = configured and not reasons
     assert not (ready and requires_webhook_reset)

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from fastapi.testclient import TestClient
 
 from opentulpa.api.app import create_app
 from opentulpa.core.config import get_settings
+from opentulpa.interfaces.telegram.client import TelegramClient
 from opentulpa.skills.service import SkillStoreService
 
 
@@ -56,7 +57,7 @@ def test_healthz_reports_draining_during_shutdown(tmp_path: Path) -> None:
         healthz = client.get("/healthz")
         assert healthz.status_code == 200
 
-        client.app.state.shutdown_drain.start_draining()
+        cast(Any, client.app).state.shutdown_drain.start_draining()
         draining = client.get("/healthz")
 
     assert draining.status_code == 503
@@ -121,4 +122,45 @@ def test_generic_web_chat_route_is_public_but_bearer_protected(
 
     assert no_header.status_code == 401
     assert bad_body.status_code == 422
+    get_settings.cache_clear()
+
+
+def test_telegram_webhook_status_route_is_public_but_bearer_protected(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    async def fake_get_webhook_info(self: TelegramClient) -> dict[str, object]:
+        _ = self
+        return {
+            "url": "https://app.example.com/webhook/telegram",
+            "pending_update_count": 0,
+            "allowed_updates": [
+                "message",
+                "edited_message",
+                "callback_query",
+                "my_chat_member",
+                "business_connection",
+                "business_message",
+                "edited_business_message",
+                "deleted_business_messages",
+            ],
+        }
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "tg-secret")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    monkeypatch.setattr(TelegramClient, "get_webhook_info", fake_get_webhook_info)
+    get_settings.cache_clear()
+    with _mk_client(tmp_path, client_host="8.8.8.8") as client:
+        no_header = client.get("/web/telegram/status")
+        accepted = client.get(
+            "/web/telegram/status",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert no_header.status_code == 401
+    assert accepted.status_code == 200
+    assert accepted.json()["ready"] is True
+    assert accepted.json()["requires_webhook_reset"] is False
     get_settings.cache_clear()

--- a/tests/test_telegram_webhook_health.py
+++ b/tests/test_telegram_webhook_health.py
@@ -116,6 +116,27 @@ def test_readiness_accepts_matching_webhook_and_allowed_updates(monkeypatch: Any
     assert result.reasons == ()
 
 
+def test_readiness_reports_last_error_without_blocking_matching_webhook(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    runtime = build_runtime_config(_settings())
+
+    result = evaluate_webhook_readiness(
+        runtime=runtime,
+        telegram=TelegramWebhookInfo(
+            available=True,
+            url="https://app.example.com/webhook/telegram",
+            pending_update_count=0,
+            allowed_updates=tuple(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+            last_error_message="historical delivery error",
+        ),
+    )
+
+    assert result.ready is True
+    assert result.requires_webhook_reset is False
+    assert result.last_error_message == "historical delivery error"
+    assert result.reasons == ()
+
+
 def test_web_status_route_reports_ready_with_mocked_telegram(monkeypatch: Any) -> None:
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
     fake_client = _FakeTelegramClient(

--- a/tests/test_telegram_webhook_health.py
+++ b/tests/test_telegram_webhook_health.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opentulpa.api.routes.telegram_webhook_health import register_telegram_webhook_health_routes
+from opentulpa.interfaces.telegram.constants import TELEGRAM_WEBHOOK_ALLOWED_UPDATES
+from opentulpa.interfaces.telegram.webhook_health import (
+    TelegramWebhookInfo,
+    build_runtime_config,
+    evaluate_webhook_readiness,
+)
+
+
+class _FakeTelegramClient:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self.result = result
+        self.calls = 0
+
+    async def get_webhook_info(self) -> dict[str, Any]:
+        self.calls += 1
+        return self.result
+
+
+class _FailingTelegramClient:
+    async def get_webhook_info(self) -> dict[str, Any]:
+        raise RuntimeError("network down for token 123:abc")
+
+
+def _settings(*, token: str = "123:abc", secret: str = "secret") -> SimpleNamespace:
+    return SimpleNamespace(
+        telegram_bot_token=token,
+        telegram_webhook_secret=secret,
+        opentulpa_web_token="web-secret",
+    )
+
+
+def test_runtime_config_reports_expected_webhook_url(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com/")
+
+    config = build_runtime_config(_settings())
+
+    assert config.bot_token_configured is True
+    assert config.webhook_secret_configured is True
+    assert config.public_url == "https://app.example.com"
+    assert config.expected_webhook_url == "https://app.example.com/webhook/telegram"
+    assert config.allowed_updates == tuple(TELEGRAM_WEBHOOK_ALLOWED_UPDATES)
+
+
+def test_readiness_reports_missing_runtime_config_without_redeploy_opinion(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    runtime = build_runtime_config(_settings(token="", secret=""))
+
+    result = evaluate_webhook_readiness(
+        runtime=runtime,
+        telegram=TelegramWebhookInfo(
+            available=False,
+            url="",
+            pending_update_count=0,
+            allowed_updates=(),
+        ),
+    )
+
+    assert result.configured is False
+    assert result.ready is False
+    assert result.requires_webhook_reset is False
+    assert result.reasons == (
+        "telegram_bot_token_missing",
+        "telegram_webhook_secret_missing",
+        "public_base_url_missing",
+    )
+
+
+def test_readiness_requires_webhook_reset_for_telegram_url_mismatch(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    runtime = build_runtime_config(_settings())
+
+    result = evaluate_webhook_readiness(
+        runtime=runtime,
+        telegram=TelegramWebhookInfo(
+            available=True,
+            url="https://old.example.com/webhook/telegram",
+            pending_update_count=0,
+            allowed_updates=tuple(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+        ),
+    )
+
+    assert result.configured is True
+    assert result.ready is False
+    assert result.requires_webhook_reset is True
+    assert result.reasons == ("telegram_webhook_url_mismatch",)
+
+
+def test_readiness_accepts_matching_webhook_and_allowed_updates(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    runtime = build_runtime_config(_settings())
+
+    result = evaluate_webhook_readiness(
+        runtime=runtime,
+        telegram=TelegramWebhookInfo(
+            available=True,
+            url="https://app.example.com/webhook/telegram",
+            pending_update_count=0,
+            allowed_updates=tuple(reversed(TELEGRAM_WEBHOOK_ALLOWED_UPDATES)),
+        ),
+    )
+
+    assert result.configured is True
+    assert result.ready is True
+    assert result.requires_webhook_reset is False
+    assert result.reasons == ()
+
+
+def test_web_status_route_reports_ready_with_mocked_telegram(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    fake_client = _FakeTelegramClient(
+        {
+            "url": "https://app.example.com/webhook/telegram",
+            "pending_update_count": 0,
+            "allowed_updates": list(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+        }
+    )
+    app = FastAPI()
+    register_telegram_webhook_health_routes(
+        app,
+        settings=_settings(),
+        get_telegram_client=lambda: fake_client,
+        web_token="web-secret",
+    )
+
+    with TestClient(app) as client:
+        rejected = client.get("/web/telegram/status")
+        accepted = client.get(
+            "/web/telegram/status",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert rejected.status_code == 401
+    assert accepted.status_code == 200
+    payload = accepted.json()
+    assert payload["configured"] is True
+    assert payload["ready"] is True
+    assert payload["requires_webhook_reset"] is False
+    assert payload["expected_webhook_url"] == "https://app.example.com/webhook/telegram"
+    assert payload["telegram_webhook_url"] == "https://app.example.com/webhook/telegram"
+    assert payload["reasons"] == []
+    assert fake_client.calls == 1
+
+
+def test_web_status_route_returns_unavailable_when_telegram_raises(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    app = FastAPI()
+    register_telegram_webhook_health_routes(
+        app,
+        settings=_settings(),
+        get_telegram_client=lambda: _FailingTelegramClient(),
+        web_token="web-secret",
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/telegram/status",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["configured"] is True
+    assert payload["ready"] is False
+    assert payload["telegram"]["available"] is False
+    assert payload["telegram"]["raw_error"] == "RuntimeError: network down for token [redacted]"
+    assert payload["reasons"] == ["telegram_webhook_status_unavailable"]

--- a/tests/test_telegram_webhook_health.py
+++ b/tests/test_telegram_webhook_health.py
@@ -173,6 +173,34 @@ def test_web_status_route_reports_ready_with_mocked_telegram(monkeypatch: Any) -
     assert fake_client.calls == 1
 
 
+def test_web_status_route_reports_unavailable_when_web_token_missing(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
+    fake_client = _FakeTelegramClient(
+        {
+            "url": "https://app.example.com/webhook/telegram",
+            "pending_update_count": 0,
+            "allowed_updates": list(TELEGRAM_WEBHOOK_ALLOWED_UPDATES),
+        }
+    )
+    app = FastAPI()
+    register_telegram_webhook_health_routes(
+        app,
+        settings=_settings(),
+        get_telegram_client=lambda: fake_client,
+        web_token=None,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/telegram/status",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "OPENTULPA_WEB_TOKEN is not configured"}
+    assert fake_client.calls == 0
+
+
 def test_web_status_route_returns_unavailable_when_telegram_raises(monkeypatch: Any) -> None:
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.example.com")
     app = FastAPI()

--- a/tests/test_web_intake_workflows.py
+++ b/tests/test_web_intake_workflows.py
@@ -25,18 +25,23 @@ def _file_vault(tmp_path: Path) -> FileVaultService:
     )
 
 
-def _app(service: IntakeWorkflowService, vault: FileVaultService) -> FastAPI:
+def _app(
+    service: IntakeWorkflowService,
+    vault: FileVaultService,
+    *,
+    web_token: str | None = "secret",
+) -> FastAPI:
     app = FastAPI()
     register_intake_workflow_routes(
         app,
         get_intake_workflows=lambda: service,
         get_workflow_setup_service=lambda: None,
         get_file_vault=lambda: vault,
-        web_token="secret",
+        web_token=web_token,
     )
     register_generic_chat_routes(
         app,
-        web_token="secret",
+        web_token=web_token,
         get_agent_runtime=lambda: None,
         get_file_vault=lambda: vault,
         get_workflow_setup_service=lambda: None,
@@ -82,6 +87,20 @@ def test_web_workflow_routes_require_bearer_token(tmp_path: Path) -> None:
     assert rejected.status_code == 401
     assert accepted.status_code == 200
     assert accepted.json() == {"ok": True, "workflows": []}
+
+
+def test_web_workflow_routes_keep_unauthorized_when_web_token_missing(tmp_path: Path) -> None:
+    app = _app(_service(tmp_path), _file_vault(tmp_path), web_token=None)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/intake/workflows",
+            params={"customer_id": "dashboard"},
+            headers={"authorization": "Bearer secret"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}
 
 
 def test_web_workflow_list_and_get_include_knowledge_files(tmp_path: Path) -> None:
@@ -163,10 +182,12 @@ def test_web_workflow_put_validates_and_persists(tmp_path: Path) -> None:
     assert updated.status_code == 200
     assert updated.json()["workflow"]["name"] == "Updated booking"
     assert updated.json()["workflow"]["enabled"] is False
-    assert service.get_workflow(
+    persisted = service.get_workflow(
         customer_id="dashboard",
         workflow_id=str(workflow["workflow_id"]),
-    )["required_fields"] == ["name", "vehicle"]
+    )
+    assert persisted is not None
+    assert persisted["required_fields"] == ["name", "vehicle"]
     assert invalid.status_code == 400
     assert "name is required" in invalid.json()["detail"]
 


### PR DESCRIPTION
## Summary
- add side-effect-free Telegram webhook readiness service
- expose bearer-protected `GET /web/telegram/status` and internal `GET /internal/telegram/status`
- use Telegram `getWebhookInfo` to report configured URL, allowed updates, pending count, last error, and webhook reset need
- keep redeploy ownership out of runtime; no fingerprint or `requires_redeploy` contract
- report historical Telegram last errors without blocking readiness when webhook config matches
- extract shared web bearer-auth helper for web routes and remove duplicated local auth parsing from generic chat, intake, and Telegram status routes

## Validation
- `uv run pytest tests/test_telegram_webhook_health.py tests/test_web_intake_workflows.py tests/test_internal_api_auth.py tests/test_generic_chat_routes.py -q` -> 27 passed
- `uv run pytest tests/test_telegram_webhook_health.py tests/test_internal_api_auth.py tests/test_main_bootstrap.py tests/test_telegram_business_webhook.py tests/test_web_intake_workflows.py tests/test_generic_chat_routes.py -q` -> 43 passed
- `uv run ruff check src/opentulpa/api/web_auth.py src/opentulpa/api/routes/telegram_webhook_health.py src/opentulpa/api/routes/generic_chat.py src/opentulpa/api/routes/intake.py tests/test_telegram_webhook_health.py tests/test_web_intake_workflows.py`
- `uv run mypy src/opentulpa/api/web_auth.py src/opentulpa/api/routes/telegram_webhook_health.py src/opentulpa/api/routes/generic_chat.py src/opentulpa/api/routes/intake.py tests/test_telegram_webhook_health.py tests/test_web_intake_workflows.py`
- `git diff --check`

## Notes
This is the runtime half of OPE-189. OpenTulpaWebsite owns save/redeploy/status UX and consumes this endpoint after redeploy. Passive health does not prove a user can send Telegram messages; that needs a separate user-sent test message flow.