### PR TITLE
Simplify README and clarify local and hosted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,264 +1,18 @@
 <p align="center">
-  <img src="docs/assets/opentulpa-logo.png" alt="OpenTulpa" width="180"/>
+  <picture>
+    <source media="(max-width: 600px)" srcset="./assets/readme/hero-mobile.svg">
+    <img src="./assets/readme/hero.svg" width="100%" alt="OpenTulpa, the self-evolving agent">
+  </picture>
 </p>
 
-<h1 align="center">OpenTulpa</h1>
+No static agent harness can be great at every job. OpenTulpa aims to solve this by
+evolving its own code for your specific use cases.
 
-<p align="center">
-  <strong>A small, self-hosted Deep Agents operator that can inspect, edit, test, and safely replace its own code.</strong><br/>
-  One Agent API, explicit tools, durable triggers, and a fixed rollback boundary.
-</p>
+## Get started
 
-## What It Is
+OpenTulpa needs Git, curl, and a model API key. The installer handles the rest.
 
-OpenTulpa is one persistent agent with multiple replaceable ways to reach it. The local
-terminal client, Telegram worker, schedules, intake, browser automation, and future
-integrations all submit work through the same tenant-scoped Agent API. They do not own
-their own model loops or conversation stores.
-
-[`deepagents==0.6.12`](https://github.com/langchain-ai/deepagents) owns the agent loop,
-planning, delegation, checkpointing, summarization, memory, skills, and filesystem
-middleware. OpenTulpa supplies the smaller product and safety boundary around it:
-
-- authenticated tenant and actor identity;
-- a generated, typed tool contract with persisted approvals;
-- deterministic intake, scheduling, delivery, and external side effects;
-- tenant memory, skills, and persistent workspaces;
-- capability workers that use the universal Agent API;
-- an immutable bootstrap that evaluates, activates, and rolls back source releases.
-
-There is no custom LangGraph harness, model loop, tool gateway, prompt compactor, or
-legacy runtime facade.
-
-## Fixed And Mutable
-
-OpenTulpa keeps deployment machinery outside the application image it replaces.
-
-| Fixed host boundary | Mutable application runtime |
-|---|---|
-| Setup, owner authentication, encrypted configuration, process health, logs, proxy, recovery | Deep Agent service, prompts, tools, and approval policy |
-| Source-worktree sandbox limits and trusted evaluation commands | Agent API, product services, integrations, and interfaces |
-| Source sandbox, fixed evaluator, activation health, and rollback | Capability workers, manifests, local TUI, tests, and documentation |
-| Host credentials and deployment authority | Any other normal, secret-free repository source path |
-
-The owner can ask the main OpenTulpa agent to change any source. That agent edits a
-detached Git worktree through an unprivileged sandbox, never the serving checkout. It can run
-tests and experiments over multiple chat turns, inspect its own traces, and ask the owner
-for feedback. `source_release` creates one persisted chat approval; after approval the
-fixed supervisor commits and evaluates the exact bytes, binds a release artifact, and
-queues health-checked activation. Railway and Docker use a persistent source overlay
-inside the stable host; managed VM mode builds a rootless OCI image. No second model or
-host-shell approval participates.
-
-The dependency lock and trusted image recipe remain fixed during this path. A dependency
-change requires an administrator to rebuild the immutable runtime base. Host recovery
-commands remain available if both the mutable release and its normal approval interface
-are unavailable.
-
-The chat approval is a policy enforced by the currently trusted application release. It
-is not cryptographic protection against an already malicious release: that release holds
-a scoped evolution credential so it can drive the source workflow. The stable bootstrap
-proves source lineage, fixed checks, image identity, staged health, and rollback; it does
-not independently prove human intent. Requiring protection from a hostile active release
-would need a second authority outside the application, which this deliberately simple
-one-approval design does not include.
-
-This gives instances room to specialize without silently fragmenting the project. An
-instance keeps a Git lineage, and an evaluated candidate can be exported as a sanitized,
-digest-checked patch for normal upstream review.
-
-## Interfaces And Capabilities
-
-FastAPI exposes the headless public API. The bundled `opentulpa` command opens a native
-OpenTUI client with streamed Markdown, a visible activity spinner, compact expandable
-tool calls, drag-and-drop attachments, server-backed sessions, and clickable
-**Approve**, **Edit**, and **Reject** controls. Telegram uses the same Agent API with a
-scoped credential. Use `ctrl+p` or `/sessions` to reopen the same durable Deep Agents
-threads from another client. Type `/` in the composer to search and select commands.
-While a turn is running, `Esc` stops it, `Enter` queues the next message, and
-`Shift+Enter` steers the active turn. When idle, `Shift+Enter` inserts a newline.
-
-The API key remains the zero-friction default. Inside any owner conversation, `/model`,
-`/reasoning`, and `/speed` select that thread's next-run inference settings without
-restarting OpenTulpa.
-`/login codex` optionally connects a ChatGPT Codex subscription through device login;
-the rotating OAuth credential is encrypted on the server and never shared with an
-existing Codex CLI login. Codex has no implicit cross-provider fallback. Use
-`/model codex MODEL fallback` only when you explicitly want transient Codex failures to
-fall back to the configured Kimi-to-GLM API chain.
-
-For example, from the terminal client you can write:
-
-> Enable Telegram for this OpenTulpa. Here is my BotFather token: `<token>`.
-
-Recognized credentials are encrypted before the message reaches a checkpoint; the
-model sees an opaque `secret://` handle. OpenTulpa can test the bundled Telegram
-capability, ask for activation approval, and start its worker. Pair the first Telegram
-account with `/start <code>`; by default the one-time code is the last eight characters
-of the bot token. A later request to change Telegram behavior becomes a source
-candidate and managed release rather than an in-place edit.
-
-Other credentials work the same way. Paste `SERVICE_API_KEY=<value>` in an authenticated
-owner chat, or use `<secret name="SERVICE_CREDENTIAL">...</secret>` for multiline
-material. OpenTulpa persists only the encrypted value and an opaque handle. For example,
-paste `COMPOSIO_API_KEY=<value>`, then ask it to connect GitHub; it hot-loads the key and
-returns the tenant-owned OAuth link without a restart.
-
-For repository contributions, ask OpenTulpa to open a GitHub URL. It creates an isolated
-checkout for that conversation, edits complete files with Deep Agents' native filesystem
-and shell tools, runs tests, and commits on a branch. `repository_publish_pr` approves only
-the repository, branch, exact commit SHA, and PR metadata; the trusted publisher pushes the
-existing commit, so source files never pass through model output or integration arguments.
-It works without sandbox credentials: local machines use the bundled OCI boundary and compatible
-Linux hosts such as Railway use a serialized unprivileged process sandbox. An active Composio
-GitHub connection publishes the exact verified commit without exposing OAuth to the sandbox. Paste
-`GITHUB_TOKEN=<fine-grained-token>` only for private checkout or unsupported commit shapes. Daytona
-remains an optional hosted provider for stronger isolation or workspaces that outlive the volume.
-`/repo` opens or inspects a workspace in the TUI, and `/repos` lists them.
-
-Sandboxing does not disable integrations. The same owner run can edit or test in a repository or
-source sandbox and call Composio tools normally; OAuth and the Composio API key stay in the trusted
-host and are never mounted into the sandbox.
-
-In managed OCI mode the stable bootstrap derives the active release image and runs that
-worker rootless with only private capability `/state`; product `/workspace`, source,
-databases, host credentials, and the container socket are never mounted. Generation
-handover stops the old poller first and restores it if the new generation fails. Direct
-development mode keeps reviewed subprocess workers. The bundled Docker and Railway host
-can replace and roll back its Deep Agents child without a container socket.
-
-The stable setup host imports `TELEGRAM_BOT_TOKEN` into the encrypted capability vault
-and starts only the long-poll worker. Explicit direct `server` mode retains the webhook
-adapter for development and blocks dynamic Telegram so two consumers cannot use one
-bot.
-
-Browser automation, Composio, document parsers, and Crawl4AI are optional adapters,
-not agent-runtime dependencies. The core installs and starts without them:
-
-```bash
-uv sync --no-dev                         # lean core and API
-uv sync --no-dev --extra browser         # Browser Use Cloud SDK and Playwright CDP client
-uv sync --no-dev --extra integrations    # Composio
-uv sync --no-dev --extra documents       # PDF, workbook, and encoding helpers
-uv sync --no-dev --extra research        # Crawl4AI extraction
-uv sync --no-dev --extra hosted-sandbox  # optional Daytona provider
-uv sync --no-dev --extra bundled         # all optional bundled adapters
-```
-
-`start.sh` keeps the lean core by default. Set `OPENTULPA_EXTRAS=bundled` (or a
-comma-separated subset such as `integrations,documents`) to retain those adapters
-across installs and bake the same extras into a managed runtime image.
-
-With `BROWSER_USE_API_KEY`, explicit browser tools use a tenant-scoped Browser Use
-Cloud session. The Playwright package is only the CDP control client; Chromium and its
-target network run in Browser Use Cloud isolation. OpenTulpa has no host-browser
-fallback. It requires explicit destination domains and rejects direct private or
-link-local targets, but it cannot DNS-pin Chromium inside the vendor environment.
-`content_fetch` has a bounded built-in HTML
-extractor and uses Crawl4AI only when the research extra is present.
-When the configured model endpoint is OpenRouter, `web_search` uses OpenRouter's
-model-agnostic web plugin with the same API key and returns only grounded URL-cited
-results; no separate search-provider key is required. `EXA_API_KEY` remains an
-optional direct-provider override.
-
-## Runs, Notifications, And Approvals
-
-All owner interfaces use the same V2 surfaces:
-
-| Endpoint | Purpose |
-|---|---|
-| `POST /v2/agent/threads` | Create a durable server-backed conversation |
-| `GET /v2/agent/threads` | List tenant-owned conversations |
-| `GET /v2/agent/threads/{thread_id}/timeline` | Replay messages, tools, artifacts, and approvals |
-| `PATCH /v2/agent/threads/{thread_id}` | Rename or archive a conversation |
-| `GET/PATCH /v2/agent/threads/{thread_id}/inference` | Read or change that conversation's model |
-| `/v2/inference` | Discover models and manage optional Codex device authentication |
-| `POST /v2/agent/runs` | Start an owner run and stream normalized SSE events |
-| `GET /v2/agent/runs/{run_id}` | Read tenant-scoped status and pending approvals |
-| `POST /v2/agent/runs/{run_id}/resume` | Approve, edit, or reject an interrupted run |
-| `GET /v2/notifications` | Long-poll durable background and approval notifications |
-| `POST /v2/notifications/{id}/ack` | Acknowledge one notification for this interface |
-| `/v2/agent-specs` | Revisioned model, tools, memory, workspace, and instruction policy |
-| `/v2/trigger-specs` | Revisioned time, interval, or authenticated-event triggers |
-| `/v2/schedules` | Simple reminder and agent-job projection over trigger specs |
-| `/v2/capabilities` | Test and activate release-bundled capability revisions |
-| `/v2/repositories/workspaces` | Create, resume, inspect, stop, and publish isolated Git workspaces |
-| `/v2/evolution` | Inspect release lineage and export evaluated contribution patches |
-
-Run streaming is normalized to `run.started`, `message.delta`, `tool.started`,
-`tool.completed`, `approval.required`, `artifact.ready`, `run.completed`, and
-`run.failed`. Each event has a run ID, monotonic sequence, and timestamp. The durable
-notification stream carries schedule results, pending approvals, candidate results,
-activation failures, and rollback outcomes back to the TUI and Telegram after restarts.
-
-Tool arguments never contain tenant IDs, credentials, filesystem roots, or ownership
-identifiers. The registry in `opentulpa.tooling` generates LangChain tools, approval
-policy, audit metadata, JSON Schema, and the committed
-[tool contract](docs/tool-contract.md).
-
-## AgentSpecs And Triggers
-
-An `AgentSpec` is an immutable behavioral revision: model alias, instructions, tool
-allowlist, memory scope, workspace scope, delegation, and runtime budgets. Secrets
-remain behind explicit tools and capability manifests rather than entering an agent
-configuration. Owner, routine, and intake are seed specs, not separate runtimes.
-
-A `TriggerSpec` selects an exact `AgentSpec` revision and adds a source, instruction,
-and delivery rule. Sources can be one-off time, cron with an IANA timezone, interval,
-or an authenticated event. APScheduler and the durable dispatcher only submit runs;
-they never auto-approve an interrupted action.
-
-The simpler `/v2/schedules` and schedule tools project:
-
-```text
-At | Cron -> Reminder | AgentJob -> routine AgentSpec -> owner notification
-```
-
-Use full AgentSpec and TriggerSpec revisions when a background process needs another
-model, a narrower tool set, isolated memory, different instructions, or an external
-event source.
-
-## Self-Improvement
-
-On Docker, Railway, and managed installations, the owner agent controls one isolated
-source checkout backed by persistent Git lineage:
-
-- `source_shell` creates or resumes it and can inspect, edit, test, and experiment with
-  any OpenTulpa source using ordinary shell commands;
-- `source_status` shows the current checkout and bounded diff without changing it;
-- `trace_list` and `trace_get` expose the agent's own redacted durable execution traces;
-- `source_release` requests one native chat approval, runs fixed checks, builds the exact
-  source commit, and queues safe activation;
-- `source_rollback` restores the previous healthy release with owner approval.
-
-The source shell cannot see production data, credentials, the serving checkout,
-bootstrap state, deployment controls, or a container socket. It is unprivileged,
-resource-bounded, and has outbound network access without gaining access to host
-secrets. The agent may change core runtime, API, integrations, interfaces, tools,
-prompts, schedules, or add new code. The stable bootstrap and its release recipe remain
-outside the mutable release.
-
-Evaluation and release building are bound to the source commit, dependency lock hash,
-evaluator fingerprint, and artifact digest. The candidate's Dockerfile is not used.
-Dependency-lock changes still require an administrator-built runtime base.
-
-Failures remain in the lineage with a sanitized cause. The originating owner thread
-and notification stream receive completion or failure. After a successful cutover,
-the new release uses the same persistent checkpoints, memory, skills, notification
-store, and workspace, so it can explain what happened. If the new release fails during
-activation or probation, the immutable bootstrap automatically restores the previous
-release and reports the rollback. Only release-coupled capability worker state is
-restored; messages, checkpoints, files, memories, bookings, schedules, and other
-product data written during probation are preserved. Self-updates therefore must not
-perform irreversible product-data migrations.
-
-Rollback restores code, the serving process, and release-coupled capability state. It
-cannot retract an external message, purchase, authorization change, or other provider
-effect already emitted while a candidate was serving probation traffic. Changes near
-external effects must be rehearsed with fake sinks and continue to rely on tool approval
-and idempotency; image rollback is not a transaction over the outside world.
-
-## Start
+### Run locally
 
 ```bash
 git clone https://github.com/kvyb/opentulpa.git
@@ -267,110 +21,74 @@ cd opentulpa
 opentulpa
 ```
 
-Choose **Run here**, enter the model API key once, and the CLI starts the private server
-and opens the native TUI. A source checkout builds and caches the platform client on the
-first run; CI also produces macOS and Linux platform archives. Later, just run
-`opentulpa` again.
+Choose **Run here** and enter your model API key. OpenTulpa starts a private server on
+your computer and opens the terminal interface.
 
-In the TUI, use `/model`, `/reasoning`, `/speed`, or `/login codex`. Remote
-connections change the remote thread; no Codex environment variable, callback server,
-or extra process is used.
+### Use a hosted server
 
-```bash
-# Remote server
-opentulpa server --public-url https://tulpa.example
+OpenTulpa is self-hosted. Run the server on Railway, with Docker, or on your own VM.
 
-# Local machine
-opentulpa connect https://tulpa.example
-```
+**Railway:** deploy this repository, attach a persistent volume at
+`/app/opentulpa_data`, and set
+`OPENTULPA_DATA_ROOT=/app/opentulpa_data`. The included
+[Railway config](railway.toml) supplies the start command and health check.
 
-Paste the one-time pairing code printed by the server. See
-[Deployment](docs/DEPLOYMENT.md) for Docker, Railway, managed self-improvement, and
-non-interactive configuration.
-
-### Managed self-improving mode
-
-Set at least:
-
-```env
-OPENAI_COMPATIBLE_API_KEY=...
-OPENTULPA_OWNER_TOKEN=...
-EVOLUTION_ENABLED=true
-OPENTULPA_RECOVERY_TOKEN=<32-or-more-random-characters>
-OPENTULPA_INGRESS_TOKEN=<32-or-more-random-characters>
-OPENTULPA_RELEASE_BASE_IMAGE=opentulpa-runtime-base:0.1.0
-OPENTULPA_RELEASE_EGRESS_NETWORK=opentulpa-release-egress
-OPENTULPA_RELEASE_WORKSPACE=/absolute/persistent/opentulpa-release-data
-```
-
-The egress network must be created and restricted by the administrator. Then:
+**Docker:**
 
 ```bash
-./start.sh install managed   # builds runtime, evaluator, and tenant sandbox images
-./start.sh doctor managed    # checks Git, OCI, images, network, and writable state
-./start.sh run managed       # starts only, without reinstalling
-# or: ./start.sh managed     # install, then start
+git clone https://github.com/kvyb/opentulpa.git
+cd opentulpa
+cp .env.example .env
+docker compose up --build
 ```
 
-The immutable gateway remains on the public host/port and proxies to the active
-release. The release gets a persistent `/workspace`; it never receives the source
-checkout, bootstrap database, `.env`, container socket, or sandbox image authority.
-Tenant commands cross a private, lease-bound endpoint and the stable host derives the
-tenant root and launches the exact locally resolved reviewed image. See
-[Deployment](docs/DEPLOYMENT.md) for the complete host contract.
+Keep the `opentulpa_data` volume. It stores conversations, settings, and the agent's
+release history.
 
-Use `opentulpa-recovery status`, `rollback`, `restart`, or `safe-mode` from the host if
-the mutable release or its normal approval interface is unavailable. `/recovery` is
-reserved and always returns `404`; recovery credentials are never accepted from a
-browser control page.
-
-Health checks are `/healthz` and `/agent/healthz` in host, direct, and managed modes.
-
-## Persistence And Migration
-
-The default is one active process with SQLite:
-
-- fresh Deep Agents checkpoints and persisted approval interrupts;
-- a tenant-namespaced store for `/memories/` and `/skills/`;
-- persistent tenant `/workspace` directories;
-- separate product stores for runs, notifications, jobs, triggers, intake, files,
-  knowledge, profiles, connections, secrets, capabilities, and evolution lineage.
-
-Multiple active replicas require shared saver/store and product persistence. Historical
-legacy chat checkpoints are intentionally not imported.
-
-Dry-run legacy data migration first:
+Once the server is running, copy the one-time pairing code from its logs. Install the
+terminal client on your computer using the local steps above, then connect:
 
 ```bash
-uv run --extra migration opentulpa-migrate-deepagents \
-  --data-root /path/to/copied-data --dry-run
+opentulpa connect https://your-opentulpa.example
 ```
 
-The migration preserves product records, translates valid routines to AgentSpec and
-TriggerSpec-backed schedules, translates setup sessions to drafts, exports tenant
-memories, and converts user-authored skills. Invalid legacy rows are reported and
-disabled rather than guessed. Cutover verification fails if a preserved product
-database is absent, which prevents a wrong `--data-root` from looking successful.
-`--allow-missing` is reserved for a verified new installation with no legacy data.
-It also transactionally rebases persisted uploaded-file paths to the selected data
-root. Destination content conflicts block cutover without disabling their legacy
-source rows, so they can be resolved and the migration safely rerun.
+Paste the pairing code when prompted. See the
+[deployment guide](docs/DEPLOYMENT.md) for domains, environment variables, and managed
+VM setup.
 
-## Development
+## Details
 
-```bash
-uv sync --extra dev
-uv run pytest -q
-uv run ruff check .
-uv run mypy src
-```
+### Capabilities
 
-| Document | Contents |
-|---|---|
-| [Architecture](docs/ARCHITECTURE.md) | Fixed/mutable boundary, universal protocol, and flows |
-| [Tool Contract](docs/tool-contract.md) | Complete model-visible tool surface |
-| [Deployment](docs/DEPLOYMENT.md) | Direct and managed host setup |
-| [E2E Testing](docs/E2E_TESTING.md) | Migration, interface, improvement, and rollback rehearsal |
-| [Prompt Cookbook](docs/CHAT_COOKBOOK.md) | Accurate requests for capabilities, triggers, and evolution |
+- The terminal, Telegram, schedules, and Agent API all talk to the same agent.
+- Conversations keep their messages, memory, skills, files, and workspaces.
+- Repository work runs in isolated checkouts. OpenTulpa can edit code, run tests, commit
+  the result, and publish that exact commit as a pull request.
+- Optional adapters add browser access, web search, Composio integrations, document
+  tools, and hosted sandboxes.
+- OpenTulpa works with OpenAI-compatible model providers and supports ChatGPT Codex
+  device login.
+
+### How self-evolution works
+
+OpenTulpa can inspect its own source code and redacted execution traces. When a change
+could help with your work:
+
+1. The agent makes the change in an isolated Git worktree.
+2. The fixed host tests the exact candidate commit.
+3. The host starts the candidate and checks that it stays healthy.
+4. If it fails, the host restores the previous healthy release.
+
+The agent can change its runtime, prompts, tools, integrations, and interfaces. It
+cannot access host credentials or release controls. The fixed host remains responsible
+for evaluation, activation, and rollback.
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md)
+- [Deployment](docs/DEPLOYMENT.md)
+- [Tool contract](docs/tool-contract.md)
+- [E2E testing](docs/E2E_TESTING.md)
+- [Prompt cookbook](docs/CHAT_COOKBOOK.md)
 
 MIT licensed.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 <p align="center">
