### PR TITLE
Fix Codex device login

### DIFF
--- a/src/opentulpa/inference/service.py
+++ b/src/opentulpa/inference/service.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
-import secrets
 from collections import OrderedDict
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -22,7 +19,6 @@ from opentulpa.inference.codex import (
     CHATGPT_DEVICE_TOKEN_URL,
     CHATGPT_TOKEN_URL,
     CODEX_MODELS_URL,
-    DEFAULT_SCOPE,
     CodexAuthenticationError,
     CodexProviderError,
     CodexTokenProvider,
@@ -36,6 +32,7 @@ from opentulpa.secrets.cipher import HostKeySecretCipher
 _API_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 _MODEL_CACHE_LIMIT = 24
 _CATALOG_TTL = timedelta(minutes=5)
+_CODEX_DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device"
 
 
 class InferenceConflictError(RuntimeError):
@@ -177,22 +174,11 @@ class InferenceService:
         return resolved
 
     async def start_device_login(self, tenant_id: str) -> dict[str, Any]:
-        verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b"=").decode("ascii")
-        challenge = (
-            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
-            .rstrip(b"=")
-            .decode("ascii")
-        )
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     CHATGPT_DEVICE_CODE_URL,
-                    data={
-                        "client_id": CHATGPT_CLIENT_ID,
-                        "scope": DEFAULT_SCOPE,
-                        "code_challenge": challenge,
-                        "code_challenge_method": "S256",
-                    },
+                    json={"client_id": CHATGPT_CLIENT_ID},
                     headers={"Accept": "application/json"},
                 )
             if response.status_code >= 400:
@@ -204,42 +190,26 @@ class InferenceService:
             raise CodexProviderError("Codex device login could not be started") from exc
         if not isinstance(payload, dict):
             raise CodexProviderError("Codex returned an invalid device login response")
-        device_code = str(payload.get("device_code") or "").strip()
+        device_auth_id = str(payload.get("device_auth_id") or "").strip()
         user_code = str(payload.get("user_code") or "").strip()
-        verification_url = str(
-            payload.get("verification_uri") or payload.get("verification_uri_complete") or ""
-        ).strip()
-        if not device_code or not user_code or not verification_url:
+        if not device_auth_id or not user_code:
             raise CodexProviderError("Codex returned an incomplete device login response")
-        try:
-            verification_target = httpx.URL(verification_url)
-        except httpx.InvalidURL as exc:
-            raise CodexProviderError("Codex returned an invalid verification URL") from exc
-        if verification_target.scheme != "https" or verification_target.host not in {
-            "auth.openai.com",
-            "chatgpt.com",
-        }:
-            raise CodexProviderError("Codex returned an invalid verification URL")
         now = datetime.now(UTC)
         try:
-            interval = max(1.0, float(payload.get("interval") or 5.0))
+            interval = max(3.0, float(payload.get("interval") or 5.0))
         except (TypeError, ValueError):
             interval = 5.0
-        try:
-            expires_in = max(30, int(payload.get("expires_in") or 600))
-        except (TypeError, ValueError):
-            expires_in = 600
+        expires_at = self._device_expiry(payload.get("expires_at"), now=now)
         login = DeviceLogin(
             id=new_short_id("login", suffix_chars=12),
             tenant_id=tenant_id,
             status="pending",
-            verification_url=verification_url,
+            verification_url=_CODEX_DEVICE_VERIFICATION_URL,
             user_code=user_code,
-            device_code=device_code,
-            code_verifier=verifier,
+            device_auth_id=device_auth_id,
             interval_seconds=interval,
             next_poll_at=now,
-            expires_at=now + timedelta(seconds=expires_in),
+            expires_at=expires_at,
         )
         self._store.create_device_login(login)
         return self._public_login(login)
@@ -280,7 +250,10 @@ class InferenceService:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     CHATGPT_DEVICE_TOKEN_URL,
-                    data={"client_id": CHATGPT_CLIENT_ID, "device_code": login.device_code},
+                    json={
+                        "device_auth_id": login.device_auth_id,
+                        "user_code": login.user_code,
+                    },
                     headers={"Accept": "application/json"},
                 )
             payload = response.json()
@@ -294,11 +267,16 @@ class InferenceService:
         if not isinstance(payload, dict):
             payload = {}
         authorization_code = str(payload.get("authorization_code") or "").strip()
