### PR TITLE
OPE-184: Add usage telemetry API

### DIFF
--- a/src/opentulpa/api/app.py
+++ b/src/opentulpa/api/app.py
@@ -32,6 +32,7 @@ from opentulpa.api.routes import (
     register_telegram_webhook_health_routes,
     register_telegram_webhook_routes,
     register_tulpa_routes,
+    register_usage_telemetry_routes,
     register_user_context_routes,
     register_wake_and_search_routes,
     register_web_event_routes,
@@ -66,6 +67,10 @@ from opentulpa.tasks.sandbox import PROJECT_ROOT
 from opentulpa.tasks.sandbox import delete_file as sandbox_delete_file
 from opentulpa.tasks.service import TaskService
 from opentulpa.tasks.wake_queue import WakeQueueService
+from opentulpa.telemetry.usage import (
+    LocalTraceUsageTelemetryRepository,
+    UsageTelemetryService,
+)
 from opentulpa.web.events import WebEventStore, set_default_web_event_store
 
 logger = logging.getLogger(__name__)
@@ -336,6 +341,16 @@ def create_app(
     def get_web_events() -> WebEventStore:
         return web_event_store
 
+    trace_path = getattr(runtime, "_llm_call_trace_path", None) or (
+        PROJECT_ROOT / ".opentulpa" / "logs" / "llm_call_traces.jsonl"
+    )
+    usage_telemetry = UsageTelemetryService(
+        LocalTraceUsageTelemetryRepository(trace_path=trace_path)
+    )
+
+    def get_usage_telemetry() -> UsageTelemetryService:
+        return usage_telemetry
+
     def get_profiles() -> CustomerProfileService:
         return _require(profile_service, "CustomerProfileService")
 
@@ -599,6 +614,7 @@ def create_app(
             and not path.startswith("/web/files/")
             and not path.startswith("/web/local-files/")
             and path != "/web/telegram/status"
+            and path != "/web/usage"
             and path not in public_health_paths
         ):
             return JSONResponse(status_code=403, content={"detail": "forbidden public endpoint"})
@@ -719,6 +735,12 @@ def create_app(
         app,
         settings=settings,
         get_web_events=get_web_events,
+        resolve_customer_id=profile_service.resolve_customer_id,
+    )
+    register_usage_telemetry_routes(
+        app,
+        web_token=settings.opentulpa_web_token,
+        get_usage_telemetry=get_usage_telemetry,
         resolve_customer_id=profile_service.resolve_customer_id,
     )
     register_tulpa_routes(

--- a/src/opentulpa/api/routes/__init__.py
+++ b/src/opentulpa/api/routes/__init__.py
@@ -24,6 +24,7 @@ _ROUTE_IMPORTS = {
     "register_telegram_webhook_health_routes": "opentulpa.api.routes.telegram_webhook_health",
     "register_telegram_webhook_routes": "opentulpa.api.routes.telegram_webhook",
     "register_tulpa_routes": "opentulpa.api.routes.tulpa",
+    "register_usage_telemetry_routes": "opentulpa.api.routes.usage_telemetry",
     "register_user_context_routes": "opentulpa.api.routes.user_context",
     "register_wake_and_search_routes": "opentulpa.api.routes.wake_search",
     "register_web_event_routes": "opentulpa.api.routes.web_events",

--- a/src/opentulpa/api/routes/usage_telemetry.py
+++ b/src/opentulpa/api/routes/usage_telemetry.py
@@ -1,0 +1,89 @@
+"""Authenticated usage telemetry API for dashboards."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
+
+from opentulpa.api.customer_ids import resolve_customer_id as resolve_customer_id_value
+from opentulpa.api.web_auth import web_auth_error
+from opentulpa.telemetry.usage import (
+    UsageTelemetryQuery,
+    UsageTelemetryResponse,
+    UsageTelemetryService,
+)
+
+
+def register_usage_telemetry_routes(
+    app: FastAPI,
+    *,
+    web_token: str | None,
+    get_usage_telemetry: Callable[[], UsageTelemetryService],
+    resolve_customer_id: Callable[[str], str] | None = None,
+) -> None:
+    """Register dashboard-facing token and cost telemetry routes."""
+
+    @app.get("/web/usage", response_model=UsageTelemetryResponse)
+    async def web_usage(
+        request: Request,
+        customer_id: Annotated[str | None, Query()] = None,
+        thread_id: Annotated[str | None, Query()] = None,
+        workflow_id: Annotated[str | None, Query()] = None,
+        since: Annotated[datetime | None, Query()] = None,
+        until: Annotated[datetime | None, Query()] = None,
+        limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    ) -> UsageTelemetryResponse | JSONResponse:
+        auth_error = web_auth_error(request, web_token)
+        if auth_error is not None:
+            return auth_error
+
+        requested_customer_id = _none_if_empty(customer_id)
+        if requested_customer_id is None:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "customer_id is required"},
+            )
+
+        normalized_since = _normalize_datetime(since)
+        normalized_until = _normalize_datetime(until)
+        if (
+            normalized_since is not None
+            and normalized_until is not None
+            and normalized_since > normalized_until
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "since must be before or equal to until"},
+            )
+        resolved_customer_id = resolve_customer_id_value(
+            requested_customer_id,
+            resolve_customer_id,
+        )
+        service = get_usage_telemetry()
+        return service.query(
+            UsageTelemetryQuery(
+                customer_id=resolved_customer_id,
+                thread_id=_none_if_empty(thread_id),
+                workflow_id=_none_if_empty(workflow_id),
+                since=normalized_since,
+                until=normalized_until,
+                limit=limit,
+            )
+        )
+
+
+def _none_if_empty(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/src/opentulpa/telemetry/__init__.py
+++ b/src/opentulpa/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Telemetry read models and services."""

--- a/src/opentulpa/telemetry/usage.py
+++ b/src/opentulpa/telemetry/usage.py
@@ -1,0 +1,451 @@
+"""Read-only usage telemetry projection from local LLM call traces."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import deque
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+LOCAL_TRACE_SOURCE: Literal["local_trace_jsonl"] = "local_trace_jsonl"
+DEFAULT_TRACE_MAX_LINES = 1_000
+DEFAULT_TRACE_MAX_BYTES = 1_000_000
+
+
+class UsageTelemetryFields(BaseModel):
+    input_tokens: int | None = None
+    prompt_tokens: int | None = None
+    output_tokens: int | None = None
+    completion_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    total_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    cost_usd: float | None = None
+    cost_prompt_usd: float | None = None
+    cost_completion_usd: float | None = None
+
+
+class UsageTelemetrySummary(UsageTelemetryFields):
+    generation_count: int
+    returned_generation_count: int
+    currency: Literal["USD"] = "USD"
+
+
+class UsageTelemetryGeneration(UsageTelemetryFields):
+    timestamp: datetime | None = None
+    customer_id: str
+    thread_id: str | None = None
+    workflow_id: str | None = None
+    trace_id: str | None = None
+    call_site: str | None = None
+    turn_mode: str | None = None
+    prompt_mode: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    generation_id: str | None = None
+    source: Literal["local_trace_jsonl"] = LOCAL_TRACE_SOURCE
+
+
+class UsageTelemetrySource(BaseModel):
+    kind: Literal["local_trace_jsonl"] = LOCAL_TRACE_SOURCE
+    available: bool
+    max_source_lines: int = Field(ge=1)
+    max_source_bytes: int = Field(ge=1)
+    currency: Literal["USD"] = "USD"
+
+
+class UsageTelemetryResponse(BaseModel):
+    summary: UsageTelemetrySummary
+    generations: list[UsageTelemetryGeneration]
+    source: UsageTelemetrySource
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class UsageTelemetryQuery:
+    customer_id: str
+    thread_id: str | None = None
+    workflow_id: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = 100
+
+
+class LocalTraceUsageTelemetryRepository:
+    """Repository for capped local `llm_call_traces.jsonl` reads."""
+
+    def __init__(
+        self,
+        *,
+        trace_path: str | Path | None,
+        max_source_lines: int = DEFAULT_TRACE_MAX_LINES,
+        max_source_bytes: int = DEFAULT_TRACE_MAX_BYTES,
+    ) -> None:
+        self.trace_path = Path(trace_path) if trace_path is not None else None
+        self.max_source_lines = max(1, int(max_source_lines))
+        self.max_source_bytes = max(1, int(max_source_bytes))
+
+    @property
+    def available(self) -> bool:
+        return self.trace_path is not None and self.trace_path.exists() and self.trace_path.is_file()
+
+    def list_records(self) -> list[dict[str, Any]]:
+        assert self.max_source_lines > 0
+        assert self.max_source_bytes > 0
+        if self.trace_path is None or not self.available:
+            return []
+
+        records: list[dict[str, Any]] = []
+        for line in _tail_lines(
+            self.trace_path,
+            max_lines=self.max_source_lines,
+            max_bytes=self.max_source_bytes,
+        ):
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                records.append(payload)
+        return records
+
+
+class UsageTelemetryService:
+    def __init__(self, repository: LocalTraceUsageTelemetryRepository) -> None:
+        self._repository = repository
+
+    def query(self, query: UsageTelemetryQuery) -> UsageTelemetryResponse:
+        assert query.customer_id.strip()
+        assert query.limit > 0
+        since = _normalize_datetime(query.since)
+        until = _normalize_datetime(query.until)
+        assert since is None or until is None or since <= until
+
+        matching = [
+            _project_record(record)
+            for record in self._repository.list_records()
+            if _record_matches_query(record, query, since=since, until=until)
+        ]
+        matching.sort(key=_sort_key, reverse=True)
+        returned = matching[: query.limit]
+        assert len(returned) <= query.limit
+        return UsageTelemetryResponse(
+            summary=_summarize(
+                matching,
+                generation_count=len(matching),
+                returned_generation_count=len(returned),
+            ),
+            generations=returned,
+            source=UsageTelemetrySource(
+                available=self._repository.available,
+                max_source_lines=self._repository.max_source_lines,
+                max_source_bytes=self._repository.max_source_bytes,
+            ),
+            has_more=len(matching) > len(returned),
+        )
+
+
+def _tail_lines(path: Path, *, max_lines: int, max_bytes: int) -> list[str]:
+    assert max_lines > 0
+    assert max_bytes > 0
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return []
+
+    lines: deque[str] = deque(maxlen=max_lines)
+    try:
+        with path.open("rb") as handle:
+            start = max(0, size - max_bytes)
+            if start:
+                handle.seek(start)
+                _ = handle.readline()
+            for raw_line in handle:
+                line = raw_line.decode("utf-8", errors="ignore").strip()
+                if line:
+                    lines.append(line)
+    except OSError:
+        return []
+    return list(lines)
+
+
+def _record_matches_query(
+    record: dict[str, Any],
+    query: UsageTelemetryQuery,
+    *,
+    since: datetime | None,
+    until: datetime | None,
+) -> bool:
+    if _text(record.get("customer_id")) != query.customer_id:
+        return False
+    if query.thread_id and _text(record.get("thread_id")) != query.thread_id:
+        return False
+    if query.workflow_id and _text(record.get("workflow_id")) != query.workflow_id:
+        return False
+
+    timestamp = _datetime_value(record.get("ts"))
+    if since is not None and (timestamp is None or timestamp < since):
+        return False
+    return not (until is not None and (timestamp is None or timestamp > until))
+
+
+def _project_record(record: dict[str, Any]) -> UsageTelemetryGeneration:
+    customer_id = _text(record.get("customer_id"))
+    assert customer_id
+    tokens = _token_fields(record)
+    costs = _cost_fields(record)
+    return UsageTelemetryGeneration(
+        timestamp=_datetime_value(record.get("ts")),
+        customer_id=customer_id,
+        thread_id=_none_if_empty(record.get("thread_id")),
+        workflow_id=_none_if_empty(record.get("workflow_id")),
+        trace_id=_none_if_empty(record.get("trace_id")),
+        call_site=_none_if_empty(record.get("call_site")),
+        turn_mode=_none_if_empty(record.get("turn_mode")),
+        prompt_mode=_none_if_empty(record.get("prompt_mode")),
+        provider=_none_if_empty(record.get("response_model_provider")),
+        model=_model_name(record),
+        generation_id=_none_if_empty(record.get("openrouter_generation_id")),
+        input_tokens=tokens["input_tokens"],
+        prompt_tokens=tokens["prompt_tokens"],
+        output_tokens=tokens["output_tokens"],
+        completion_tokens=tokens["completion_tokens"],
+        reasoning_tokens=tokens["reasoning_tokens"],
+        total_tokens=tokens["total_tokens"],
+        cache_read_tokens=tokens["cache_read_tokens"],
+        cache_write_tokens=tokens["cache_write_tokens"],
+        cost_usd=costs["cost_usd"],
+        cost_prompt_usd=costs["cost_prompt_usd"],
+        cost_completion_usd=costs["cost_completion_usd"],
+    )
+
+
+def _model_name(record: dict[str, Any]) -> str | None:
+    return _none_if_empty(record.get("response_model_name")) or _none_if_empty(
+        record.get("model_name")
+    )
+
+
+def _token_fields(record: dict[str, Any]) -> dict[str, int | None]:
+    usage = _usage_dict(record)
+    prompt_details = _dict_value(usage.get("prompt_tokens_details"))
+    completion_details = _dict_value(usage.get("completion_tokens_details"))
+
+    prompt_tokens = _int_field(record, "native_tokens_prompt")
+    if prompt_tokens is None:
+        prompt_tokens = _int_value(usage.get("prompt_tokens"))
+    if prompt_tokens is None:
+        prompt_tokens = _int_value(usage.get("input_tokens"))
+
+    completion_tokens = _int_field(record, "native_tokens_completion")
+    if completion_tokens is None:
+        completion_tokens = _int_value(usage.get("completion_tokens"))
+    if completion_tokens is None:
+        completion_tokens = _int_value(usage.get("output_tokens"))
+
+    reasoning_tokens = _int_field(record, "native_tokens_reasoning")
+    if reasoning_tokens is None:
+        reasoning_tokens = _int_value(completion_details.get("reasoning_tokens"))
+
+    total_tokens = _int_field(record, "native_tokens_total")
+    if total_tokens is None:
+        total_tokens = _int_value(usage.get("total_tokens"))
+
+    cache_read_tokens = _int_field(record, "native_tokens_cached")
+    if cache_read_tokens is None:
+        cache_read_tokens = _int_value(prompt_details.get("cached_tokens"))
+    if cache_read_tokens is None:
+        cache_read_tokens = _int_value(usage.get("prompt_cache_hit_tokens"))
+
+    cache_write_tokens = _int_field(record, "native_tokens_cache_write")
+    if cache_write_tokens is None:
+        cache_write_tokens = _int_value(prompt_details.get("cache_write_tokens"))
+    if cache_write_tokens is None:
+        cache_write_tokens = _int_value(usage.get("prompt_cache_miss_tokens"))
+
+    return {
+        "input_tokens": prompt_tokens,
+        "prompt_tokens": prompt_tokens,
+        "output_tokens": completion_tokens,
+        "completion_tokens": completion_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "total_tokens": total_tokens,
+        "cache_read_tokens": cache_read_tokens,
+        "cache_write_tokens": cache_write_tokens,
+    }
+
+
+def _cost_fields(record: dict[str, Any]) -> dict[str, float | None]:
+    usage = _usage_dict(record)
+    native_cost_details = _dict_value(record.get("native_cost_details"))
+    usage_cost_details = _dict_value(usage.get("cost_details"))
+
+    cost_usd = _float_field(record, "native_cost_usd")
+    if cost_usd is None:
+        cost_usd = _float_value(native_cost_details.get("total"))
+    if cost_usd is None:
+        cost_usd = _float_value(native_cost_details.get("cost"))
+    if cost_usd is None:
+        cost_usd = _float_value(usage.get("cost"))
+    if cost_usd is None:
+        cost_usd = _float_value(usage_cost_details.get("total"))
+    if cost_usd is None:
+        cost_usd = _float_value(usage_cost_details.get("cost"))
+
+    return {
+        "cost_usd": cost_usd,
+        "cost_prompt_usd": _cost_part(
+            record,
+            "native_cost_prompt_usd",
+            native_cost_details,
+            usage_cost_details,
+            "prompt",
+            "input",
+        ),
+        "cost_completion_usd": _cost_part(
+            record,
+            "native_cost_completion_usd",
+            native_cost_details,
+            usage_cost_details,
+            "completion",
+            "completions",
+            "output",
+        ),
+    }
+
+
+def _cost_part(
+    record: dict[str, Any],
+    native_field: str,
+    native_cost_details: dict[str, Any],
+    usage_cost_details: dict[str, Any],
+    *detail_keys: str,
+) -> float | None:
+    value = _float_field(record, native_field)
+    if value is not None:
+        return value
+    for key in detail_keys:
+        value = _float_value(native_cost_details.get(key))
+        if value is not None:
+            return value
+    for key in detail_keys:
+        value = _float_value(usage_cost_details.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _summarize(
+    generations: list[UsageTelemetryGeneration],
+    *,
+    generation_count: int,
+    returned_generation_count: int,
+) -> UsageTelemetrySummary:
+    assert generation_count >= len(generations)
+    assert 0 <= returned_generation_count <= generation_count
+    return UsageTelemetrySummary(
+        generation_count=generation_count,
+        returned_generation_count=returned_generation_count,
+        input_tokens=_sum_int(generations, "input_tokens"),
+        prompt_tokens=_sum_int(generations, "prompt_tokens"),
+        output_tokens=_sum_int(generations, "output_tokens"),
+        completion_tokens=_sum_int(generations, "completion_tokens"),
+        reasoning_tokens=_sum_int(generations, "reasoning_tokens"),
+        total_tokens=_sum_int(generations, "total_tokens"),
+        cache_read_tokens=_sum_int(generations, "cache_read_tokens"),
+        cache_write_tokens=_sum_int(generations, "cache_write_tokens"),
+        cost_usd=_sum_float(generations, "cost_usd"),
+        cost_prompt_usd=_sum_float(generations, "cost_prompt_usd"),
+        cost_completion_usd=_sum_float(generations, "cost_completion_usd"),
+    )
+
+
+def _usage_dict(record: dict[str, Any]) -> dict[str, Any]:
+    value = record.get("usage")
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _sum_int(generations: list[UsageTelemetryGeneration], field_name: str) -> int | None:
+    values = [getattr(generation, field_name) for generation in generations]
+    ints = [int(value) for value in values if value is not None]
+    return sum(ints) if ints else None
+
+
+def _sum_float(generations: list[UsageTelemetryGeneration], field_name: str) -> float | None:
+    values = [getattr(generation, field_name) for generation in generations]
+    floats = [float(value) for value in values if value is not None]
+    return math.fsum(floats) if floats else None
+
+
+def _sort_key(generation: UsageTelemetryGeneration) -> tuple[datetime, str, str]:
+    return (
+        generation.timestamp or datetime.min.replace(tzinfo=UTC),
+        generation.trace_id or "",
+        generation.call_site or "",
+    )
+
+
+def _int_field(record: dict[str, Any], field_name: str) -> int | None:
+    return _int_value(record.get(field_name))
+
+
+def _float_field(record: dict[str, Any], field_name: str) -> float | None:
+    return _float_value(record.get(field_name))
+
+
+def _int_value(value: Any) -> int | None:
+    try:
+        if value in (None, ""):
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_value(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _datetime_value(value: Any) -> datetime | None:
+    text = _text(value)
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _normalize_datetime(parsed)
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _none_if_empty(value: Any) -> str | None:
+    text = _text(value)
+    return text or None
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -11,12 +12,17 @@ from opentulpa.interfaces.telegram.client import TelegramClient
 from opentulpa.skills.service import SkillStoreService
 
 
-def _mk_client(tmp_path: Path, *, client_host: str = "127.0.0.1") -> TestClient:
+def _mk_client(
+    tmp_path: Path,
+    *,
+    client_host: str = "127.0.0.1",
+    agent_runtime: Any | None = None,
+) -> TestClient:
     store = SkillStoreService(
         db_path=tmp_path / "skills.db",
         root_dir=tmp_path / "skills",
     )
-    app = create_app(skill_store_service=store)
+    app = create_app(skill_store_service=store, agent_runtime=agent_runtime)
     return TestClient(app, client=(client_host, 50000))
 
 
@@ -163,4 +169,55 @@ def test_telegram_webhook_status_route_is_public_but_bearer_protected(
     assert accepted.status_code == 200
     assert accepted.json()["ready"] is True
     assert accepted.json()["requires_webhook_reset"] is False
+    get_settings.cache_clear()
+
+
+def test_web_usage_route_public_with_bearer_auth(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    trace_path = tmp_path / "llm_call_traces.jsonl"
+    trace_path.write_text(
+        json.dumps(
+            {
+                "ts": "2026-06-04T00:00:00+00:00",
+                "customer_id": "telegram_1",
+                "thread_id": "dashboard-owner-1",
+                "trace_id": "trace_usage",
+                "native_tokens_prompt": 12,
+                "native_cost_usd": 0.004,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime = type("Runtime", (), {"_llm_call_trace_path": trace_path})()
+    monkeypatch.setenv("OPENTULPA_WEB_TOKEN", "web-secret")
+    get_settings.cache_clear()
+    with _mk_client(tmp_path, client_host="8.8.8.8", agent_runtime=runtime) as client:
+        no_header = client.get("/web/usage")
+        missing_customer = client.get(
+            "/web/usage",
+            headers={"authorization": "Bearer web-secret"},
+        )
+        bad_window = client.get(
+            "/web/usage?customer_id=telegram_1&since=2026-06-05T00:00:00Z&until=2026-06-04T00:00:00Z",
+            headers={"authorization": "Bearer web-secret"},
+        )
+        accepted = client.get(
+            "/web/usage?customer_id=telegram_1",
+            headers={"authorization": "Bearer web-secret"},
+        )
+
+    assert no_header.status_code == 401
+    assert missing_customer.status_code == 400
+    assert missing_customer.json() == {"detail": "customer_id is required"}
+    assert bad_window.status_code == 400
+    assert bad_window.json() == {"detail": "since must be before or equal to until"}
+    assert accepted.status_code == 200
+    body = accepted.json()
+    assert body["summary"]["generation_count"] == 1
+    assert body["summary"]["input_tokens"] == 12
+    assert body["summary"]["cost_usd"] == 0.004
+    assert body["generations"][0]["trace_id"] == "trace_usage"
     get_settings.cache_clear()

--- a/tests/test_usage_telemetry.py
+++ b/tests/test_usage_telemetry.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from opentulpa.telemetry.usage import (
+    LocalTraceUsageTelemetryRepository,
+    UsageTelemetryQuery,
+    UsageTelemetryService,
+)
+
+
+def test_usage_telemetry_projects_and_aggregates_trace_rows(tmp_path: Path) -> None:
+    trace_path = tmp_path / "llm_call_traces.jsonl"
+    _write_jsonl(
+        trace_path,
+        {
+            "ts": "2026-06-04T00:00:00+00:00",
+            "customer_id": "telegram_1",
+            "thread_id": "thread_a",
+            "trace_id": "trace_old",
+            "call_site": "graph_agent",
+            "turn_mode": "interactive",
+            "prompt_mode": "literal_chat",
+            "model_name": "google/gemini-3-flash-preview",
+            "response_model_provider": "openrouter",
+            "response_model_name": "google/gemini-3-flash-preview",
+            "openrouter_generation_id": "gen_old",
+            "native_tokens_prompt": 100,
+            "native_tokens_completion": 50,
+            "native_tokens_reasoning": 10,
+            "native_tokens_total": 150,
+            "native_tokens_cached": 20,
+            "native_tokens_cache_write": 5,
+            "native_cost_usd": 0.03,
+            "native_cost_prompt_usd": 0.01,
+            "native_cost_completion_usd": 0.02,
+        },
+        {
+            "ts": "2026-06-04T01:00:00+00:00",
+            "customer_id": "telegram_1",
+            "thread_id": "thread_a",
+            "workflow_id": "iwf_1",
+            "trace_id": "trace_new",
+            "call_site": "intake_workflow_decision",
+            "model_name": "z-ai/glm-5.1",
+            "usage": {
+                "prompt_tokens": 30,
+                "completion_tokens": 7,
+                "total_tokens": 37,
+                "prompt_tokens_details": {"cached_tokens": 3},
+                "completion_tokens_details": {"reasoning_tokens": 2},
+            },
+        },
+        {
+            "ts": "2026-06-04T02:00:00+00:00",
+            "customer_id": "telegram_2",
+            "thread_id": "thread_b",
+            "native_tokens_prompt": 999,
+            "native_cost_usd": 99,
+        },
+    )
+    service = UsageTelemetryService(
+        LocalTraceUsageTelemetryRepository(trace_path=trace_path, max_source_lines=20)
+    )
+
+    response = service.query(UsageTelemetryQuery(customer_id="telegram_1", limit=10))
+
+    assert response.source.available is True
+    assert response.has_more is False
+    assert response.summary.generation_count == 2
+    assert response.summary.returned_generation_count == 2
+    assert response.summary.input_tokens == 130
+    assert response.summary.prompt_tokens == 130
+    assert response.summary.output_tokens == 57
+    assert response.summary.completion_tokens == 57
+    assert response.summary.reasoning_tokens == 12
+    assert response.summary.total_tokens == 187
+    assert response.summary.cache_read_tokens == 23
+    assert response.summary.cache_write_tokens == 5
+    assert response.summary.cost_usd == 0.03
+    assert response.summary.cost_prompt_usd == 0.01
+    assert response.summary.cost_completion_usd == 0.02
+    assert [generation.trace_id for generation in response.generations] == [
+        "trace_new",
+        "trace_old",
+    ]
+    latest = response.generations[0]
+    assert latest.workflow_id == "iwf_1"
+    assert latest.model == "z-ai/glm-5.1"
+    assert latest.cost_usd is None
+
+
+def test_usage_telemetry_filters_window_and_reports_limit(tmp_path: Path) -> None:
+    trace_path = tmp_path / "llm_call_traces.jsonl"
+    _write_jsonl(
+        trace_path,
+        {
+            "ts": "2026-06-04T00:00:00+00:00",
+            "customer_id": "telegram_1",
+            "thread_id": "thread_a",
+            "trace_id": "trace_old",
+            "native_tokens_prompt": 10,
+        },
+        {
+            "ts": "2026-06-04T01:00:00+00:00",
+            "customer_id": "telegram_1",
+            "thread_id": "thread_a",
+            "trace_id": "trace_mid",
+            "native_tokens_prompt": 20,
+        },
+        {
+            "ts": "2026-06-04T02:00:00+00:00",
+            "customer_id": "telegram_1",
+            "thread_id": "thread_a",
+            "trace_id": "trace_new",
+            "native_tokens_prompt": 30,
+        },
+    )
+    service = UsageTelemetryService(
+        LocalTraceUsageTelemetryRepository(trace_path=trace_path, max_source_lines=20)
+    )
+
+    response = service.query(
+        UsageTelemetryQuery(
+            customer_id="telegram_1",
+            thread_id="thread_a",
+            since=datetime(2026, 6, 4, 1, 0),
+            until=datetime(2026, 6, 4, 2, 0),
+            limit=1,
+        )
+    )
+
+    assert response.has_more is True
+    assert response.summary.generation_count == 2
+    assert response.summary.returned_generation_count == 1
+    assert response.summary.input_tokens == 50
+    assert [generation.trace_id for generation in response.generations] == ["trace_new"]
+
+
+def test_usage_telemetry_missing_trace_returns_empty_null_totals(tmp_path: Path) -> None:
+    service = UsageTelemetryService(
+        LocalTraceUsageTelemetryRepository(trace_path=tmp_path / "missing.jsonl")
+    )
+
+    response = service.query(UsageTelemetryQuery(customer_id="telegram_1", limit=10))
+
+    assert response.source.available is False
+    assert response.summary.generation_count == 0
+    assert response.summary.input_tokens is None
+    assert response.summary.cost_usd is None
+    assert response.generations == []
+
+
+def _write_jsonl(path: Path, *records: dict[str, object]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary
- add bearer-protected `GET /web/usage` for dashboard token/cost telemetry
- project local `llm_call_traces.jsonl` rows into explicit typed usage summaries and per-generation records
- require `customer_id` for usage reads so the web API does not expose deployment-wide usage by default
- reuse canonical `opentulpa.api.web_auth.web_auth_error` instead of adding another local bearer-auth helper
- keep cost honest: missing provider cost remains `null`, not inferred or zeroed

## Thermo-nuclear quality notes
- branch rebased onto current `main`, preserving OPE-189 merged webhook readiness code
- removed arbitrary path-probing magic from the prototype; telemetry projection now reads exact normalized `native_*` trace fields with a small explicit legacy `usage` fallback
- no file crosses 1k lines; `api/app.py` remains under threshold

## Validation
- `uv run pytest tests/test_usage_telemetry.py tests/test_internal_api_auth.py tests/test_main_bootstrap.py tests/test_telegram_webhook_health.py tests/test_web_intake_workflows.py tests/test_generic_chat_routes.py -q` -> 42 passed
- `uv run ruff check src/opentulpa/telemetry/usage.py src/opentulpa/api/routes/usage_telemetry.py src/opentulpa/api/app.py tests/test_usage_telemetry.py tests/test_internal_api_auth.py`
- `uv run mypy src/opentulpa/api/app.py src/opentulpa/api/routes/usage_telemetry.py src/opentulpa/telemetry/usage.py tests/test_usage_telemetry.py tests/test_internal_api_auth.py`
- `git diff --check`