-  <img src="docs/assets/opentulpa-logo.png" alt="OpenTulpa" width="180"/>
+  <img src="docs/assets/opentulpa-hero.svg" alt="OpenTulpa — self-hosted agent operator" width="100%"/>
 </p>
-
-<h1 align="center">OpenTulpa</h1>
 
 <p align="center">
   <strong>A small, self-hosted Deep Agents operator that can inspect, edit, test, and safely replace its own code.</strong><br/>
   One Agent API, explicit tools, durable triggers, and a fixed rollback boundary.
 </p>
 
-## What It Is
+<p align="center">
+  <code>TUI</code> &middot; <code>Telegram</code> &middot; <code>Triggers</code> &rarr; one tenant-scoped <strong>Agent API</strong>
+</p>
+
+## What It Does
 
 OpenTulpa is one persistent agent with multiple replaceable ways to reach it. The local
 terminal client, Telegram worker, schedules, intake, browser automation, and future
@@ -29,6 +31,10 @@ middleware. OpenTulpa supplies the smaller product and safety boundary around it
 
 There is no custom LangGraph harness, model loop, tool gateway, prompt compactor, or
 legacy runtime facade.
+
+<p align="center">
+  <img src="docs/assets/opentulpa-conversation-insta.jpg" alt="An OpenTulpa owner conversation" width="720"/>
+</p>
 
 ## Fixed And Mutable
 

