### PR TITLE
Improve long-running Telegram agent sessions

### DIFF
--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -1290,6 +1290,7 @@ def build_application(*, project_root: Path, settings: Settings) -> ApplicationC
                 telegram_business=telegram_business,
                 intake_workflows=intake_workflows,
                 resolve_agent_spec=resolve_agent_spec,
+                inference=inference,
             )
             if telegram_client is not None
             else None

--- a/src/opentulpa/deep_agent/prompts.py
+++ b/src/opentulpa/deep_agent/prompts.py
@@ -61,9 +61,9 @@ Use trace_list and trace_get to recover evidence from prior runs or investigate 
 Identity, tenant scope, actor, credentials, and filesystem roots are injected by the application.
 Never guess them or request them as tool arguments.
 
-Use source_shell only to inspect or change OpenTulpa itself. Use source_status immediately before
-source_release or source_rollback and bind the request to the exact identifiers and digest it
-returns. Do not make irreversible product-data migrations through self-update.
+Use source_shell only to inspect or change OpenTulpa itself; its results omit full diffs. Use
+source_status before source_release or source_rollback and bind its identifiers and digest. Do not
+make irreversible product-data migrations through self-update.
 
 For any external Git repository, start with repository_open and work in its `/workspace/`. Inspect,
 edit, test, and commit there; then call repository_status and publish the exact clean head with

--- a/src/opentulpa/deep_agent/service.py
+++ b/src/opentulpa/deep_agent/service.py
@@ -1624,6 +1624,30 @@ class DeepAgentService:
             "preview": "",
         }
 
+    async def ensure_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+        channel: str,
+    ) -> None:
+        """Persist caller-owned thread metadata before a run or preference update."""
+
+        self._require_started()
+        now = utc_now_iso()
+        db = self._require_runs_db()
+        async with self._run_event_lock:
+            await db.execute(
+                """
+                INSERT INTO agent_threads (
+                    tenant_id, thread_id, title, channel, archived, created_at, updated_at
+                ) VALUES (?, ?, 'New session', ?, 0, ?, ?)
+                ON CONFLICT (tenant_id, thread_id) DO NOTHING
+                """,
+                (tenant_id, thread_id, channel, now, now),
+            )
+            await db.commit()
+
     async def list_threads(
         self,
         *,

--- a/src/opentulpa/evolution/supervisor.py
+++ b/src/opentulpa/evolution/supervisor.py
@@ -206,7 +206,7 @@ class EvolutionSupervisor:
         timeout_seconds: int = 300,
         audit_context: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
-        """Run one command in the isolated, writable source candidate."""
+        """Run one command and return concise candidate status; source_status includes the diff."""
 
         self._require_started()
         safe_command = str(command or "").strip()
@@ -229,7 +229,7 @@ class EvolutionSupervisor:
             with self._hide_git_metadata(workspace):
                 response = await backend.aexecute(safe_command, timeout=timeout)
             current = await self._required_candidate(candidate.id)
-            snapshot = await self._source_snapshot(current, workspace)
+            snapshot = await self._source_snapshot(current, workspace, include_diff=False)
             output, output_truncated = self._bounded_text(response.output)
             return {
                 **snapshot,
@@ -1773,10 +1773,11 @@ class EvolutionSupervisor:
         self,
         candidate: Candidate,
         workspace: CandidateWorkspace,
+        *,
+        include_diff: bool = True,
     ) -> dict[str, Any]:
         diff = await asyncio.to_thread(self._source_diff, workspace)
         status = await asyncio.to_thread(self._workspaces.status, workspace)
-        bounded_diff, diff_truncated = self._bounded_text(diff)
         metadata_paths = candidate.metadata.get("changed_paths")
         changed_files = (
             {str(path) for path in metadata_paths if isinstance(path, str)}
@@ -1785,17 +1786,20 @@ class EvolutionSupervisor:
         )
         changed_files.update(self._status_path(item) for item in status)
         changed_files.discard("")
-        return {
+        snapshot = {
             "active": True,
             "candidate_id": candidate.id,
             "candidate": self._source_candidate_data(candidate),
             "dirty": bool(status),
             "changed_files": sorted(changed_files)[:1_000],
             "working_tree_status": [item[:1_000] for item in status[:1_000]],
-            "diff": bounded_diff,
             "diff_sha256": hashlib.sha256(diff.encode("utf-8")).hexdigest(),
-            "diff_truncated": diff_truncated,
         }
+        if include_diff:
+            bounded_diff, diff_truncated = self._bounded_text(diff)
+            snapshot["diff"] = bounded_diff
+            snapshot["diff_truncated"] = diff_truncated
+        return snapshot
 
     def _source_diff(self, workspace: CandidateWorkspace) -> str:
         return self._workspaces.full_diff(workspace)

--- a/src/opentulpa/interfaces/telegram/deep_agent_relay.py
+++ b/src/opentulpa/interfaces/telegram/deep_agent_relay.py
@@ -19,10 +19,17 @@ from opentulpa.deep_agent.contracts import (
     AgentApproval,
     AgentRunEvent,
     AgentRunRequest,
+    AgentRunSnapshot,
     ApprovalDecision,
 )
 from opentulpa.interfaces.telegram.attachments import extract_attachments
 from opentulpa.interfaces.telegram.client import TelegramClient
+from opentulpa.interfaces.telegram.inference_controls import (
+    TelegramInferenceAgent,
+    TelegramInferenceControls,
+    TelegramInferenceService,
+)
+from opentulpa.interfaces.telegram.run_output import TelegramRunOutput
 from opentulpa.interfaces.telegram.security import is_user_allowed
 from opentulpa.interfaces.telegram.state_store import TelegramStateStore
 from opentulpa.specs import AgentSpecRef, OriginRef
@@ -48,6 +55,14 @@ _HIDDEN_EDIT_ARGUMENTS = {
     "tenant_id",
     "thread_id",
 }
+_TELEGRAM_COMMANDS = [
+    {"command": "fresh", "description": "Start a new conversation"},
+    {"command": "model", "description": "Show or select the model"},
+    {"command": "models", "description": "List available models"},
+    {"command": "reasoning", "description": "Set reasoning effort"},
+    {"command": "codex", "description": "Connect or inspect Codex"},
+    {"command": "cancel", "description": "Cancel the active run or approval edit"},
+]
 
 
 @dataclass(frozen=True)
@@ -68,7 +83,7 @@ async def _with_first_event(
         yield event
 
 
-class TelegramAgentService(Protocol):
+class TelegramAgentService(TelegramInferenceAgent, Protocol):
     def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]: ...
 
     def resume(
@@ -76,6 +91,13 @@ class TelegramAgentService(Protocol):
         run_id: str,
         decision: ApprovalDecision,
     ) -> AsyncIterator[AgentRunEvent]: ...
+
+    async def cancel_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> AgentRunSnapshot | None: ...
 
 
 class DeepAgentTelegramRelay:
@@ -100,6 +122,7 @@ class DeepAgentTelegramRelay:
         telegram_business: Any | None = None,
         intake_workflows: Any | None = None,
         resolve_agent_spec: Callable[[str, str], AgentSpecRef] | None = None,
+        inference: TelegramInferenceService | None = None,
     ) -> None:
         self._agent = agent
         self._client = client
@@ -113,9 +136,17 @@ class DeepAgentTelegramRelay:
         self._telegram_business = telegram_business
         self._intake_workflows = intake_workflows
         self._resolve_agent_spec = resolve_agent_spec
+        self._inference_controls = TelegramInferenceControls(
+            agent=agent,
+            inference=inference,
+            client=client,
+            state=state,
+        )
         self._chat_locks: dict[int, asyncio.Lock] = {}
         self._approval_locks: dict[str, asyncio.Lock] = {}
         self._owner_ingress_lock = asyncio.Lock()
+        self._owner_updates_inflight: dict[str, asyncio.Task[Any]] = {}
+        self._owner_dispatch_tasks: set[asyncio.Task[None]] = set()
         self._inbox_dispatcher: asyncio.Task[None] | None = None
         self._accepted_approvals: dict[
             str,
@@ -170,16 +201,29 @@ class DeepAgentTelegramRelay:
         ingress_key = accepted.ingress_key
         if ingress_key is None:
             raise RuntimeError("Telegram owner ingress identity is unavailable")
+        current_task = asyncio.current_task()
+        if current_task is None:
+            raise RuntimeError("Telegram owner update is not running in an asyncio task")
         async with self._owner_ingress_lock:
             body = self._state.owner_update(ingress_key)
-            if body is None:
+            if body is None or ingress_key in self._owner_updates_inflight:
                 return
-            await self._handle_owner_update(body)
+            self._owner_updates_inflight[ingress_key] = current_task
+        try:
+            await self._handle_owner_update(body, ingress_key=ingress_key)
             self._state.complete_owner_update(ingress_key)
+        finally:
+            async with self._owner_ingress_lock:
+                if self._owner_updates_inflight.get(ingress_key) is current_task:
+                    self._owner_updates_inflight.pop(ingress_key, None)
 
     async def start(self) -> None:
         if self._inbox_dispatcher is not None and not self._inbox_dispatcher.done():
             return
+        try:
+            await self._client.set_my_commands(commands=_TELEGRAM_COMMANDS)
+        except Exception:
+            logger.exception("Telegram command registration failed")
         self._inbox_dispatcher = asyncio.create_task(
             self._dispatch_owner_inbox(),
             name="opentulpa-telegram-owner-inbox",
@@ -188,33 +232,54 @@ class DeepAgentTelegramRelay:
     async def shutdown(self) -> None:
         task = self._inbox_dispatcher
         self._inbox_dispatcher = None
-        if task is None:
-            return
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        active = self._owner_dispatch_tasks | {
+            owner_task
+            for owner_task in self._owner_updates_inflight.values()
+            if not owner_task.done() and owner_task is not asyncio.current_task()
+        }
+        for owner_task in active:
+            owner_task.cancel()
+        if active:
+            await asyncio.gather(*active, return_exceptions=True)
 
     async def _dispatch_owner_inbox(self) -> None:
         while True:
             for ingress_key, body in self._state.pending_owner_updates(limit=100):
-                try:
-                    await self.process_update(
+                if ingress_key in self._owner_updates_inflight:
+                    continue
+                task = asyncio.create_task(
+                    self.process_update(
                         AcceptedTelegramUpdate(
                             body=body,
                             is_business=False,
                             ingress_key=ingress_key,
                         )
-                    )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    logger.exception("Persisted Telegram owner update processing failed")
+                    ),
+                    name=f"opentulpa-telegram-owner-update:{ingress_key}",
+                )
+                self._owner_dispatch_tasks.add(task)
+                task.add_done_callback(self._owner_update_done)
             await asyncio.sleep(1.0)
+
+    def _owner_update_done(self, task: asyncio.Task[None]) -> None:
+        self._owner_dispatch_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "Persisted Telegram owner update processing failed",
+                exc_info=(type(error), error, error.__traceback__),
+            )
 
     async def handle_update(self, body: dict[str, Any]) -> None:
         accepted = await self.accept_update(body)
         await self.process_update(accepted)
 
-    async def _handle_owner_update(self, body: dict[str, Any]) -> None:
+    async def _handle_owner_update(self, body: dict[str, Any], *, ingress_key: str) -> None:
         callback = body.get("callback_query")
         if isinstance(callback, dict):
             await self._handle_callback(callback)
@@ -241,39 +306,26 @@ class DeepAgentTelegramRelay:
             return
 
         text = str(message.get("text") or message.get("caption") or "").strip()
-        if text.split(None, 1)[0:1] == ["/start"]:
+        command = self._command(text)
+        if command == "/start":
             await self._client.send_message(
                 chat_id=chat_id,
                 text=(
                     "OpenTulpa is connected. Send a request or attach files. "
-                    "Use /fresh to start a new conversation checkpoint."
+                    "Use /fresh for a new conversation, /model to inspect inference, "
+                    "or /codex login to connect Codex."
                 ),
                 parse_mode=None,
             )
             return
-        if text.split(None, 1)[0:1] == ["/fresh"]:
-            tenant_id = self._resolve_tenant(user_id)
-            self._reset_session(
-                chat_id=chat_id,
-                user_id=user_id,
-                username=username,
-                tenant_id=tenant_id,
-            )
-            await self._client.send_message(
-                chat_id=chat_id,
-                text="Started a fresh conversation.",
-                parse_mode=None,
-            )
-            return
 
-        lock = self._chat_locks.setdefault(chat_id, asyncio.Lock())
-        async with lock:
-            tenant_id = self._resolve_tenant(user_id)
+        tenant_id = self._resolve_tenant(user_id)
+        if command == "/cancel":
             if await self._handle_pending_approval_edit(
                 chat_id=chat_id,
                 user_id=user_id,
                 tenant_id=tenant_id,
-                text=text,
+                text="/cancel",
             ):
                 return
             thread_id = self._session(
@@ -282,9 +334,84 @@ class DeepAgentTelegramRelay:
                 username=username,
                 tenant_id=tenant_id,
             )
-            file_ids = await self._ingest_files(
-                message=message,
+            cancelled = await self._agent.cancel_thread(
+                tenant_id=tenant_id,
+                thread_id=thread_id,
+            )
+            if cancelled is None:
+                await self._send_plain(chat_id, "There is no active run to cancel.")
+                return
+            self._discard_run_approvals(cancelled.run_id)
+            await self._send_plain(chat_id, "Cancelled the active run.")
+            return
+
+        lock = self._chat_locks.setdefault(chat_id, asyncio.Lock())
+        async with lock:
+            if command == "/fresh":
+                self._reset_session(
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    username=username,
+                    tenant_id=tenant_id,
+                )
+                await self._client.send_message(
+                    chat_id=chat_id,
+                    text="Started a fresh conversation.",
+                    parse_mode=None,
+                )
+                return
+            preparation = self._state.owner_update_preparation(ingress_key)
+            if preparation is None:
+                thread_id = self._session(
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    username=username,
+                    tenant_id=tenant_id,
+                )
+            else:
+                thread_id, _, _ = self._decode_owner_run_preparation(
+                    preparation,
+                    tenant_id=tenant_id,
+                )
+            if await self._inference_controls.handle(
                 chat_id=chat_id,
+                tenant_id=tenant_id,
+                thread_id=thread_id,
+                text=text,
+            ):
+                return
+            if await self._handle_pending_approval_edit(
+                chat_id=chat_id,
+                user_id=user_id,
+                tenant_id=tenant_id,
+                text=text,
+            ):
+                return
+            if preparation is None:
+                file_ids = await self._ingest_files(
+                    message=message,
+                    chat_id=chat_id,
+                    tenant_id=tenant_id,
+                )
+                agent_spec = (
+                    self._resolve_agent_spec(tenant_id, AgentRunKind.OWNER.value)
+                    if self._resolve_agent_spec is not None
+                    else AgentSpecRef(
+                        tenant_id=tenant_id,
+                        spec_id="owner",
+                        revision=1,
+                    )
+                )
+                preparation = self._state.prepare_owner_update(
+                    ingress_key,
+                    {
+                        "thread_id": thread_id,
+                        "file_ids": file_ids,
+                        "agent_spec": agent_spec.model_dump(mode="json"),
+                    },
+                )
+            thread_id, file_ids, agent_spec = self._decode_owner_run_preparation(
+                preparation,
                 tenant_id=tenant_id,
             )
             if not text:
@@ -302,15 +429,7 @@ class DeepAgentTelegramRelay:
                     conversation_id=str(chat_id),
                     message_id=str(message.get("message_id") or "") or None,
                 ),
-                agent_spec=(
-                    self._resolve_agent_spec(tenant_id, AgentRunKind.OWNER.value)
-                    if self._resolve_agent_spec is not None
-                    else AgentSpecRef(
-                        tenant_id=tenant_id,
-                        spec_id="owner",
-                        revision=1,
-                    )
-                ),
+                agent_spec=agent_spec,
                 trust_class="owner",
             )
             await self._deliver_events(
@@ -321,6 +440,7 @@ class DeepAgentTelegramRelay:
                         context=context,
                         text=text,
                         file_ids=tuple(file_ids),
+                        idempotency_key=ingress_key,
                     )
                 ),
             )
