### PR TITLE
Fix Codex reasoning and speed controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ tool calls, drag-and-drop attachments, server-backed sessions, and clickable
 scoped credential. Use `ctrl+p` or `/sessions` to reopen the same durable Deep Agents
 threads from another client. Type `/` in the composer to search and select commands.
 
-The API key remains the zero-friction default. Inside any owner conversation, `/model`
-and `/reasoning` select that thread's next-run model without restarting OpenTulpa.
+The API key remains the zero-friction default. Inside any owner conversation, `/model`,
+`/reasoning`, and `/speed` select that thread's next-run inference settings without
+restarting OpenTulpa.
 `/login codex` optionally connects a ChatGPT Codex subscription through device login;
 the rotating OAuth credential is encrypted on the server and never shared with an
 existing Codex CLI login. Codex has no implicit cross-provider fallback. Use
@@ -239,8 +240,9 @@ and opens the native TUI. A source checkout builds and caches the platform clien
 first run; CI also produces macOS and Linux platform archives. Later, just run
 `opentulpa` again.
 
-In the TUI, use `/model`, `/reasoning`, or `/login codex`. Remote connections change the
-remote thread; no Codex environment variable, callback server, or extra process is used.
+In the TUI, use `/model`, `/reasoning`, `/speed`, or `/login codex`. Remote
+connections change the remote thread; no Codex environment variable, callback server,
+or extra process is used.
 
 ```bash
 # Remote server

--- a/clients/tui/src/app.tsx
+++ b/clients/tui/src/app.tsx
@@ -95,6 +95,7 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { value: "/session", description: "Open a session by name or number", acceptsArgument: true },
   { value: "/model", description: "Choose the provider and model" },
   { value: "/reasoning", description: "Choose the reasoning effort" },
+  { value: "/speed", description: "Choose normal or fast Codex inference" },
   { value: "/login codex", description: "Connect a ChatGPT Codex subscription" },
   { value: "/logout codex", description: "Disconnect the Codex subscription" },
   { value: "/regenerate", description: "Regenerate the latest response" },
@@ -524,6 +525,7 @@ export function App(props: { config: ClientConfig; onConnectionChange: (threadId
         provider: targetProvider,
         model: selected?.id ?? requestedModel,
         reasoning_effort: selected?.default_reasoning_effort ?? null,
+        service_tier: selected?.default_service_tier ?? null,
         fallback_to_api: targetProvider === "codex" && fallbackToApi,
       })
       return
@@ -546,11 +548,12 @@ export function App(props: { config: ClientConfig; onConnectionChange: (threadId
       ...visibleModels.map((model) => ({
         id: `${model.provider}:${model.id}`,
         label: model.id,
-        detail: `${model.provider}${model.reasoning_efforts.length ? ` · ${model.reasoning_efforts.join(" / ")}` : ""}`,
+        detail: `${model.provider}${model.reasoning_efforts.length ? ` · ${model.reasoning_efforts.join(" / ")}` : ""}${model.service_tiers.length ? " · normal / fast" : ""}`,
         select: () => void applyInferenceSelection({
           provider: model.provider,
           model: model.id,
           reasoning_effort: model.default_reasoning_effort,
+          service_tier: model.default_service_tier,
           fallback_to_api: false,
         }),
       })),
@@ -564,6 +567,58 @@ export function App(props: { config: ClientConfig; onConnectionChange: (threadId
       })
     }
     setPicker({ title: provider ? `${targetProvider === "codex" ? "Codex" : "API"} models` : "Models", hint: "Search providers and models", items })
+    setPickerQuery("")
+    setPickerIndex(0)
+  }
+
+  const chooseSpeed = async (requested?: string) => {
+    const current = inference()
+    if (!current) return
+    const selection = current.effective
+    if (selection.provider !== "codex") {
+      throw new ApiError("Normal/Fast selection is available for Codex models.")
+    }
+    const models = await api.inferenceModels("codex")
+    const model = models.find((item) => item.id === selection.model)
+    if (!model) throw new ApiError(`${selection.model} is not available from Codex.`)
+    const apply = (serviceTier: string | null) => void applyInferenceSelection(
+      { ...selection, service_tier: serviceTier },
+    )
+    if (requested !== undefined) {
+      const normalized = requested.toLocaleLowerCase()
+      if (normalized === "normal" || normalized === "default") {
+        apply(null)
+        return
+      }
+      const tier = model.service_tiers.find(
+        (item) => item.id.toLocaleLowerCase() === normalized
+          || item.name.toLocaleLowerCase() === normalized,
+      )
+      if (!tier) throw new ApiError(`${requested} is not supported by ${selection.model}.`)
+      apply(tier.id)
+      return
+    }
+    const items: PickerItem[] = [
+      {
+        id: "normal",
+        label: "Normal",
+        detail: selection.service_tier === null ? "Current" : "Standard usage and latency",
+        select: () => apply(null),
+      },
+      ...model.service_tiers.map((tier) => ({
+        id: tier.id,
+        label: tier.name,
+        detail: selection.service_tier === tier.id ? "Current" : tier.description || selection.model,
+        select: () => apply(tier.id),
+      })),
+    ]
+    setPicker({
+      title: `Speed · ${selection.model}`,
+      hint: model.service_tiers.length
+        ? "Choose normal or fast"
+        : "This model supports normal speed only",
+      items,
+    })
     setPickerQuery("")
     setPickerIndex(0)
   }
@@ -656,7 +711,7 @@ export function App(props: { config: ClientConfig; onConnectionChange: (threadId
     const [name, ...parts] = input.split(/\s+/)
     if (name === "/quit") renderer.destroy()
     else if (name === "/help") {
-      setError("/new  /sessions  /model  /reasoning  /login codex  /logout codex  /regenerate  /attach  /cancel  /quit")
+      setError("/new  /sessions  /model  /reasoning  /speed  /login codex  /logout codex  /regenerate  /attach  /cancel  /quit")
     } else if (name === "/sessions") {
       setSessionDialog(true)
       setSessionQuery("")
@@ -686,6 +741,7 @@ export function App(props: { config: ClientConfig; onConnectionChange: (threadId
         await chooseModel(explicitProvider, model, fallback)
       }
     } else if (name === "/reasoning") await chooseReasoning(parts[0])
+    else if (name === "/speed") await chooseSpeed(parts[0])
     else if (name === "/login" && parts[0] === "codex") await startCodexLogin()
     else if (name === "/logout" && parts[0] === "codex") {
       try {
@@ -1328,7 +1384,7 @@ export function StatusBar(props: {
           wrapMode="none"
           truncate
         >
-          {props.inference!.provider} · {props.inference!.model} · {props.inference!.reasoning_effort ?? "default"}
+          {props.inference!.provider} · {props.inference!.model} · {props.inference!.reasoning_effort ?? "default"} · {props.inference!.service_tier === "priority" ? "fast" : props.inference!.service_tier ?? "normal"}
         </text>
       </Show>
       <Show when={props.width >= 40}>

--- a/clients/tui/src/types.ts
+++ b/clients/tui/src/types.ts
@@ -82,6 +82,7 @@ export type InferenceSelection = {
   provider: InferenceProvider
   model: string
   reasoning_effort: string | null
+  service_tier: string | null
   fallback_to_api: boolean
 }
 
@@ -96,6 +97,14 @@ export type InferenceModel = {
   id: string
   reasoning_efforts: string[]
   default_reasoning_effort: string | null
+  service_tiers: InferenceServiceTier[]
+  default_service_tier: string | null
+}
+
+export type InferenceServiceTier = {
+  id: string
+  name: string
+  description: string
 }
 
 export type InferenceStatus = {

--- a/clients/tui/test/api.test.ts
+++ b/clients/tui/test/api.test.ts
@@ -53,12 +53,14 @@ describe("V2 event transport", () => {
           provider: "codex",
           model: "gpt-test",
           reasoning_effort: "high",
+          service_tier: "priority",
           fallback_to_api: false,
         },
         effective: {
           provider: "codex",
           model: "gpt-test",
           reasoning_effort: "high",
+          service_tier: "priority",
           fallback_to_api: false,
         },
       })
@@ -69,6 +71,7 @@ describe("V2 event transport", () => {
       provider: "codex",
       model: "gpt-test",
       reasoning_effort: "high",
+      service_tier: "priority",
       fallback_to_api: false,
     })
 
@@ -81,6 +84,7 @@ describe("V2 event transport", () => {
         provider: "codex",
         model: "gpt-test",
         reasoning_effort: "high",
+        service_tier: "priority",
         fallback_to_api: false,
       },
     })

--- a/clients/tui/test/render.test.tsx
+++ b/clients/tui/test/render.test.tsx
@@ -48,6 +48,7 @@ const tools: ToolCall[] = [
 describe("slash command palette", () => {
   test("filters commands by command and description", () => {
     expect(filterSlashCommands("mo").map((item) => item.value)).toContain("/model")
+    expect(filterSlashCommands("fast").map((item) => item.value)).toContain("/speed")
     expect(filterSlashCommands("subscription").map((item) => item.value)).toEqual([
       "/login codex",
       "/logout codex",
@@ -165,6 +166,33 @@ describe("tool activity rendering", () => {
 })
 
 describe("terminal chrome", () => {
+  test("shows the effective Codex reasoning and speed", async () => {
+    const setup = await testRender(
+      () => (
+        <StatusBar
+          busy={false}
+          uploading={false}
+          status="Ready"
+          width={90}
+          inference={{
+            provider: "codex",
+            model: "gpt-5.6-sol",
+            reasoning_effort: "ultra",
+            service_tier: "priority",
+            fallback_to_api: false,
+          }}
+        />
+      ),
+      { width: 90, height: 3 },
+    )
+    await setup.renderOnce()
+    const frame = setup.captureCharFrame()
+    expect(frame).toContain("gpt-5.6-sol")
+    expect(frame).toContain("ultra")
+    expect(frame).toContain("fast")
+    setup.renderer.destroy()
+  })
+
   test("shows visible thinking activity before the first token or tool", async () => {
     const turn = emptyTurn("run-1", "Help me inspect this project")
     const setup = await testRender(
@@ -291,6 +319,7 @@ describe("terminal chrome", () => {
                 provider: "codex",
                 model: "a-very-long-model-identifier-that-must-be-truncated-cleanly",
                 reasoning_effort: "high",
+                service_tier: "priority",
                 fallback_to_api: false,
               }}
             />

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,10 +75,10 @@ never rendered as the assistant's answer.
 Owner threads may override the configured API model with a revisioned API or Codex
 selection. The service resolves and persists an immutable inference plan before a run
 starts; approval resume and restart recovery reuse that exact plan. Graphs are compiled
-and bounded-cached by AgentSpec, dynamic tools, provider, model, reasoning effort, and
-Codex credential revision, so Deep Agents delegation and summarization use the same
-model as the main turn. Routine, intake, and explicit non-default AgentSpec model aliases
-ignore owner-thread preferences.
+and bounded-cached by AgentSpec, dynamic tools, provider, model, reasoning effort,
+service tier, and Codex credential revision, so Deep Agents delegation and summarization
+use the same model as the main turn. Routine, intake, and explicit non-default AgentSpec
+model aliases ignore owner-thread preferences.
 
 Codex uses the pinned private LangChain adapter directly, not a Codex or Hermes process.
 OAuth credentials and device sessions are encrypted with the host key. A 401 forces one

--- a/src/opentulpa/deep_agent/service.py
+++ b/src/opentulpa/deep_agent/service.py
@@ -2034,6 +2034,7 @@ class DeepAgentService:
         if (
             plan.primary.model == self._model_name
             and plan.primary.reasoning_effort == self._reasoning_effort
+            and plan.primary.service_tier is None
         ):
             return ResolvedModel(model=self._provided_model or self._build_model())
         return ResolvedModel(
@@ -2118,6 +2119,7 @@ class DeepAgentService:
             plan.primary.provider,
             plan.primary.model,
             plan.primary.reasoning_effort,
+            plan.primary.service_tier,
             plan.primary.fallback_to_api,
             credential_revision,
         )
@@ -2522,6 +2524,7 @@ class DeepAgentService:
             "provider": inference_plan.primary.provider,
             "model": inference_plan.primary.model,
             "reasoning_effort": inference_plan.primary.reasoning_effort,
+            "service_tier": inference_plan.primary.service_tier,
             "inference_plan_digest": inference_plan.digest,
             "preference_revision": inference_plan.preference_revision,
         }
@@ -2764,6 +2767,7 @@ class DeepAgentService:
             "inference_provider": plan.primary.provider,
             "inference_model": plan.primary.model,
             "reasoning_effort": plan.primary.reasoning_effort,
+            "service_tier": plan.primary.service_tier,
             "inference_plan_digest": plan.digest,
             "preference_revision": plan.preference_revision,
         }

--- a/src/opentulpa/inference/__init__.py
+++ b/src/opentulpa/inference/__init__.py
@@ -3,6 +3,7 @@
 from opentulpa.inference.models import (
     InferenceModel,
     InferenceSelection,
+    InferenceServiceTier,
     ResolvedInferencePlan,
 )
 from opentulpa.inference.service import InferenceService
@@ -11,5 +12,6 @@ __all__ = [
     "InferenceModel",
     "InferenceSelection",
     "InferenceService",
+    "InferenceServiceTier",
     "ResolvedInferencePlan",
 ]

--- a/src/opentulpa/inference/codex.py
+++ b/src/opentulpa/inference/codex.py
@@ -134,6 +134,7 @@ def build_codex_model(
     model: str,
     reasoning_effort: str | None,
     token_provider: CodexTokenProvider,
+    service_tier: str | None = None,
     buffer_for_fallback: bool = False,
 ) -> _ChatOpenAICodex:
     reasoning = (
@@ -146,6 +147,7 @@ def build_codex_model(
         reasoning=reasoning,
         include=["reasoning.encrypted_content"],
         output_version="responses/v1",
+        service_tier=service_tier,
         max_retries=0,
         timeout=60.0,
         # A streamed primary can emit text before middleware sees its terminal

--- a/src/opentulpa/inference/models.py
+++ b/src/opentulpa/inference/models.py
@@ -19,9 +19,10 @@ class InferenceSelection(_InferenceModel):
     provider: InferenceProvider
     model: str = Field(min_length=1, max_length=300)
     reasoning_effort: str | None = Field(default=None, max_length=50)
+    service_tier: str | None = Field(default=None, max_length=50)
     fallback_to_api: bool = False
 
-    @field_validator("model", "reasoning_effort")
+    @field_validator("model", "reasoning_effort", "service_tier")
     @classmethod
     def validate_identifier(cls, value: str | None) -> str | None:
         if value is None:
@@ -56,16 +57,25 @@ class ResolvedInferencePlan(_InferenceModel):
         )
 
 
+class InferenceServiceTier(_InferenceModel):
+    id: str = Field(min_length=1, max_length=50)
+    name: str = Field(min_length=1, max_length=80)
+    description: str = Field(default="", max_length=500)
+
+
 class InferenceModel(_InferenceModel):
     provider: InferenceProvider
     id: str = Field(min_length=1, max_length=300)
     reasoning_efforts: tuple[str, ...] = ()
     default_reasoning_effort: str | None = None
+    service_tiers: tuple[InferenceServiceTier, ...] = ()
+    default_service_tier: str | None = None
 
 
 __all__ = [
     "InferenceModel",
     "InferenceProvider",
     "InferenceSelection",
+    "InferenceServiceTier",
     "ResolvedInferencePlan",
 ]

--- a/src/opentulpa/inference/service.py
+++ b/src/opentulpa/inference/service.py
@@ -25,7 +25,12 @@ from opentulpa.inference.codex import (
     build_codex_model,
     credential_from_oauth_payload,
 )
-from opentulpa.inference.models import InferenceModel, InferenceProvider, InferenceSelection
+from opentulpa.inference.models import (
+    InferenceModel,
+    InferenceProvider,
+    InferenceSelection,
+    InferenceServiceTier,
+)
 from opentulpa.inference.store import DeviceLogin, InferenceCredentialStore
 from opentulpa.secrets.cipher import HostKeySecretCipher
 
@@ -69,9 +74,9 @@ class InferenceService:
         self._api_default_model = str(api_default_model or "").strip()
         self._api_reasoning_effort = str(api_reasoning_effort or "").strip() or None
         self._api_fallback_models = tuple(api_fallback_models)
-        self._models: OrderedDict[tuple[str, int, str, str | None, bool], ResolvedModel] = (
-            OrderedDict()
-        )
+        self._models: OrderedDict[
+            tuple[str, int, str, str | None, str | None, bool], ResolvedModel
+        ] = OrderedDict()
         self._catalogs: dict[tuple[str, int], tuple[datetime, tuple[InferenceModel, ...]]] = {}
         self._device_locks: dict[str, asyncio.Lock] = {}
 
@@ -132,13 +137,20 @@ class InferenceService:
                 raise ValueError("Codex model is not available for this account")
             if (
                 selection.reasoning_effort is not None
-                and selected.reasoning_efforts
                 and selection.reasoning_effort not in selected.reasoning_efforts
             ):
                 raise ValueError("reasoning effort is not supported by this Codex model")
+            service_tier_ids = {tier.id for tier in selected.service_tiers}
+            if (
+                selection.service_tier is not None
+                and selection.service_tier not in service_tier_ids
+            ):
+                raise ValueError("service tier is not supported by this Codex model")
             return selection
-        if selection.fallback_to_api:
-            selection = selection.model_copy(update={"fallback_to_api": False})
+        if selection.fallback_to_api or selection.service_tier is not None:
+            selection = selection.model_copy(
+                update={"fallback_to_api": False, "service_tier": None}
+            )
         return selection
 
     def resolve_model(self, tenant_id: str, selection: InferenceSelection) -> ResolvedModel:
@@ -152,6 +164,7 @@ class InferenceService:
             revision,
             selection.model,
             selection.reasoning_effort,
+            selection.service_tier,
             selection.fallback_to_api,
         )
         cached = self._models.get(key)
@@ -163,6 +176,7 @@ class InferenceService:
             model=build_codex_model(
                 model=selection.model,
                 reasoning_effort=selection.reasoning_effort,
+                service_tier=selection.service_tier,
                 token_provider=provider,
                 buffer_for_fallback=selection.fallback_to_api,
             ),
@@ -383,9 +397,18 @@ class InferenceService:
             if not model_id or visibility in {"hide", "hidden"}:
                 continue
             efforts = self._reasoning_efforts(raw)
-            default_effort = str(raw.get("default_reasoning_effort") or "").strip() or None
+            default_effort = (
+                str(
+                    raw.get("default_reasoning_level") or raw.get("default_reasoning_effort") or ""
+                ).strip()
+                or None
+            )
             if default_effort and efforts and default_effort not in efforts:
                 default_effort = None
+            service_tiers = self._service_tiers(raw)
+            default_service_tier = str(raw.get("default_service_tier") or "").strip() or None
+            if default_service_tier not in {tier.id for tier in service_tiers}:
+                default_service_tier = None
             try:
                 priority = int(raw.get("priority", 10_000))
             except (TypeError, ValueError):
@@ -398,6 +421,8 @@ class InferenceService:
                         id=model_id,
                         reasoning_efforts=efforts,
                         default_reasoning_effort=default_effort,
+                        service_tiers=service_tiers,
+                        default_service_tier=default_service_tier,
                     ),
                 )
             )
@@ -448,7 +473,12 @@ class InferenceService:
 
     @staticmethod
     def _reasoning_efforts(raw: dict[str, Any]) -> tuple[str, ...]:
-        value = raw.get("supported_reasoning_efforts") or raw.get("reasoning_efforts") or []
+        value = (
+            raw.get("supported_reasoning_levels")
+            or raw.get("supported_reasoning_efforts")
+            or raw.get("reasoning_efforts")
+            or []
+        )
         efforts: list[str] = []
         if isinstance(value, dict):
             value = list(value)
@@ -461,6 +491,31 @@ class InferenceService:
                 if effort and effort not in efforts:
                     efforts.append(effort)
         return tuple(efforts)
+
+    @staticmethod
+    def _service_tiers(raw: dict[str, Any]) -> tuple[InferenceServiceTier, ...]:
+        value = raw.get("service_tiers") or []
+        if not isinstance(value, list | tuple):
+            return ()
+        tiers: list[InferenceServiceTier] = []
+        seen: set[str] = set()
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            tier_id = str(item.get("id") or "").strip()
+            name = str(item.get("name") or tier_id).strip()
+            description = str(item.get("description") or "").strip()
+            if not tier_id or not name or tier_id in seen:
+                continue
+            tiers.append(
+                InferenceServiceTier(
+                    id=tier_id,
+                    name=name,
+                    description=description,
+                )
+            )
+            seen.add(tier_id)
+        return tuple(tiers)
 
     @staticmethod
     def _replace_login(login: DeviceLogin, **changes: Any) -> DeviceLogin:

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -86,9 +86,111 @@ def test_resolved_plan_digest_is_stable_and_revision_bound() -> None:
     first = ResolvedInferencePlan.resolve(selection, preference_revision=2)
     same = ResolvedInferencePlan.resolve(selection, preference_revision=2)
     changed = ResolvedInferencePlan.resolve(selection, preference_revision=3)
+    fast = ResolvedInferencePlan.resolve(
+        selection.model_copy(update={"service_tier": "priority"}),
+        preference_revision=2,
+    )
 
     assert first == same
     assert first.digest != changed.digest
+    assert first.digest != fast.digest
+
+
+@pytest.mark.asyncio
+async def test_codex_catalog_maps_reasoning_levels_and_service_tiers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _inference(tmp_path)
+    service._store.save_credential(  # noqa: SLF001
+        "tenant-1",
+        CodexCredential(
+            access_token="access-secret",
+            refresh_token="refresh-secret",
+            id_token=None,
+            account_id="account-1",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+    )
+
+    async def request(_: Any) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "slug": "gpt-5.6-sol",
+                        "visibility": "list",
+                        "priority": 1,
+                        "supported_reasoning_levels": [
+                            {"effort": "low"},
+                            {"effort": "medium"},
+                            {"effort": "high"},
+                            {"effort": "xhigh"},
+                            {"effort": "max"},
+                            {"effort": "ultra"},
+                        ],
+                        "default_reasoning_level": "low",
+                        "service_tiers": [
+                            {
+                                "id": "priority",
+                                "name": "Fast",
+                                "description": "1.5x speed, increased usage",
+                            }
+                        ],
+                        "default_service_tier": None,
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(service, "_request_codex_models", request)
+    models = await service.models("tenant-1", "codex")
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.reasoning_efforts == ("low", "medium", "high", "xhigh", "max", "ultra")
+    assert model.default_reasoning_effort == "low"
+    assert [tier.model_dump() for tier in model.service_tiers] == [
+        {
+            "id": "priority",
+            "name": "Fast",
+            "description": "1.5x speed, increased usage",
+        }
+    ]
+    assert model.default_service_tier is None
+    selected = await service.validate_selection(
+        "tenant-1",
+        InferenceSelection(
+            provider="codex",
+            model=model.id,
+            reasoning_effort="ultra",
+            service_tier="priority",
+        ),
+    )
+    assert selected.reasoning_effort == "ultra"
+    assert selected.service_tier == "priority"
+    with pytest.raises(ValueError, match="service tier"):
+        await service.validate_selection(
+            "tenant-1",
+            selected.model_copy(update={"service_tier": "unsupported"}),
+        )
+    with pytest.raises(ValueError, match="reasoning effort"):
+        await service.validate_selection(
+            "tenant-1",
+            selected.model_copy(update={"reasoning_effort": "unsupported"}),
+        )
+    sanitized_api = await service.validate_selection(
+        "tenant-1",
+        InferenceSelection(
+            provider="api",
+            model="test-model",
+            service_tier="priority",
+            fallback_to_api=True,
+        ),
+    )
+    assert sanitized_api.service_tier is None
+    assert sanitized_api.fallback_to_api is False
 
 
 def test_codex_credentials_are_encrypted_and_refresh_rotation_is_atomic(tmp_path: Path) -> None:
@@ -331,6 +433,7 @@ def test_pinned_langchain_codex_adapter_contract(tmp_path: Path) -> None:
         model="gpt-test",
         reasoning_effort="high",
         token_provider=provider,
+        service_tier="priority",
     )
     signature = inspect.signature(type(model))
 
@@ -342,11 +445,13 @@ def test_pinned_langchain_codex_adapter_contract(tmp_path: Path) -> None:
     assert model.originator == "opentulpa"
     assert model.include == ["reasoning.encrypted_content"]
     assert model.reasoning == {"effort": "high", "summary": "auto"}
+    assert model.service_tier == "priority"
     payload = model._get_request_payload(  # noqa: SLF001
         [SystemMessage(content="system instruction"), HumanMessage(content="hello")],
         _codex_headers={},
     )
     assert payload["instructions"] == "system instruction"
+    assert payload["service_tier"] == "priority"
     assert all(item.get("role") != "system" for item in payload["input"])
     bound = model.bind_tools(
         [
@@ -461,7 +566,7 @@ async def test_codex_401_refreshes_once_and_transient_fallback_stops_after_activ
     assert is_transient(UnauthorizedError()) is False
 
 
-def test_graph_cache_separates_provider_model_effort_and_is_bounded(tmp_path: Path) -> None:
+def test_graph_cache_separates_provider_model_effort_tier_and_is_bounded(tmp_path: Path) -> None:
     service = DeepAgentService(
         api_key="api-secret",
         base_url="https://openrouter.ai/api/v1",
@@ -487,10 +592,27 @@ def test_graph_cache_separates_provider_model_effort_and_is_bounded(tmp_path: Pa
             InferenceSelection(provider="api", model="two", reasoning_effort="high"),
             preference_revision=3,
         ),
+        ResolvedInferencePlan.resolve(
+            InferenceSelection(
+                provider="codex",
+                model="gpt-test",
+                reasoning_effort="high",
+            ),
+            preference_revision=4,
+        ),
+        ResolvedInferencePlan.resolve(
+            InferenceSelection(
+                provider="codex",
+                model="gpt-test",
+                reasoning_effort="high",
+                service_tier="priority",
+            ),
+            preference_revision=5,
+        ),
     )
 
     keys = {service._inference_cache_key("tenant-1", plan) for plan in plans}  # noqa: SLF001
-    assert len(keys) == 3
+    assert len(keys) == 5
     for index in range(10):
         service._cache_spec_graph((index,), object())  # noqa: SLF001
     assert list(service._spec_graphs) == [(index,) for index in range(2, 10)]  # noqa: SLF001

--- a/tests/test_native_tui_pty.py
+++ b/tests/test_native_tui_pty.py
@@ -56,6 +56,7 @@ class _Handler(BaseHTTPRequestHandler):
                         "provider": "api",
                         "model": "moonshotai/kimi-k3",
                         "reasoning_effort": None,
+                        "service_tier": None,
                         "fallback_to_api": False,
                     },
                     "codex": {
@@ -76,6 +77,8 @@ class _Handler(BaseHTTPRequestHandler):
                             "id": "moonshotai/kimi-k3",
                             "reasoning_efforts": ["low", "medium", "high"],
                             "default_reasoning_effort": "low",
+                            "service_tiers": [],
+                            "default_service_tier": None,
                         }
                     ],
                 }
@@ -93,6 +96,7 @@ class _Handler(BaseHTTPRequestHandler):
                         "provider": "api",
                         "model": "moonshotai/kimi-k3",
                         "reasoning_effort": None,
+                        "service_tier": None,
                         "fallback_to_api": False,
                     },
                 }

--- a/tests/test_v2_inference_routes.py
+++ b/tests/test_v2_inference_routes.py
@@ -7,7 +7,11 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from opentulpa.api.routes.v2_inference import register_v2_inference_routes
-from opentulpa.inference.models import InferenceModel, InferenceSelection
+from opentulpa.inference.models import (
+    InferenceModel,
+    InferenceSelection,
+    InferenceServiceTier,
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,7 @@ class _Inference:
                 "provider": "api",
                 "model": "kimi",
                 "reasoning_effort": "low",
+                "service_tier": None,
                 "fallback_to_api": False,
             },
             "codex": {"connected": self.connected, "credential_revision": 1},
@@ -41,6 +46,15 @@ class _Inference:
                 provider=provider,
                 id="gpt-test" if provider == "codex" else "kimi",
                 reasoning_efforts=("low", "high"),
+                service_tiers=(
+                    InferenceServiceTier(
+                        id="priority",
+                        name="Fast",
+                        description="1.5x speed, increased usage",
+                    ),
+                )
+                if provider == "codex"
+                else (),
             ),
         )
         return tuple(model for model in models if query.casefold() in model.id.casefold())
@@ -151,6 +165,7 @@ def test_inference_routes_use_authenticated_tenant_and_revisioned_thread_selecti
                 "provider": "codex",
                 "model": "gpt-test",
                 "reasoning_effort": "high",
+                "service_tier": "priority",
                 "fallback_to_api": False,
             },
         },
@@ -161,6 +176,7 @@ def test_inference_routes_use_authenticated_tenant_and_revisioned_thread_selecti
     assert updated.status_code == 200
     assert updated.json()["revision"] == 1
     assert threads.selection is not None and threads.selection.provider == "codex"
+    assert threads.selection.service_tier == "priority"
     assert (
         client.get(
             "/v2/agent/threads/thread-1/inference",


### PR DESCRIPTION
## Summary
- map the live Codex reasoning-level catalog into per-thread inference choices
- add model-aware Normal/Fast service-tier selection via `/speed`
- pin service tier in run plans, graph caches, traces, and Codex requests

## Verification
- `uv run pytest -q` (918 passed)
- `uv run mypy src/opentulpa`
- focused Ruff checks
- `bun run typecheck`
- `bun test` (30 passed)
- `bun run build --all`