--- a/assets/readme/hero-mobile.svg
+++ b/assets/readme/hero-mobile.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="720" height="280" viewBox="0 0 720 280"
+     role="img" aria-labelledby="title desc">
+  <title id="title">OpenTulpa, the self-evolving agent</title>
+  <desc id="desc">OpenTulpa with a ghost emoji and the phrase The self-evolving agent.</desc>
+
+  <rect width="720" height="280" rx="24" fill="#080A0D"/>
+  <rect x=".5" y=".5" width="719" height="279" rx="23.5" fill="none" stroke="#292E35"/>
+
+  <g text-anchor="middle">
+    <text x="325" y="135"
+          fill="#F6F4EE" font-size="72" font-weight="800" letter-spacing="-2"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+      OpenTulpa
+    </text>
+    <text x="555" y="135"
+          font-size="62"
+          font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif">👻</text>
+    <text x="360" y="191"
+          fill="#C9FA67" font-size="30" font-weight="600" letter-spacing=".2"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+      The self-evolving agent
+    </text>
+  </g>
+</svg>

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="240" viewBox="0 0 1200 240"
+     role="img" aria-labelledby="title desc">
+  <title id="title">OpenTulpa, the self-evolving agent</title>
+  <desc id="desc">OpenTulpa with a ghost emoji and the phrase The self-evolving agent.</desc>
+
+  <rect width="1200" height="240" rx="24" fill="#080A0D"/>
+  <rect x=".5" y=".5" width="1199" height="239" rx="23.5" fill="none" stroke="#292E35"/>
+
+  <g text-anchor="middle">
+    <text x="555" y="116"
+          fill="#F6F4EE" font-size="78" font-weight="800" letter-spacing="-2"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+      OpenTulpa
+    </text>
+    <text x="805" y="116"
+          font-size="68"
+          font-family="Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif">👻</text>
+    <text x="600" y="169"
+          fill="#C9FA67" font-size="29" font-weight="600" letter-spacing=".2"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+      The self-evolving agent
+    </text>
+  </g>
+</svg>