@@ -332,38 +452,40 @@ class DeepAgentTelegramRelay:
         tenant_id: str,
         events: AsyncIterator[AgentRunEvent],
     ) -> None:
-        chunks: list[str] = []
-        failed = ""
+        output = TelegramRunOutput(client=self._client, chat_id=chat_id)
         interrupted = False
+        settled = False
         async for event in events:
             if event.type == "message.delta":
-                chunks.append(str(event.data.get("text") or ""))
+                await output.delta(str(event.data.get("text") or ""))
+            elif event.type == "tool.started":
+                await output.tool_started(str(event.data.get("name") or "").strip())
+            elif event.type == "tool.completed":
+                await output.tool_completed()
             elif event.type == "approval.required":
                 interrupted = True
-                await self._send_approval(
+                delivered = await self._send_approval(
                     chat_id=chat_id,
                     tenant_id=tenant_id,
                     run_id=event.run_id,
                     approval=event.data,
                 )
+                if delivered:
+                    await output.discard()
             elif event.type == "run.failed":
-                failed = str(event.data.get("message") or "Agent run failed.")
+                settled = True
+                await output.finish(str(event.data.get("message") or "Agent run failed."))
             elif event.type == "run.completed":
+                settled = True
                 final = str(event.data.get("text") or "").strip()
-                if final:
-                    chunks = [final]
-        reply = "".join(chunks).strip()
-        if reply:
-            await self._client.send_message(chat_id=chat_id, text=reply, parse_mode=None)
+                await output.finish(final)
+        if not interrupted:
+            if not settled:
+                await output.finish("")
             self._state.touch_assistant_message(chat_id)
-        elif failed:
-            await self._client.send_message(chat_id=chat_id, text=failed, parse_mode=None)
-        elif not interrupted:
-            await self._client.send_message(
-                chat_id=chat_id,
-                text="The run completed without a message.",
-                parse_mode=None,
-            )
+
+    async def _send_plain(self, chat_id: int, text: str) -> None:
+        await self._client.send_message(chat_id=chat_id, text=text, parse_mode=None)
 
     async def _send_approval(
         self,
@@ -372,7 +494,7 @@ class DeepAgentTelegramRelay:
         tenant_id: str,
         run_id: str,
         approval: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         approval_id = str(approval.get("approval_id") or "").strip()
         token = new_short_id("approval", suffix_chars=12)
         raw_allowed = approval.get("allowed_decisions")
@@ -407,12 +529,13 @@ class DeepAgentTelegramRelay:
             if decision in allowed_decisions
         ]
         markup = {"inline_keyboard": [buttons]}
-        await self._client.send_message(
+        response = await self._client.send_message(
             chat_id=chat_id,
             text=f"Approval required for {tool_name}: {description}",
             parse_mode=None,
             reply_markup=markup,
         )
+        return response is not None
 
     async def deliver_approval(
         self,
@@ -688,6 +811,31 @@ class DeepAgentTelegramRelay:
 
         return bool(self._state.update(consume))
 
+    def _discard_run_approvals(self, run_id: str) -> None:
+        def discard(state: dict[str, Any]) -> None:
+            pending = state.get("pending_approvals")
+            if not isinstance(pending, dict):
+                return
+            removed = {
+                token
+                for token, record in pending.items()
+                if isinstance(record, dict) and str(record.get("run_id") or "") == run_id
+            }
+            if not removed:
+                return
+            state["pending_approvals"] = {
+                token: record for token, record in pending.items() if token not in removed
+            }
+            edits = state.get("pending_approval_edits")
+            if isinstance(edits, dict):
+                state["pending_approval_edits"] = {
+                    key: marker
+                    for key, marker in edits.items()
+                    if not isinstance(marker, dict) or str(marker.get("token") or "") not in removed
+                }
+
+        self._state.update(discard)
+
     def _finish_accepted_approval(
         self,
         *,
@@ -785,7 +933,7 @@ class DeepAgentTelegramRelay:
                 parse_mode=None,
             )
             return True
-        if text.split(None, 1)[0:1] == ["/cancel"]:
+        if self._command(text) == "/cancel":
             self._clear_pending_approval_edit(
                 chat_id=chat_id,
                 user_id=user_id,
@@ -893,6 +1041,24 @@ class DeepAgentTelegramRelay:
         if self._owner_tenant_id:
             return self._profiles.resolve_customer_id(self._owner_tenant_id)
         return self._profiles.resolve_telegram_customer_id(user_id)
+
+    @staticmethod
+    def _decode_owner_run_preparation(
+        preparation: dict[str, Any],
+        *,
+        tenant_id: str,
+    ) -> tuple[str, list[str], AgentSpecRef]:
+        thread_id = str(preparation.get("thread_id") or "").strip()
+        raw_file_ids = preparation.get("file_ids")
+        file_ids = (
+            [str(file_id) for file_id in raw_file_ids if str(file_id).strip()]
+            if isinstance(raw_file_ids, list)
+            else []
+        )
+        agent_spec = AgentSpecRef.model_validate(preparation.get("agent_spec"))
+        if not thread_id or agent_spec.tenant_id != tenant_id:
+            raise RuntimeError("Telegram owner run preparation is invalid")
+        return thread_id, file_ids, agent_spec
 
     def _session(
         self,
@@ -1026,6 +1192,11 @@ class DeepAgentTelegramRelay:
                     },
                 )
                 raise RuntimeError("Telegram Business intake could not be queued")
+
+    @staticmethod
+    def _command(text: str) -> str:
+        parts = str(text or "").split(None, 1)
+        return parts[0].split("@", 1)[0].casefold() if parts else ""
 
     @staticmethod
     def _positive_int(value: Any) -> int | None:

--- a/src/opentulpa/interfaces/telegram/inference_controls.py
+++ b/src/opentulpa/interfaces/telegram/inference_controls.py
@@ -1,0 +1,361 @@
+"""Telegram slash commands for per-thread inference and Codex authentication."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal, Protocol, cast
+
+from opentulpa.inference import InferenceModel, InferenceSelection
+from opentulpa.inference.service import InferenceConflictError, InferenceUnavailableError
+from opentulpa.interfaces.telegram.client import TelegramClient
+from opentulpa.interfaces.telegram.state_store import TelegramStateStore
+from opentulpa.tooling import AgentChannel
+
+logger = logging.getLogger(__name__)
+_INFERENCE_COMMANDS = {"/model", "/models", "/reasoning", "/codex"}
+
+
+class TelegramInferenceAgent(Protocol):
+    async def ensure_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+        channel: str,
+    ) -> None: ...
+
+    async def get_thread_inference(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def update_thread_inference(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+        expected_revision: int,
+        selection: InferenceSelection | None,
+    ) -> dict[str, Any] | None: ...
+
+
+class TelegramInferenceService(Protocol):
+    def codex_connected(self, tenant_id: str) -> bool: ...
+
+    async def status(self, tenant_id: str) -> dict[str, Any]: ...
+
+    async def models(
+        self,
+        tenant_id: str,
+        provider: Literal["api", "codex"],
+        *,
+        query: str = "",
+    ) -> tuple[InferenceModel, ...]: ...
+
+    async def start_device_login(self, tenant_id: str) -> dict[str, Any]: ...
+
+    async def get_device_login(
+        self,
+        tenant_id: str,
+        login_id: str,
+    ) -> dict[str, Any] | None: ...
+
+
+class TelegramInferenceControls:
+    def __init__(
+        self,
+        *,
+        agent: TelegramInferenceAgent,
+        inference: TelegramInferenceService | None,
+        client: TelegramClient,
+        state: TelegramStateStore,
+    ) -> None:
+        self._agent = agent
+        self._inference = inference
+        self._client = client
+        self._state = state
+
+    async def handle(
+        self,
+        *,
+        chat_id: int,
+        tenant_id: str,
+        thread_id: str,
+        text: str,
+    ) -> bool:
+        parts = str(text or "").split()
+        if not parts:
+            return False
+        command = parts[0].split("@", 1)[0].casefold()
+        if command not in _INFERENCE_COMMANDS:
+            return False
+        if self._inference is None:
+            await self._send_plain(chat_id, "Inference controls are unavailable.")
+            return True
+        try:
+            await self._agent.ensure_thread(
+                tenant_id=tenant_id,
+                thread_id=thread_id,
+                channel=AgentChannel.TELEGRAM.value,
+            )
+            if command == "/model":
+                await self._handle_model(
+                    chat_id=chat_id,
+                    tenant_id=tenant_id,
+                    thread_id=thread_id,
+                    arguments=parts[1:],
+                )
+            elif command == "/models":
+                await self._handle_models(
+                    chat_id=chat_id,
+                    tenant_id=tenant_id,
+                    thread_id=thread_id,
+                    arguments=parts[1:],
+                )
+            elif command == "/reasoning":
+                await self._handle_reasoning(
+                    chat_id=chat_id,
+                    tenant_id=tenant_id,
+                    thread_id=thread_id,
+                    arguments=parts[1:],
+                )
+            else:
+                await self._handle_codex(
+                    chat_id=chat_id,
+                    tenant_id=tenant_id,
+                    arguments=parts[1:],
+                )
+        except (InferenceConflictError, InferenceUnavailableError, ValueError) as exc:
+            await self._send_plain(chat_id, str(exc))
+        except Exception:
+            logger.exception(
+                "Telegram inference command failed",
+                extra={"tenant_id": tenant_id, "thread_id": thread_id, "command": command},
+            )
+            await self._send_plain(chat_id, "The inference command could not be completed.")
+        return True
+
+    async def _handle_model(
+        self,
+        *,
+        chat_id: int,
+        tenant_id: str,
+        thread_id: str,
+        arguments: list[str],
+    ) -> None:
+        current = await self._thread_inference(tenant_id=tenant_id, thread_id=thread_id)
+        if not arguments:
+            await self._send_plain(
+                chat_id,
+                self._selection_text("Current model", current["effective"]),
+            )
+            return
+        if len(arguments) not in {2, 3}:
+            raise ValueError("Usage: /model <api|codex> <model> [reasoning]")
+        provider = arguments[0].casefold()
+        if provider not in {"api", "codex"}:
+            raise ValueError("Provider must be api or codex.")
+        selection = InferenceSelection(
+            provider=cast(Literal["api", "codex"], provider),
+            model=arguments[1],
+            reasoning_effort=arguments[2] if len(arguments) > 2 else None,
+        )
+        updated = await self._agent.update_thread_inference(
+            tenant_id=tenant_id,
+            thread_id=thread_id,
+            expected_revision=int(current["revision"]),
+            selection=selection,
+        )
+        if updated is None:
+            raise RuntimeError("Telegram conversation is unavailable")
+        await self._send_plain(
+            chat_id,
+            self._selection_text("Model selected", updated["effective"]),
+        )
+
+    async def _handle_models(
+        self,
+        *,
+        chat_id: int,
+        tenant_id: str,
+        thread_id: str,
+        arguments: list[str],
+    ) -> None:
+        current = await self._thread_inference(tenant_id=tenant_id, thread_id=thread_id)
+        provider = (
+            arguments[0].casefold()
+            if arguments and arguments[0].casefold() in {"api", "codex"}
+            else str(current["effective"]["provider"])
+        )
+        query_parts = arguments[1:] if arguments and arguments[0].casefold() == provider else arguments
+        models = await self._require_inference().models(
+            tenant_id,
+            cast(Literal["api", "codex"], provider),
+            query=" ".join(query_parts),
+        )
+        lines = [f"Available {provider} models:"]
+        for model in models[:20]:
+            efforts = f" [{', '.join(model.reasoning_efforts)}]" if model.reasoning_efforts else ""
+            lines.append(f"- {model.id}{efforts}")
+        if len(models) > 20:
+            lines.append(f"...and {len(models) - 20} more. Add a search term to /models.")
+        lines.append(f"Select with: /model {provider} <model> [reasoning]")
+        await self._send_plain(chat_id, "\n".join(lines))
+
+    async def _handle_reasoning(
+        self,
+        *,
+        chat_id: int,
+        tenant_id: str,
+        thread_id: str,
+        arguments: list[str],
+    ) -> None:
+        if len(arguments) != 1:
+            raise ValueError("Usage: /reasoning <minimal|low|medium|high|xhigh|max|ultra>")
+        current = await self._thread_inference(tenant_id=tenant_id, thread_id=thread_id)
+        effective = current["effective"]
+        selection = InferenceSelection(
+            provider=effective["provider"],
+            model=effective["model"],
+            reasoning_effort=arguments[0].casefold(),
+            service_tier=effective.get("service_tier"),
+            fallback_to_api=bool(effective.get("fallback_to_api", False)),
+        )
+        updated = await self._agent.update_thread_inference(
+            tenant_id=tenant_id,
+            thread_id=thread_id,
+            expected_revision=int(current["revision"]),
+            selection=selection,
+        )
+        if updated is None:
+            raise RuntimeError("Telegram conversation is unavailable")
+        await self._send_plain(
+            chat_id,
+            self._selection_text("Reasoning updated", updated["effective"]),
+        )
+
+    async def _handle_codex(
+        self,
+        *,
+        chat_id: int,
+        tenant_id: str,
+        arguments: list[str],
+    ) -> None:
+        action = arguments[0].casefold() if arguments else "status"
+        if action == "login":
+            inference = self._require_inference()
+            if inference.codex_connected(tenant_id):
+                await self._send_plain(
+                    chat_id,
+                    "Codex is already connected. Use /models codex to select a model.",
+                )
+                return
+            login = await inference.start_device_login(tenant_id)
+            login_id = str(login["id"])
+            self._remember_codex_login(chat_id, login_id)
+            await self._send_plain(
+                chat_id,
+                (
+                    "Connect Codex:\n"
+                    f"1. Open {login['verification_url']}\n"
+                    f"2. Enter code {login['user_code']}\n"
+                    f"3. Run /codex status {login_id}"
+                ),
+            )
+            return
+        if action != "status":
+            raise ValueError("Usage: /codex [login|status [login_id]]")
+        login_id = arguments[1] if len(arguments) > 1 else self._codex_login(chat_id)
+        if login_id:
+            login_state = await self._require_inference().get_device_login(
+                tenant_id,
+                login_id,
+            )
+            if login_state is None:
+                raise ValueError("Codex login was not found. Start again with /codex login.")
+            login_status = str(login_state.get("status") or "unknown")
+            if login_status == "authorized":
+                self._remember_codex_login(chat_id, None)
+                await self._send_plain(
+                    chat_id,
+                    "Codex is connected. Use /models codex to select a model.",
+                )
+                return
+            await self._send_plain(
+                chat_id,
+                (
+                    f"Codex login status: {login_status}. "
+                    f"Run /codex status {login_id} to check again."
+                ),
+            )
+            return
+        service_status = await self._require_inference().status(tenant_id)
+        connected = bool(service_status.get("codex", {}).get("connected"))
+        await self._send_plain(
+            chat_id,
+            (
+                "Codex is connected. Use /models codex to select a model."
+                if connected
+                else "Codex is not connected. Run /codex login."
+            ),
+        )
+
+    async def _thread_inference(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        current = await self._agent.get_thread_inference(
+            tenant_id=tenant_id,
+            thread_id=thread_id,
+        )
+        if current is None:
+            raise RuntimeError("Telegram conversation is unavailable")
+        return current
+
+    def _require_inference(self) -> TelegramInferenceService:
+        if self._inference is None:
+            raise RuntimeError("Inference controls are unavailable")
+        return self._inference
+
+    @staticmethod
+    def _selection_text(title: str, selection: dict[str, Any]) -> str:
+        reasoning = str(selection.get("reasoning_effort") or "provider default")
+        return (
+            f"{title}:\n"
+            f"Provider: {selection.get('provider')}\n"
+            f"Model: {selection.get('model')}\n"
+            f"Reasoning: {reasoning}"
+        )
+
+    async def _send_plain(self, chat_id: int, text: str) -> None:
+        await self._client.send_message(chat_id=chat_id, text=text, parse_mode=None)
+
+    def _remember_codex_login(self, chat_id: int, login_id: str | None) -> None:
+        def update(state: dict[str, Any]) -> None:
+            logins = state.get("codex_logins")
+            if not isinstance(logins, dict):
+                logins = {}
+            if login_id:
+                logins[str(chat_id)] = login_id
+            else:
+                logins.pop(str(chat_id), None)
+            state["codex_logins"] = logins
+
+        self._state.update(update)
+
+    def _codex_login(self, chat_id: int) -> str:
+        logins = self._state.load().get("codex_logins")
+        if not isinstance(logins, dict):
+            return ""
+        return str(logins.get(str(chat_id)) or "").strip()
+
+
+__all__ = [
+    "TelegramInferenceAgent",
+    "TelegramInferenceControls",
+    "TelegramInferenceService",
+]

--- a/src/opentulpa/interfaces/telegram/run_output.py
+++ b/src/opentulpa/interfaces/telegram/run_output.py
@@ -1,0 +1,188 @@
+"""Bounded, rate-limited Telegram output for one active agent run."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from opentulpa.interfaces.telegram.client import TelegramClient
+from opentulpa.telegram_formatting import TELEGRAM_TEXT_CHAR_LIMIT
+
+_EDIT_MIN_INTERVAL_SECONDS = 1.5
+_PREVIEW_CHAR_LIMIT = TELEGRAM_TEXT_CHAR_LIMIT - 300
+_PREVIEW_PREFIX = "[Earlier progress omitted]\n\n"
+_TOOL_PROGRESS_LABELS = {
+    "source_shell": "Working on OpenTulpa source",
+    "source_status": "Reviewing OpenTulpa changes",
+    "write_todos": "Updating the plan",
+}
+
+
+def _message_id(response: dict[str, Any] | None) -> int | None:
+    if not isinstance(response, dict):
+        return None
+    result = response.get("result")
+    value = result.get("message_id") if isinstance(result, dict) else response.get("message_id")
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+class TelegramRunOutput:
+    """Edit one compact Telegram message while a run is active."""
+
+    def __init__(self, *, client: TelegramClient, chat_id: int) -> None:
+        self._client = client
+        self._chat_id = chat_id
+        self._message_id: int | None = None
+        self._rendered = ""
+        self._last_edit = 0.0
+        self._segment: list[str] = []
+        self._latest_segment = ""
+        self._pending_text: str | None = None
+        self._pending_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    async def delta(self, text: str) -> None:
+        value = str(text or "")
+        if not value or self._closed:
+            return
+        self._segment.append(value)
+        segment = self._bounded_segment("".join(self._segment))
+        self._segment = [segment]
+        await self._replace(segment)
+
+    async def tool_started(self, name: str) -> None:
+        if self._closed:
+            return
+        self._finish_segment()
+        label = _TOOL_PROGRESS_LABELS.get(name, f"Running {name or 'tool'}")
+        text = f"{self._latest_segment}\n\nWorking: {label}..." if self._latest_segment else (
+            f"Working: {label}..."
+        )
+        await self._replace(text)
+
+    async def tool_completed(self) -> None:
+        self._finish_segment()
+
+    async def finish(self, text: str) -> None:
+        if self._closed:
+            return
+        await self._cancel_pending()
+        final = str(text or "").strip()
+        if not final:
+            self._finish_segment()
+            final = self._latest_segment
+        response = await self._client.send_message(
+            chat_id=self._chat_id,
+            text=final or "The run completed without a message.",
+            parse_mode=None,
+        )
+        if response is not None and self._message_id is not None:
+            await self._client.delete_message(
+                chat_id=self._chat_id,
+                message_id=self._message_id,
+            )
+        self._closed = True
+
+    async def discard(self) -> None:
+        """Remove transient progress once another durable Telegram message replaces it."""
+
+        if self._closed:
+            return
+        await self._cancel_pending()
+        if self._message_id is not None:
+            await self._client.delete_message(
+                chat_id=self._chat_id,
+                message_id=self._message_id,
+            )
+        self._closed = True
+
+    def _finish_segment(self) -> None:
+        segment = self._bounded_segment("".join(self._segment)).strip()
+        self._segment.clear()
+        if segment:
+            self._latest_segment = segment
+
+    async def _replace(self, text: str) -> None:
+        preview = self._bounded_preview(text)
+        if self._closed or not preview:
+            return
+        now = asyncio.get_running_loop().time()
+        if self._message_id is None:
+            if self._rendered:
+                return
+            await self._apply(preview)
+            return
+        if now - self._last_edit >= _EDIT_MIN_INTERVAL_SECONDS:
+            await self._cancel_pending()
+            await self._apply(preview)
+            return
+        self._pending_text = preview
+        if self._pending_task is None or self._pending_task.done():
+            delay = _EDIT_MIN_INTERVAL_SECONDS - (now - self._last_edit)
+            self._pending_task = asyncio.create_task(self._flush_pending(delay))
+
+    async def _apply(self, preview: str) -> None:
+        if self._closed or preview == self._rendered:
+            return
+        if self._message_id is None:
+            response = await self._client.send_message(
+                chat_id=self._chat_id,
+                text=preview,
+                parse_mode=None,
+            )
+            if response is None:
+                return
+            self._message_id = _message_id(response)
+        else:
+            edited = await self._client.edit_message_text(
+                chat_id=self._chat_id,
+                message_id=self._message_id,
+                text=preview,
+                parse_mode=None,
+            )
+            if not edited:
+                return
+        self._rendered = preview
+        self._last_edit = asyncio.get_running_loop().time()
+
+    async def _flush_pending(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(max(0.0, delay))
+            preview = self._pending_text
+            self._pending_text = None
+            if preview is not None:
+                await self._apply(preview)
+        finally:
+            self._pending_task = None
+            preview = self._pending_text
+            self._pending_text = None
+            if preview is not None and not self._closed:
+                await self._replace(preview)
+
+    async def _cancel_pending(self) -> None:
+        task = self._pending_task
+        self._pending_task = None
+        self._pending_text = None
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    @staticmethod
+    def _bounded_preview(text: str) -> str:
+        return TelegramRunOutput._bounded_segment(str(text or "").strip())
+
+    @staticmethod
+    def _bounded_segment(text: str) -> str:
+        preview = str(text or "")
+        if len(preview) <= _PREVIEW_CHAR_LIMIT:
+            return preview
+        available = _PREVIEW_CHAR_LIMIT - len(_PREVIEW_PREFIX)
+        return _PREVIEW_PREFIX + preview[-available:].lstrip()
+
+
+__all__ = ["TelegramRunOutput"]

--- a/src/opentulpa/interfaces/telegram/state_store.py
+++ b/src/opentulpa/interfaces/telegram/state_store.py
@@ -28,6 +28,7 @@ class TelegramStateStore:
             "support_bindings": {},
             "support_audit": [],
             "support_command_chats": {},
+            "codex_logins": {},
             "owner_update_inbox": {},
             "owner_update_completed": [],
         }
@@ -184,6 +185,33 @@ class TelegramStateStore:
         item = inbox.get(ingress_key) if isinstance(inbox, dict) else None
         body = item.get("body") if isinstance(item, dict) else None
         return dict(body) if isinstance(body, dict) else None
+
+    def owner_update_preparation(self, ingress_key: str) -> dict[str, Any] | None:
+        state = self.load()
+        inbox = state.get("owner_update_inbox")
+        item = inbox.get(ingress_key) if isinstance(inbox, dict) else None
+        preparation = item.get("preparation") if isinstance(item, dict) else None
+        return dict(preparation) if isinstance(preparation, dict) else None
+
+    def prepare_owner_update(
+        self,
+        ingress_key: str,
+        preparation: dict[str, Any],
+    ) -> dict[str, Any]:
+        detached = json.loads(json.dumps(preparation, ensure_ascii=False, allow_nan=False))
+
+        def prepare(state: dict[str, Any]) -> dict[str, Any]:
+            inbox = state.get("owner_update_inbox")
+            item = inbox.get(ingress_key) if isinstance(inbox, dict) else None
+            if not isinstance(item, dict):
+                raise KeyError(f"Telegram owner update is unavailable: {ingress_key}")
+            existing = item.get("preparation")
+            if isinstance(existing, dict):
+                return dict(existing)
+            item["preparation"] = detached
+            return dict(detached)
+
+        return cast("dict[str, Any]", self.update(prepare))
 
     def pending_owner_updates(self, *, limit: int = 100) -> list[tuple[str, dict[str, Any]]]:
         state = self.load()

--- a/src/opentulpa/specs/defaults.py
+++ b/src/opentulpa/specs/defaults.py
@@ -5,6 +5,8 @@ from opentulpa.specs.models import AgentSpecWrite
 DEFAULT_OWNER_SPEC_ID = "owner"
 DEFAULT_ROUTINE_SPEC_ID = "routine"
 DEFAULT_INTAKE_SPEC_ID = "intake"
+DEFAULT_OWNER_MAX_RUNTIME_SECONDS = 7_200
+DEFAULT_OWNER_MAX_MODEL_CALLS = 500
 
 
 def default_agent_spec_writes() -> dict[str, AgentSpecWrite]:
@@ -22,6 +24,8 @@ def default_agent_spec_writes() -> dict[str, AgentSpecWrite]:
             memory_scope="owner",
             workspace_scope="read_write",
             allow_delegation=True,
+            max_runtime_seconds=DEFAULT_OWNER_MAX_RUNTIME_SECONDS,
+            max_model_calls=DEFAULT_OWNER_MAX_MODEL_CALLS,
         ),
         DEFAULT_ROUTINE_SPEC_ID: AgentSpecWrite(
             name="Routine",
@@ -51,6 +55,8 @@ def default_agent_spec_writes() -> dict[str, AgentSpecWrite]:
 
 __all__ = [
     "DEFAULT_INTAKE_SPEC_ID",
+    "DEFAULT_OWNER_MAX_MODEL_CALLS",
+    "DEFAULT_OWNER_MAX_RUNTIME_SECONDS",
     "DEFAULT_OWNER_SPEC_ID",
     "DEFAULT_ROUTINE_SPEC_ID",
     "default_agent_spec_writes",

--- a/src/opentulpa/specs/service.py
+++ b/src/opentulpa/specs/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from opentulpa.core.ids import new_short_id
-from opentulpa.specs.defaults import default_agent_spec_writes
+from opentulpa.specs.defaults import DEFAULT_OWNER_SPEC_ID, default_agent_spec_writes
 from opentulpa.specs.models import AgentSpec, AgentSpecWrite, TriggerSpec, TriggerSpecWrite
 from opentulpa.specs.protocol import AgentSpecRef
 from opentulpa.specs.store import (
@@ -137,6 +137,11 @@ class AgentSpecService:
         for spec_id, write in default_agent_spec_writes().items():
             active = self._store.get_active(tenant_id=tenant_id, spec_id=spec_id)
             if active is not None:
+                active = self._upgrade_legacy_owner_default(
+                    active=active,
+                    desired=write,
+                    actor_id=actor_id,
+                )
                 active_specs.append(active)
                 continue
             latest = self._store.get_latest(tenant_id=tenant_id, spec_id=spec_id)
@@ -155,6 +160,49 @@ class AgentSpecService:
             )
             active_specs.append(latest)
         return active_specs
+
+    def _upgrade_legacy_owner_default(
+        self,
+        *,
+        active: AgentSpec,
+        desired: AgentSpecWrite,
+        actor_id: str,
+    ) -> AgentSpec:
+        if active.id != DEFAULT_OWNER_SPEC_ID:
+            return active
+        active_write = AgentSpecWrite.model_validate(
+            active.model_dump(include=set(AgentSpecWrite.model_fields))
+        )
+        legacy = desired.model_copy(
+            update={
+                "max_runtime_seconds": 900,
+                "max_model_calls": 100,
+            }
+        )
+        if active_write != legacy:
+            return active
+        latest = self._store.get_latest(tenant_id=active.tenant_id, spec_id=active.id)
+        if latest is not None and latest.revision != active.revision:
+            latest_write = AgentSpecWrite.model_validate(
+                latest.model_dump(include=set(AgentSpecWrite.model_fields))
+            )
+            if latest_write != desired:
+                return active
+            upgraded = latest
+        else:
+            upgraded = self._store.create_revision(
+                tenant_id=active.tenant_id,
+                spec_id=active.id,
+                write=desired,
+                expected_revision=active.revision,
+                created_by=actor_id,
+            )
+        self._store.activate(
+            upgraded.ref,
+            expected_active_revision=active.revision,
+            updated_by=actor_id,
+        )
+        return upgraded
 
 
 class TriggerSpecService:

--- a/tests/test_agent_specs_store.py
+++ b/tests/test_agent_specs_store.py
@@ -17,6 +17,7 @@ from opentulpa.specs import (
     TriggerSpecService,
     TriggerSpecStore,
     TriggerSpecWrite,
+    default_agent_spec_writes,
 )
 
 NOW = datetime(2026, 7, 20, 12, tzinfo=UTC)
@@ -87,6 +88,80 @@ def test_agent_spec_revisions_are_immutable_idempotent_and_tenant_scoped(
             expected_revision=1,
             created_by="owner",
         )
+
+
+def test_seed_defaults_upgrades_only_the_legacy_owner_budget(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    service = AgentSpecService(store)
+    desired = default_agent_spec_writes()["owner"]
+    legacy = desired.model_copy(
+        update={"max_runtime_seconds": 900, "max_model_calls": 100}
+    )
+    first = store.create_revision(
+        tenant_id="tenant-a",
+        spec_id="owner",
+        write=legacy,
+        expected_revision=None,
+        created_by="bootstrap",
+    )
+    store.activate(
+        first.ref,
+        expected_active_revision=None,
+        updated_by="bootstrap",
+    )
+
+    seeded = service.seed_defaults(tenant_id="tenant-a", actor_id="bootstrap")
+    owner = next(spec for spec in seeded if spec.id == "owner")
+
+    assert owner.revision == 2
+    assert owner.max_runtime_seconds == 7_200
+    assert owner.max_model_calls == 500
+    assert store.get_active(tenant_id="tenant-a", spec_id="owner") == owner
+
+    customized = service.save(
+        tenant_id="tenant-a",
+        actor_id="owner",
+        spec_id="owner",
+        expected_revision=2,
+        write=desired.model_copy(update={"max_runtime_seconds": 3_600}),
+    )
+    service.activate(
+        tenant_id="tenant-a",
+        actor_id="owner",
+        spec_id="owner",
+        revision=customized.revision,
+        expected_active_revision=2,
+    )
+
+    reseeded = service.seed_defaults(tenant_id="tenant-a", actor_id="bootstrap")
+    active = next(spec for spec in reseeded if spec.id == "owner")
+    assert active.revision == customized.revision
+    assert active.max_runtime_seconds == 3_600
+
+    legacy_b = store.create_revision(
+        tenant_id="tenant-b",
+        spec_id="owner",
+        write=legacy,
+        expected_revision=None,
+        created_by="bootstrap",
+    )
+    store.activate(
+        legacy_b.ref,
+        expected_active_revision=None,
+        updated_by="bootstrap",
+    )
+    interrupted_upgrade = store.create_revision(
+        tenant_id="tenant-b",
+        spec_id="owner",
+        write=desired,
+        expected_revision=1,
+        created_by="bootstrap",
+    )
+
+    recovered = service.seed_defaults(tenant_id="tenant-b", actor_id="bootstrap")
+    recovered_owner = next(spec for spec in recovered if spec.id == "owner")
+    assert recovered_owner == interrupted_upgrade
+    assert store.get_active(tenant_id="tenant-b", spec_id="owner") == interrupted_upgrade
 
 
 def test_agent_spec_activation_is_compare_and_swap_and_can_roll_back(tmp_path: Path) -> None:

--- a/tests/test_deep_agent_telegram_lifecycle.py
+++ b/tests/test_deep_agent_telegram_lifecycle.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opentulpa.deep_agent.contracts import AgentRunEvent, AgentRunRequest, ApprovalDecision
+from opentulpa.interfaces.telegram.deep_agent_relay import DeepAgentTelegramRelay
+from opentulpa.interfaces.telegram.state_store import TelegramStateStore
+
+
+class _Profiles:
+    def resolve_customer_id(self, value: str) -> str:
+        return value
+
+    def resolve_telegram_customer_id(self, value: int) -> str:
+        return f"telegram_{value}"
+
+
+class _Files:
+    def ingest_file(self, **_: Any) -> dict[str, str]:
+        return {"id": "file_1"}
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+        self.edits: list[dict[str, Any]] = []
+        self.deleted: list[dict[str, Any]] = []
+
+    async def send_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.messages.append(kwargs)
+        return {"ok": True, "result": {"message_id": len(self.messages)}}
+
+    async def edit_message_text(self, **kwargs: Any) -> bool:
+        self.edits.append(kwargs)
+        return True
+
+    async def delete_message(self, **kwargs: Any) -> bool:
+        self.deleted.append(kwargs)
+        return True
+
+    async def set_my_commands(self, **_: Any) -> bool:
+        return True
+
+    async def download_file(self, **_: Any) -> dict[str, bytes]:
+        return {"raw_bytes": b"file"}
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.requests: list[AgentRunRequest] = []
+        self.cancelled_threads: list[tuple[str, str]] = []
+
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        yield AgentRunEvent("run.started", "run_1", 1, "now", {})
+        yield AgentRunEvent("run.completed", "run_1", 2, "now", {"text": request.text})
+
+    async def resume(
+        self,
+        run_id: str,
+        decision: ApprovalDecision,
+    ) -> AsyncIterator[AgentRunEvent]:
+        del decision
+        yield AgentRunEvent("run.started", run_id, 1, "now", {})
+        yield AgentRunEvent("run.completed", run_id, 2, "now", {"text": "resumed"})
+
+    async def cancel_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> Any | None:
+        self.cancelled_threads.append((tenant_id, thread_id))
+        return None
+
+
+class _ApprovalAgent(_Agent):
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        yield AgentRunEvent("run.started", "run_approval", 1, "now", {})
+        yield AgentRunEvent(
+            "message.delta",
+            "run_approval",
+            2,
+            "now",
+            {"text": "Preparing the change"},
+        )
+        yield AgentRunEvent(
+            "approval.required",
+            "run_approval",
+            3,
+            "now",
+            {
+                "approval_id": "approval_1",
+                "tool_name": "source_release",
+                "description": "Release the candidate",
+                "allowed_decisions": ["approve", "reject"],
+            },
+        )
+
+
+class _BlockingAgent(_Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.cancelled = False
+
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        yield AgentRunEvent("run.started", "run_blocked", 1, "now", {})
+        yield AgentRunEvent("message.delta", "run_blocked", 2, "now", {"text": "Working"})
+        self.started.set()
+        await self.release.wait()
+        if self.cancelled:
+            yield AgentRunEvent(
+                "run.failed",
+                "run_blocked",
+                3,
+                "now",
+                {"message": "Agent run was cancelled."},
+            )
+        else:
+            yield AgentRunEvent("run.completed", "run_blocked", 3, "now", {"text": "Finished"})
+
+    async def cancel_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> Any:
+        self.cancelled_threads.append((tenant_id, thread_id))
+        self.cancelled = True
+        self.release.set()
+        return SimpleNamespace(run_id="run_blocked")
+
+
+class _ConcurrentAgent(_Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_started = asyncio.Event()
+        self.both_started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        self.first_started.set()
+        if len(self.requests) == 2:
+            self.both_started.set()
+        run_id = f"run_{len(self.requests)}"
+        yield AgentRunEvent("run.started", run_id, 1, "now", {})
+        await self.release.wait()
+        yield AgentRunEvent("run.completed", run_id, 2, "now", {"text": request.text})
+
+
+class _FailingAgent(_Agent):
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        raise RuntimeError("worker stopped")
+        yield  # pragma: no cover
+
+
+def _relay(
+    tmp_path: Path,
+    *,
+    agent: _Agent,
+    state: TelegramStateStore | None = None,
+) -> tuple[DeepAgentTelegramRelay, _Client, TelegramStateStore]:
+    client = _Client()
+    state = state or TelegramStateStore(tmp_path / "telegram.json")
+    relay = DeepAgentTelegramRelay(
+        agent=agent,  # type: ignore[arg-type]
+        client=client,  # type: ignore[arg-type]
+        state=state,
+        profiles=_Profiles(),  # type: ignore[arg-type]
+        files=_Files(),  # type: ignore[arg-type]
+        bot_token="token",
+        owner_tenant_id="tenant-a",
+        allowed_user_ids="7",
+        allowed_usernames=None,
+    )
+    return relay, client, state
+
+
+def _update(update_id: int, *, chat_id: int = 9, text: str = "work") -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "chat": {"id": chat_id},
+            "from": {"id": 7, "username": "owner"},
+            "text": text,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_approval_replaces_transient_progress_message(tmp_path: Path) -> None:
+    relay, client, state = _relay(tmp_path, agent=_ApprovalAgent())
+
+    await relay.handle_update(_update(4, text="release"))
+
+    assert [message["text"] for message in client.messages] == [
+        "Preparing the change",
+        "Approval required for source_release: Release the candidate",
+    ]
+    assert client.deleted == [{"chat_id": 9, "message_id": 1}]
+    assert len(state.load()["pending_approvals"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_owner_processing_claims_once_and_sets_run_idempotency(
+    tmp_path: Path,
+) -> None:
+    agent = _BlockingAgent()
+    relay, _, state = _relay(tmp_path, agent=agent)
+    accepted = await relay.accept_update(_update(42, text="change source"))
+
+    first = asyncio.create_task(relay.process_update(accepted))
+    await agent.started.wait()
+    duplicate = asyncio.create_task(relay.process_update(accepted))
+    await duplicate
+
+    assert len(agent.requests) == 1
+    assert agent.requests[0].idempotency_key == "telegram:update:42"
+    assert accepted.ingress_key is not None
+    preparation = state.owner_update_preparation(accepted.ingress_key)
+    assert preparation is not None
+    assert preparation["thread_id"] == agent.requests[0].context.thread_id
+
+    agent.release.set()
+    await first
+    assert state.owner_update(accepted.ingress_key) is None
+
+
+@pytest.mark.asyncio
+async def test_retry_reuses_durable_run_preparation(tmp_path: Path) -> None:
+    failed = _FailingAgent()
+    relay, _, state = _relay(tmp_path, agent=failed)
+    accepted = await relay.accept_update(_update(43, text="survive restart"))
+
+    with pytest.raises(RuntimeError, match="worker stopped"):
+        await relay.process_update(accepted)
+    assert accepted.ingress_key is not None
+    preparation = state.owner_update_preparation(accepted.ingress_key)
+    assert preparation is not None
+
+    recovered = _Agent()
+    recovered_relay, _, _ = _relay(tmp_path, agent=recovered, state=state)
+    await recovered_relay.process_update(accepted)
+
+    assert len(failed.requests) == len(recovered.requests) == 1
+    original = failed.requests[0]
+    retry = recovered.requests[0]
+    assert retry.idempotency_key == original.idempotency_key
+    assert retry.context.thread_id == original.context.thread_id
+    assert retry.context.agent_spec == original.context.agent_spec
+    assert retry.file_ids == original.file_ids
+
+
+@pytest.mark.asyncio
+async def test_owner_runs_are_concurrent_across_chats_and_ordered_within_chat(
+    tmp_path: Path,
+) -> None:
+    concurrent = _ConcurrentAgent()
+    relay, _, _ = _relay(tmp_path, agent=concurrent)
+
+    await relay.accept_update(_update(51, text="first chat"))
+    await relay.accept_update(_update(52, chat_id=10, text="second chat"))
+    await relay.start()
+    try:
+        await asyncio.wait_for(concurrent.both_started.wait(), timeout=1)
+        concurrent.release.set()
+        for _ in range(50):
+            if not relay._owner_updates_inflight:  # noqa: SLF001
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await relay.shutdown()
+    assert {request.text for request in concurrent.requests} == {"first chat", "second chat"}
+
+    ordered = _ConcurrentAgent()
+    ordered_relay, _, _ = _relay(tmp_path / "ordered", agent=ordered)
+    first = asyncio.create_task(ordered_relay.handle_update(_update(53, text="first")))
+    await ordered.first_started.wait()
+    second = asyncio.create_task(ordered_relay.handle_update(_update(54, text="second")))
+    await asyncio.sleep(0.02)
+    assert [request.text for request in ordered.requests] == ["first"]
+    ordered.release.set()
+    await asyncio.gather(first, second)
+    assert [request.text for request in ordered.requests] == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_bypasses_active_chat_run_and_cleans_approval_state(tmp_path: Path) -> None:
+    agent = _BlockingAgent()
+    relay, client, state = _relay(tmp_path, agent=agent)
+    running = asyncio.create_task(relay.handle_update(_update(61, text="keep working")))
+    await agent.started.wait()
+    await relay._send_approval(  # noqa: SLF001
+        chat_id=9,
+        tenant_id="tenant-a",
+        run_id="run_blocked",
+        approval={"approval_id": "approval_1", "tool_name": "source_release"},
+    )
+
+    await asyncio.wait_for(relay.handle_update(_update(62, text="/cancel")), timeout=1)
+    await running
+
+    assert len(agent.cancelled_threads) == 1
+    assert state.load()["pending_approvals"] == {}
+    assert any(message["text"] == "Cancelled the active run." for message in client.messages)

--- a/tests/test_deep_agent_telegram_relay.py
+++ b/tests/test_deep_agent_telegram_relay.py
@@ -14,6 +14,7 @@ from opentulpa.deep_agent.contracts import (
     AgentRunRequest,
     ApprovalDecision,
 )
+from opentulpa.inference import InferenceModel
 from opentulpa.interfaces.telegram.business import TelegramBusinessService
 from opentulpa.interfaces.telegram.deep_agent_relay import DeepAgentTelegramRelay
 from opentulpa.interfaces.telegram.delivery import TelegramOwnerDelivery
@@ -37,11 +38,26 @@ class _Files:
 class _Client:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] = []
+        self.edits: list[dict[str, Any]] = []
+        self.deleted: list[dict[str, Any]] = []
+        self.commands: list[dict[str, str]] = []
         self.callbacks: list[dict[str, Any]] = []
 
     async def send_message(self, **kwargs: Any) -> dict[str, Any]:
         self.messages.append(kwargs)
-        return {"ok": True}
+        return {"ok": True, "result": {"message_id": len(self.messages)}}
+
+    async def edit_message_text(self, **kwargs: Any) -> bool:
+        self.edits.append(kwargs)
+        return True
+
+    async def set_my_commands(self, *, commands: list[dict[str, str]]) -> bool:
+        self.commands = commands
+        return True
+
+    async def delete_message(self, **kwargs: Any) -> bool:
+        self.deleted.append(kwargs)
+        return True
 
     async def answer_callback_query(self, **kwargs: Any) -> bool:
         self.callbacks.append(kwargs)
@@ -56,6 +72,18 @@ class _Agent:
     def __init__(self) -> None:
         self.requests: list[AgentRunRequest] = []
         self.decisions: list[tuple[str, ApprovalDecision]] = []
+        self.threads: set[tuple[str, str]] = set()
+        self.inference = {
+            "revision": 0,
+            "selection": None,
+            "effective": {
+                "provider": "api",
+                "model": "api/default",
+                "reasoning_effort": "low",
+                "service_tier": None,
+                "fallback_to_api": False,
+            },
+        }
 
     async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
         self.requests.append(request)
@@ -71,6 +99,88 @@ class _Agent:
         self.decisions.append((run_id, decision))
         yield AgentRunEvent("run.started", run_id, 3, "now", {"resumed": True})
         yield AgentRunEvent("run.completed", run_id, 4, "now", {"text": "approved"})
+
+    async def ensure_thread(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+        channel: str,
+    ) -> None:
+        assert channel == "telegram"
+        self.threads.add((tenant_id, thread_id))
+
+    async def get_thread_inference(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+    ) -> dict[str, Any] | None:
+        return self.inference if (tenant_id, thread_id) in self.threads else None
+
+    async def update_thread_inference(
+        self,
+        *,
+        tenant_id: str,
+        thread_id: str,
+        expected_revision: int,
+        selection: Any,
+    ) -> dict[str, Any] | None:
+        if (tenant_id, thread_id) not in self.threads:
+            return None
+        assert expected_revision == self.inference["revision"]
+        self.inference = {
+            "revision": expected_revision + 1,
+            "selection": selection.model_dump(mode="json"),
+            "effective": selection.model_dump(mode="json"),
+        }
+        return self.inference
+
+class _Inference:
+    def __init__(self) -> None:
+        self.connected = False
+
+    def codex_connected(self, tenant_id: str) -> bool:
+        assert tenant_id == "tenant-a"
+        return self.connected
+
+    async def status(self, tenant_id: str) -> dict[str, Any]:
+        return {"codex": {"connected": self.codex_connected(tenant_id)}}
+
+    async def models(
+        self,
+        tenant_id: str,
+        provider: str,
+        *,
+        query: str = "",
+    ) -> tuple[InferenceModel, ...]:
+        assert tenant_id == "tenant-a"
+        model = InferenceModel(
+            provider=provider,
+            id="gpt-5.3-codex" if provider == "codex" else "api/default",
+            reasoning_efforts=("low", "high", "ultra"),
+            default_reasoning_effort="low",
+        )
+        return (model,) if not query or query in model.id else ()
+
+    async def start_device_login(self, tenant_id: str) -> dict[str, Any]:
+        assert tenant_id == "tenant-a"
+        return {
+            "id": "login_1",
+            "status": "pending",
+            "verification_url": "https://auth.openai.com/codex/device",
+            "user_code": "ABCD-EFGH",
+        }
+
+    async def get_device_login(
+        self,
+        tenant_id: str,
+        login_id: str,
+    ) -> dict[str, Any] | None:
+        assert tenant_id == "tenant-a"
+        assert login_id == "login_1"
+        self.connected = True
+        return {"id": login_id, "status": "authorized"}
 
 
 class _GatedAgent(_Agent):
@@ -89,6 +199,30 @@ class _GatedAgent(_Agent):
         await self.resume_accepted.wait()
         yield AgentRunEvent("run.started", run_id, 3, "now", {"resumed": True})
         yield AgentRunEvent("run.completed", run_id, 4, "now", {"text": "approved"})
+
+
+class _ProgressAgent(_Agent):
+    async def stream(self, request: AgentRunRequest) -> AsyncIterator[AgentRunEvent]:
+        self.requests.append(request)
+        yield AgentRunEvent("run.started", "run_1", 1, "now", {})
+        yield AgentRunEvent("message.delta", "run_1", 2, "now", {"text": "Inspecting"})
+        yield AgentRunEvent(
+            "tool.started",
+            "run_1",
+            3,
+            "now",
+            {"name": "source_shell"},
+        )
+        await asyncio.sleep(0.02)
+        yield AgentRunEvent(
+            "tool.completed",
+            "run_1",
+            4,
+            "now",
+            {"name": "source_shell"},
+        )
+        yield AgentRunEvent("message.delta", "run_1", 5, "now", {"text": "Finished"})
+        yield AgentRunEvent("run.completed", "run_1", 6, "now", {"text": "All done"})
 
 
 class _FailOnceAgent(_Agent):
@@ -155,6 +289,7 @@ def _relay(
     agent: _Agent | None = None,
     owner_tenant_id: str | None = "tenant-a",
     allowed_user_ids: str = "7",
+    inference: _Inference | None = None,
 ) -> tuple[DeepAgentTelegramRelay, _Agent, _Client, TelegramStateStore]:
     agent = agent or _Agent()
     client = _Client()
@@ -169,6 +304,7 @@ def _relay(
         owner_tenant_id=owner_tenant_id,
         allowed_user_ids=allowed_user_ids,
         allowed_usernames=None,
+        inference=inference,
     )
     return relay, agent, client, state
 
@@ -180,11 +316,19 @@ def test_edited_arguments_reject_exponent_overflow() -> None:
 
 @pytest.mark.asyncio
 async def test_health_tracks_durable_owner_inbox_dispatcher(tmp_path: Path) -> None:
-    relay, _, _, _ = _relay(tmp_path)
+    relay, _, client, _ = _relay(tmp_path)
 
     assert relay.healthy() is False
     await relay.start()
     assert relay.healthy() is True
+    assert {command["command"] for command in client.commands} == {
+        "fresh",
+        "model",
+        "models",
+        "reasoning",
+        "codex",
+        "cancel",
+    }
     await relay.shutdown()
     assert relay.healthy() is False
 
@@ -206,7 +350,74 @@ async def test_owner_update_injects_tenant_context_and_reuses_thread(tmp_path: P
     assert [request.context.tenant_id for request in agent.requests] == ["tenant-a", "tenant-a"]
     assert agent.requests[0].context.thread_id == agent.requests[1].context.thread_id
     assert agent.requests[0].context.actor_id == "telegram:7"
-    assert [message["text"] for message in client.messages] == ["hello", "hello"]
+    assert [message["text"] for message in client.messages] == [
+        "hello",
+        "hello",
+        "hello",
+        "hello",
+    ]
+    assert [item["message_id"] for item in client.deleted] == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_owner_progress_edits_one_message_without_concatenating_segments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opentulpa.interfaces.telegram.run_output._EDIT_MIN_INTERVAL_SECONDS",
+        0.01,
+    )
+    relay, _, client, _ = _relay(tmp_path, agent=_ProgressAgent())
+
+    await relay.handle_update(
+        {
+            "update_id": 1,
+            "message": {
+                "chat": {"id": 9},
+                "from": {"id": 7, "username": "owner"},
+                "text": "change the source",
+            },
+        }
+    )
+
+    assert [message["text"] for message in client.messages] == ["Inspecting", "All done"]
+    assert client.edits[0]["text"] == (
+        "Inspecting\n\nWorking: Working on OpenTulpa source..."
+    )
+    assert client.deleted == [{"chat_id": 9, "message_id": 1}]
+    assert all("InspectingFinished" not in edit["text"] for edit in client.edits)
+
+
+@pytest.mark.asyncio
+async def test_telegram_codex_login_model_and_reasoning_commands(tmp_path: Path) -> None:
+    inference = _Inference()
+    relay, agent, client, _ = _relay(tmp_path, inference=inference)
+
+    async def send(update_id: int, text: str) -> None:
+        await relay.handle_update(
+            {
+                "update_id": update_id,
+                "message": {
+                    "chat": {"id": 9},
+                    "from": {"id": 7, "username": "owner"},
+                    "text": text,
+                },
+            }
+        )
+
+    await send(1, "/codex login")
+    assert "ABCD-EFGH" in client.messages[-1]["text"]
+    await send(2, "/codex status")
+    assert client.messages[-1]["text"].startswith("Codex is connected")
+    await send(3, "/models codex")
+    assert "gpt-5.3-codex" in client.messages[-1]["text"]
+    await send(4, "/model codex gpt-5.3-codex high")
+    assert agent.inference["effective"]["provider"] == "codex"
+    assert agent.inference["effective"]["reasoning_effort"] == "high"
+    await send(5, "/reasoning ultra")
+    assert agent.inference["effective"]["reasoning_effort"] == "ultra"
+    assert agent.requests == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_evolution_supervisor.py
+++ b/tests/test_evolution_supervisor.py
@@ -349,7 +349,8 @@ async def test_interactive_source_session_survives_restart_and_releases(
     assert shell["exit_code"] == 0
     assert shell["output"] == "source-edited\n"
     assert shell["dirty"] is True
-    assert "@app.get('/status')" in shell["diff"]
+    assert "diff" not in shell
+    assert shell["diff_sha256"]
     await first.shutdown()
 
     resumed = _supervisor(tmp_path, source, activator=activator)

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -709,17 +709,11 @@ async def test_thread_preference_is_revisioned_owned_and_run_plan_is_pinned(tmp_
     context = _context()
     await service.start()
     try:
-        await service.create_thread(
+        await service.ensure_thread(
             tenant_id=context.tenant_id,
+            thread_id=context.thread_id,
             channel="web",
-            title="Inference test",
         )
-        db = service._require_runs_db()  # noqa: SLF001
-        await db.execute(
-            "UPDATE agent_threads SET thread_id = ? WHERE tenant_id = ?",
-            (context.thread_id, context.tenant_id),
-        )
-        await db.commit()
         selected = InferenceSelection(
             provider="api",
             model="test-model",

--- a/tests/test_telegram_run_output.py
+++ b/tests/test_telegram_run_output.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from opentulpa.interfaces.telegram.run_output import TelegramRunOutput
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+        self.edits: list[dict[str, Any]] = []
+        self.deleted: list[dict[str, Any]] = []
+
+    async def send_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.messages.append(kwargs)
+        return {"ok": True, "result": {"message_id": len(self.messages)}}
+
+    async def edit_message_text(self, **kwargs: Any) -> bool:
+        self.edits.append(kwargs)
+        return True
+
+    async def delete_message(self, **kwargs: Any) -> bool:
+        self.deleted.append(kwargs)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_run_output_coalesces_tool_bursts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opentulpa.interfaces.telegram.run_output._EDIT_MIN_INTERVAL_SECONDS",
+        0.01,
+    )
+    client = _Client()
+    output = TelegramRunOutput(client=client, chat_id=9)  # type: ignore[arg-type]
+
+    await output.delta("Checking")
+    await output.tool_started("source_shell")
+    await output.tool_started("write_todos")
+    await output.tool_started("source_status")
+    await asyncio.sleep(0.02)
+
+    assert len(client.edits) == 1
+    assert client.edits[0]["text"].endswith("Working: Reviewing OpenTulpa changes...")
+
+    await output.finish("Done")
+    assert client.deleted == [{"chat_id": 9, "message_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_run_output_keeps_latest_text_within_telegram_limit() -> None:
+    client = _Client()
+    output = TelegramRunOutput(client=client, chat_id=9)  # type: ignore[arg-type]
+
+    await output.delta(("old-" * 1_200) + "LATEST_PROGRESS")
+
+    preview = client.messages[0]["text"]
+    assert len(preview) <= 3_500
+    assert preview.startswith("[Earlier progress omitted]")
+    assert preview.endswith("LATEST_PROGRESS")
+
+
+@pytest.mark.asyncio
+async def test_run_output_preserves_whitespace_between_deltas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opentulpa.interfaces.telegram.run_output._EDIT_MIN_INTERVAL_SECONDS",
+        0,
+    )
+    client = _Client()
+    output = TelegramRunOutput(client=client, chat_id=9)  # type: ignore[arg-type]
+
+    await output.delta("Hello ")
+    await output.delta("world")
+
+    assert client.edits[-1]["text"] == "Hello world"


### PR DESCRIPTION
## Summary

- raise default owner runs to 500 model calls and two hours with a safe legacy-default migration
- make Telegram progress bounded, rate-limited, durable across retries, cancellable, and concurrent across chats
- add Telegram Codex login plus per-thread model and reasoning controls
- keep self-editing concise by returning full source diffs only from `source_status`

## Why

Long Telegram code-editing runs could exhaust the old budget, produce unreadable accumulated deltas, block other updates, and replay preparation after a restart. This keeps the shared agent runtime intact while making Telegram a reliable interface to the same capabilities available through the TUI.

## Validation

- `python -m pytest -q`: 1034 passed, 5 skipped
- `ruff check .`: passed
- `mypy src`: passed
- `git diff --check`: passed