-        if authorization_code:
-            return await self._exchange_device_login(login, authorization_code)
-        error = str(payload.get("error") or "").strip()
-        interval = login.interval_seconds + (5.0 if error == "slow_down" else 0.0)
-        if not error or error in {"authorization_pending", "slow_down"}:
+        code_verifier = str(payload.get("code_verifier") or "").strip()
+        if response.status_code == 200 and authorization_code and code_verifier:
+            return await self._exchange_device_login(login, authorization_code, code_verifier)
+        error = self._oauth_error_code(payload)
+        slow_down = response.status_code == 429 or error == "slow_down"
+        interval = login.interval_seconds + (5.0 if slow_down else 0.0)
+        if response.status_code in {403, 404, 429} or error in {
+            "authorization_pending",
+            "slow_down",
+        }:
             pending = self._replace_login(
                 login,
                 interval_seconds=interval,
@@ -314,6 +292,7 @@ class InferenceService:
         self,
         login: DeviceLogin,
         authorization_code: str,
+        code_verifier: str,
     ) -> dict[str, Any]:
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
@@ -324,7 +303,7 @@ class InferenceService:
                         "code": authorization_code,
                         "redirect_uri": CHATGPT_DEVICE_REDIRECT_URI,
                         "client_id": CHATGPT_CLIENT_ID,
-                        "code_verifier": login.code_verifier,
+                        "code_verifier": code_verifier,
                     },
                     headers={"Accept": "application/json"},
                 )
@@ -352,6 +331,21 @@ class InferenceService:
             (key, value) for key, value in self._models.items() if key[0] != login.tenant_id
         )
         return self._public_login(authorized)
+
+    @staticmethod
+    def _device_expiry(raw: Any, *, now: datetime) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00")).astimezone(UTC)
+        except (TypeError, ValueError):
+            return now + timedelta(minutes=15)
+        return parsed if parsed > now else now + timedelta(seconds=30)
+
+    @staticmethod
+    def _oauth_error_code(payload: dict[str, Any]) -> str:
+        error = payload.get("error")
+        if isinstance(error, dict):
+            return str(error.get("code") or error.get("type") or "").strip()
+        return str(error or "").strip()
 
     async def _codex_models(self, tenant_id: str) -> tuple[InferenceModel, ...]:
         if not self.codex_connected(tenant_id):

--- a/src/opentulpa/inference/store.py
+++ b/src/opentulpa/inference/store.py
@@ -39,8 +39,7 @@ class DeviceLogin:
     status: str
     verification_url: str
     user_code: str
-    device_code: str
-    code_verifier: str
+    device_auth_id: str
     interval_seconds: float
     next_poll_at: datetime
     expires_at: datetime
@@ -344,8 +343,7 @@ class InferenceCredentialStore:
             status=str(row["status"]),
             verification_url=str(payload["verification_url"]),
             user_code=str(payload["user_code"]),
-            device_code=str(payload["device_code"]),
-            code_verifier=str(payload["code_verifier"]),
+            device_auth_id=str(payload["device_auth_id"]),
             interval_seconds=float(payload["interval_seconds"]),
             next_poll_at=datetime.fromisoformat(str(payload["next_poll_at"])).astimezone(UTC),
             expires_at=datetime.fromisoformat(str(payload["expires_at"])).astimezone(UTC),