--- a/docs/assets/opentulpa-hero.svg
+++ b/docs/assets/opentulpa-hero.svg
@@ -1,86 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-label="OpenTulpa hero">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0d1117"/>
-      <stop offset="0.55" stop-color="#101826"/>
-      <stop offset="1" stop-color="#13231f"/>
-    </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#58e6c9"/>
-      <stop offset="1" stop-color="#6aa9ff"/>
-    </linearGradient>
-    <radialGradient id="glow" cx="0.78" cy="0.3" r="0.6">
-      <stop offset="0" stop-color="#58e6c9" stop-opacity="0.16"/>
-      <stop offset="1" stop-color="#58e6c9" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="title desc">
+  <title id="title">OpenTulpa</title>
+  <desc id="desc">An original ASCII ghost mascot floats beside the OpenTulpa name and a terminal transcript showing inspect, edit, test, and owner-approved release.</desc>
 
-  <rect width="1200" height="360" rx="18" fill="url(#bg)"/>
-  <rect width="1200" height="360" rx="18" fill="url(#glow)"/>
-  <rect x="1" y="1" width="1198" height="358" rx="17" fill="none" stroke="#ffffff" stroke-opacity="0.08"/>
+  <rect width="1200" height="400" fill="#080b0a"/>
+  <path d="M0 36H1200" stroke="#1d2822" stroke-width="2"/>
 
-  <!-- Title -->
-  <text x="64" y="112" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="56" font-weight="700" fill="#f2f5f7" letter-spacing="0.5">OpenTulpa</text>
-  <rect x="64" y="132" width="300" height="4" rx="2" fill="url(#accent)"/>
+  <!-- Original terminal ghost: the spirit living in the owner's machine. -->
+  <g id="ghost" transform="translate(74 52)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="29" font-weight="700">
+    <text x="0" y="30" fill="#34483d">01</text>
+    <text x="0" y="72" fill="#34483d">02</text>
+    <text x="0" y="114" fill="#34483d">03</text>
+    <text x="0" y="156" fill="#34483d">04</text>
+    <text x="0" y="198" fill="#34483d">05</text>
+    <text x="0" y="240" fill="#34483d">06</text>
 
-  <!-- Tagline -->
-  <text x="64" y="172" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="20" fill="#aab4bf">A small, self-hosted agent operator that can inspect, edit,</text>
-  <text x="64" y="198" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="20" fill="#aab4bf">test, and safely replace its own code.</text>
-
-  <!-- Chips -->
-  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="15" font-weight="600">
-    <rect x="64" y="228" width="132" height="34" rx="17" fill="#58e6c9" fill-opacity="0.10" stroke="#58e6c9" stroke-opacity="0.5"/>
-    <text x="130" y="250" text-anchor="middle" fill="#58e6c9">typed tools</text>
-    <rect x="210" y="228" width="158" height="34" rx="17" fill="#6aa9ff" fill-opacity="0.10" stroke="#6aa9ff" stroke-opacity="0.5"/>
-    <text x="289" y="250" text-anchor="middle" fill="#6aa9ff">durable triggers</text>
-    <rect x="382" y="228" width="168" height="34" rx="17" fill="#c792ea" fill-opacity="0.10" stroke="#c792ea" stroke-opacity="0.5"/>
-    <text x="466" y="250" text-anchor="middle" fill="#c792ea">rollback boundary</text>
+    <g fill="#b8ffce">
+      <text x="58" y="30" xml:space="preserve">      .----.</text>
+      <text x="58" y="72" xml:space="preserve">   .-'      `-.</text>
+      <text x="58" y="114" xml:space="preserve">  /   (o  o)   \</text>
+      <text x="58" y="156" xml:space="preserve"> |      ^       |</text>
+      <text x="58" y="198" xml:space="preserve"> |   &lt;edit/&gt;    |</text>
+      <text x="58" y="240" xml:space="preserve">  `._/\/\_/\/\_.'</text>
+    </g>
+    <text x="59" y="286" fill="#8aa092" font-size="19">// friendly haunt · owner controlled</text>
   </g>
 
-  <!-- Architecture diagram -->
-  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="14">
-    <!-- interfaces -->
-    <g font-weight="600">
-      <rect x="640" y="72" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
-      <text x="700" y="97" text-anchor="middle" fill="#dfe6ec">TUI</text>
-      <rect x="640" y="126" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
-      <text x="700" y="151" text-anchor="middle" fill="#dfe6ec">Telegram</text>
-      <rect x="640" y="180" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
-      <text x="700" y="205" text-anchor="middle" fill="#dfe6ec">Triggers</text>
-    </g>
-    <!-- arrows -->
-    <g stroke="#58e6c9" stroke-opacity="0.65" stroke-width="2" fill="none">
-      <path d="M 760 92 C 800 92 800 130 842 142"/>
-      <path d="M 760 146 L 842 146"/>
-      <path d="M 760 200 C 800 200 800 162 842 150"/>
-    </g>
-    <g fill="#58e6c9" fill-opacity="0.8">
-      <path d="M 842 137 l 10 5 -10 5 z"/>
-      <path d="M 842 141 l 10 5 -10 5 z"/>
-      <path d="M 842 145 l 10 5 -10 5 z"/>
-    </g>
-    <!-- agent api -->
-    <rect x="856" y="112" width="150" height="68" rx="12" fill="#58e6c9" fill-opacity="0.12" stroke="#58e6c9" stroke-opacity="0.6"/>
-    <text x="931" y="142" text-anchor="middle" font-size="16" font-weight="700" fill="#7df0d8">Agent API</text>
-    <text x="931" y="164" text-anchor="middle" font-size="12" fill="#aab4bf">tenant-scoped</text>
-    <!-- loop -->
-    <g stroke="#6aa9ff" stroke-opacity="0.7" stroke-width="2" fill="none">
-      <path d="M 1006 130 C 1060 130 1078 110 1078 146 C 1078 182 1060 162 1006 162"/>
-    </g>
-    <text x="1092" y="150" font-size="12" fill="#6aa9ff" text-anchor="middle">tools</text>
+  <g id="identity" transform="translate(430 74)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="0" y="0" fill="#6f887b" font-size="18" letter-spacing="3">SELF-HOSTED AGENT OPERATOR</text>
+    <text x="0" y="78" fill="#f1f7f3" font-size="68" font-weight="800" letter-spacing="-3">OpenTulpa</text>
+    <text x="2" y="118" fill="#b8ffce" font-size="23">a persistent ghost in your machine.</text>
   </g>
 
-  <!-- Footer -->
-  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="14">
-    <rect x="64" y="296" width="700" height="36" rx="8" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
-    <text x="84" y="319" fill="#8b949e">source_release</text>
-    <text x="200" y="319" fill="#58e6c9">&#8594;</text>
-    <text x="224" y="319" fill="#8b949e">fixed checks + image build</text>
-    <text x="430" y="319" fill="#58e6c9">&#8594;</text>
-    <text x="454" y="319" fill="#8b949e">staged health</text>
-    <text x="578" y="319" fill="#58e6c9">&#8594;</text>
-    <text x="602" y="319" fill="#7df0d8">activate</text>
-    <text x="676" y="319" fill="#8b949e">/</text>
-    <text x="690" y="319" fill="#f47067">rollback</text>
+  <!-- The proof is a real OpenTulpa action rhythm, not decorative architecture. -->
+  <g id="terminal-proof" transform="translate(434 220)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="20">
+    <text x="0" y="0" fill="#8aa092">owner@opentulpa:~$</text>
+    <text x="240" y="0" fill="#f1f7f3">change yourself</text>
+
+    <text x="0" y="40" fill="#b8ffce">› inspect</text>
+    <text x="116" y="40" fill="#b8ffce">› edit</text>
+    <text x="205" y="40" fill="#b8ffce">› test</text>
+    <text x="292" y="40" fill="#b8ffce">› ask approval</text>
+
+    <text x="0" y="82" fill="#8aa092">candidate</text>
+    <text x="118" y="82" fill="#f1f7f3">a8f3c2d</text>
+    <text x="238" y="82" fill="#8aa092">checks</text>
+    <text x="322" y="82" fill="#b8ffce">passed</text>
+
+    <text x="0" y="124" fill="#8aa092">release</text>
+    <text x="100" y="124" fill="#f1f7f3">owner-approved</text>
+    <rect x="300" y="102" width="12" height="25" fill="#b8ffce"/>
   </g>
 </svg>

--- a/docs/assets/opentulpa-hero.svg
+++ b/docs/assets/opentulpa-hero.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-label="OpenTulpa hero">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="0.55" stop-color="#101826"/>
+      <stop offset="1" stop-color="#13231f"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#58e6c9"/>
+      <stop offset="1" stop-color="#6aa9ff"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.78" cy="0.3" r="0.6">
+      <stop offset="0" stop-color="#58e6c9" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#58e6c9" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="360" rx="18" fill="url(#bg)"/>
+  <rect width="1200" height="360" rx="18" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1198" height="358" rx="17" fill="none" stroke="#ffffff" stroke-opacity="0.08"/>
+
+  <!-- Title -->
+  <text x="64" y="112" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="56" font-weight="700" fill="#f2f5f7" letter-spacing="0.5">OpenTulpa</text>
+  <rect x="64" y="132" width="300" height="4" rx="2" fill="url(#accent)"/>
+
+  <!-- Tagline -->
+  <text x="64" y="172" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="20" fill="#aab4bf">A small, self-hosted agent operator that can inspect, edit,</text>
+  <text x="64" y="198" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="20" fill="#aab4bf">test, and safely replace its own code.</text>
+
+  <!-- Chips -->
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="15" font-weight="600">
+    <rect x="64" y="228" width="132" height="34" rx="17" fill="#58e6c9" fill-opacity="0.10" stroke="#58e6c9" stroke-opacity="0.5"/>
+    <text x="130" y="250" text-anchor="middle" fill="#58e6c9">typed tools</text>
+    <rect x="210" y="228" width="158" height="34" rx="17" fill="#6aa9ff" fill-opacity="0.10" stroke="#6aa9ff" stroke-opacity="0.5"/>
+    <text x="289" y="250" text-anchor="middle" fill="#6aa9ff">durable triggers</text>
+    <rect x="382" y="228" width="168" height="34" rx="17" fill="#c792ea" fill-opacity="0.10" stroke="#c792ea" stroke-opacity="0.5"/>
+    <text x="466" y="250" text-anchor="middle" fill="#c792ea">rollback boundary</text>
+  </g>
+
+  <!-- Architecture diagram -->
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="14">
+    <!-- interfaces -->
+    <g font-weight="600">
+      <rect x="640" y="72" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
+      <text x="700" y="97" text-anchor="middle" fill="#dfe6ec">TUI</text>
+      <rect x="640" y="126" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
+      <text x="700" y="151" text-anchor="middle" fill="#dfe6ec">Telegram</text>
+      <rect x="640" y="180" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.18"/>
+      <text x="700" y="205" text-anchor="middle" fill="#dfe6ec">Triggers</text>
+    </g>
+    <!-- arrows -->
+    <g stroke="#58e6c9" stroke-opacity="0.65" stroke-width="2" fill="none">
+      <path d="M 760 92 C 800 92 800 130 842 142"/>
+      <path d="M 760 146 L 842 146"/>
+      <path d="M 760 200 C 800 200 800 162 842 150"/>
+    </g>
+    <g fill="#58e6c9" fill-opacity="0.8">
+      <path d="M 842 137 l 10 5 -10 5 z"/>
+      <path d="M 842 141 l 10 5 -10 5 z"/>
+      <path d="M 842 145 l 10 5 -10 5 z"/>
+    </g>
+    <!-- agent api -->
+    <rect x="856" y="112" width="150" height="68" rx="12" fill="#58e6c9" fill-opacity="0.12" stroke="#58e6c9" stroke-opacity="0.6"/>
+    <text x="931" y="142" text-anchor="middle" font-size="16" font-weight="700" fill="#7df0d8">Agent API</text>
+    <text x="931" y="164" text-anchor="middle" font-size="12" fill="#aab4bf">tenant-scoped</text>
+    <!-- loop -->
+    <g stroke="#6aa9ff" stroke-opacity="0.7" stroke-width="2" fill="none">
+      <path d="M 1006 130 C 1060 130 1078 110 1078 146 C 1078 182 1060 162 1006 162"/>
+    </g>
+    <text x="1092" y="150" font-size="12" fill="#6aa9ff" text-anchor="middle">tools</text>
+  </g>
+
+  <!-- Footer -->
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="14">
+    <rect x="64" y="296" width="700" height="36" rx="8" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.10"/>
+    <text x="84" y="319" fill="#8b949e">source_release</text>
+    <text x="200" y="319" fill="#58e6c9">&#8594;</text>
+    <text x="224" y="319" fill="#8b949e">fixed checks + image build</text>
+    <text x="430" y="319" fill="#58e6c9">&#8594;</text>
+    <text x="454" y="319" fill="#8b949e">staged health</text>
+    <text x="578" y="319" fill="#58e6c9">&#8594;</text>
+    <text x="602" y="319" fill="#7df0d8">activate</text>
+    <text x="676" y="319" fill="#8b949e">/</text>
+    <text x="690" y="319" fill="#f47067">rollback</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- replace the dense README hero with responsive desktop and mobile SVGs
- reduce the opening to OpenTulpa, the ghost mark, and "The self-evolving agent"
- explain local setup and hosted Railway/Docker setup with copy-pasteable commands
- summarize the main capabilities and the fixed-host self-evolution flow in plain language
- keep detailed architecture, deployment, tool, testing, and prompt documentation linked instead of duplicating it

## Validation

- `python3 /Users/kvyb/.codex/skills/beautify-github-readme/scripts/audit_readme.py README.md`
- `xmllint --noout assets/readme/hero.svg assets/readme/hero-mobile.svg`
- verified every local README link resolves
- `git diff --check origin/main...HEAD`