@@ -357,8 +355,7 @@ class InferenceCredentialStore:
         return {
             "verification_url": login.verification_url,
             "user_code": login.user_code,
-            "device_code": login.device_code,
-            "code_verifier": login.code_verifier,
+            "device_auth_id": login.device_auth_id,
             "interval_seconds": login.interval_seconds,
             "next_poll_at": login.next_poll_at.astimezone(UTC).isoformat(),
             "expires_at": login.expires_at.astimezone(UTC).isoformat(),

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -21,6 +21,8 @@ from opentulpa.deep_agent.service import (
     _ProviderFallbackMiddleware,
 )
 from opentulpa.inference.codex import (
+    CHATGPT_CLIENT_ID,
+    CHATGPT_DEVICE_REDIRECT_URI,
     CodexProviderError,
     CodexTokenProvider,
     build_codex_model,
@@ -184,19 +186,25 @@ async def test_device_login_persists_authorized_credential_without_exposing_toke
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    expires_at = (datetime.now(UTC) + timedelta(minutes=15)).isoformat()
     responses = iter(
         (
             httpx.Response(
                 200,
                 json={
-                    "device_code": "private-device-code",
+                    "device_auth_id": "private-device-auth-id",
                     "user_code": "ABCD-EFGH",
-                    "verification_uri": "https://auth.openai.com/codex/device",
-                    "interval": 1,
-                    "expires_in": 600,
+                    "interval": "3",
+                    "expires_at": expires_at,
                 },
             ),
-            httpx.Response(200, json={"authorization_code": "private-authorization-code"}),
+            httpx.Response(
+                200,
+                json={
+                    "authorization_code": "private-authorization-code",
+                    "code_verifier": "private-code-verifier",
+                },
+            ),
             httpx.Response(
                 200,
                 json={
@@ -207,6 +215,7 @@ async def test_device_login_persists_authorized_credential_without_exposing_toke
             ),
         )
     )
+    requests: list[dict[str, Any]] = []
 
     class Client:
         def __init__(self, **_: Any) -> None:
@@ -218,7 +227,8 @@ async def test_device_login_persists_authorized_credential_without_exposing_toke
         async def __aexit__(self, *_: Any) -> None:
             return None
 
-        async def post(self, *_: Any, **__: Any) -> httpx.Response:
+        async def post(self, *_: Any, **kwargs: Any) -> httpx.Response:
+            requests.append(kwargs)
             return next(responses)
 
     monkeypatch.setattr("opentulpa.inference.service.httpx.AsyncClient", Client)
@@ -228,41 +238,25 @@ async def test_device_login_persists_authorized_credential_without_exposing_toke
     authorized = await service.get_device_login("tenant-1", started["login_id"])
 
     assert started["status"] == "pending"
+    assert started["verification_url"] == "https://auth.openai.com/codex/device"
     assert authorized is not None and authorized["status"] == "authorized"
     assert "access_token" not in authorized
     assert service.codex_connected("tenant-1") is True
     assert b"private-access-token" not in (tmp_path / "inference.db").read_bytes()
-
-
-@pytest.mark.asyncio
-async def test_device_login_rejects_untrusted_verification_url(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class Client:
-        def __init__(self, **_: Any) -> None:
-            pass
-
-        async def __aenter__(self) -> Client:
-            return self
-
-        async def __aexit__(self, *_: Any) -> None:
-            return None
-
-        async def post(self, *_: Any, **__: Any) -> httpx.Response:
-            return httpx.Response(
-                200,
-                json={
-                    "device_code": "private-device-code",
-                    "user_code": "ABCD-EFGH",
-                    "verification_uri": "https://evil.example/collect",
-                    "expires_in": 600,
-                },
-            )
-
-    monkeypatch.setattr("opentulpa.inference.service.httpx.AsyncClient", Client)
-    with pytest.raises(CodexProviderError, match="invalid verification URL"):
-        await _inference(tmp_path).start_device_login("tenant-1")
+    assert requests[0]["json"] == {"client_id": CHATGPT_CLIENT_ID}
+    assert "data" not in requests[0]
+    assert requests[1]["json"] == {
+        "device_auth_id": "private-device-auth-id",
+        "user_code": "ABCD-EFGH",
+    }
+    assert "data" not in requests[1]
+    assert requests[2]["data"] == {
+        "grant_type": "authorization_code",
+        "code": "private-authorization-code",
+        "redirect_uri": CHATGPT_DEVICE_REDIRECT_URI,
+        "client_id": CHATGPT_CLIENT_ID,
+        "code_verifier": "private-code-verifier",
+    }
 
 
 @pytest.mark.asyncio
@@ -272,7 +266,7 @@ async def test_device_login_slow_down_expiry_and_denial_are_sanitized(
 ) -> None:
     responses = iter(
         (
-            httpx.Response(400, json={"error": "slow_down"}),
+            httpx.Response(429, json={"error": "slow_down"}),
             httpx.Response(400, json={"error": "access_denied", "error_description": "secret"}),
         )
     )
@@ -299,8 +293,7 @@ async def test_device_login_slow_down_expiry_and_denial_are_sanitized(
         status="pending",
         verification_url="https://auth.openai.com/codex/device",
         user_code="ABCD-EFGH",
-        device_code="private-device",
-        code_verifier="private-verifier",
+        device_auth_id="private-device-auth-id",
         interval_seconds=1,
         next_poll_at=now - timedelta(seconds=1),
         expires_at=now + timedelta(minutes=10),


### PR DESCRIPTION
## Summary
- update Codex device authorization to the current JSON contract
- persist the returned device auth identifier and obtain PKCE verification data during polling
- retain encrypted credentials and sanitized public responses

## Verification
- uv run pytest -q: 917 passed
- uv run ruff check .
- uv run mypy src
- live provider contract probe returned the expected device auth response