### PR TITLE
Fix Telegram Codex device login response

### DIFF
--- a/src/opentulpa/capability_workers/telegram_controls.py
+++ b/src/opentulpa/capability_workers/telegram_controls.py
@@ -189,7 +189,7 @@ class TelegramInferenceControls:
                 )
                 return
             login = await self._agent.start_codex_login()
-            login_id = str(login["id"])
+            login_id = str(login["login_id"])
             self._state.set_codex_login(chat_id, login_id)
             await self._send(
                 chat_id,

--- a/tests/test_capability_worker_agent_api.py
+++ b/tests/test_capability_worker_agent_api.py
@@ -357,13 +357,16 @@ async def test_interface_controls_use_scoped_agent_api_routes() -> None:
             return httpx.Response(
                 201,
                 json={
-                    "id": "login-1",
+                    "login_id": "login-1",
                     "verification_url": "https://auth.openai.com/device",
                     "user_code": "ABCD-EFGH",
                 },
             )
         if path.endswith("/device-logins/login-1"):
-            return httpx.Response(200, json={"id": "login-1", "status": "pending"})
+            return httpx.Response(
+                200,
+                json={"login_id": "login-1", "status": "pending"},
+            )
         if path.endswith("/cancel"):
             return httpx.Response(200, json={"status": "cancelled"})
         raise AssertionError(request.url)
@@ -392,7 +395,7 @@ async def test_interface_controls_use_scoped_agent_api_routes() -> None:
     assert updated["revision"] == 1
     assert models[0]["id"] == "gpt-5.2-codex"
     assert status["codex"]["connected"] is False
-    assert login["id"] == "login-1"
+    assert login["login_id"] == "login-1"
     assert login_status["status"] == "pending"
     assert cancelled["status"] == "cancelled"
     assert all(request.headers["Authorization"] == "Bearer private-token" for request in requests)

--- a/tests/test_capability_worker_telegram.py
+++ b/tests/test_capability_worker_telegram.py
@@ -143,7 +143,7 @@ class _Agent:
         ]
         self.codex_status: dict[str, Any] = {"codex": {"connected": False}}
         self.codex_login = {
-            "id": "login-1",
+            "login_id": "login-1",
             "verification_url": "https://auth.openai.com/device",
             "user_code": "ABCD-EFGH",
             "status": "pending",
@@ -194,7 +194,7 @@ class _Agent:
         return dict(self.codex_login)
 
     async def get_codex_login(self, login_id: str) -> dict[str, Any]:
-        assert login_id == self.codex_login["id"]
+        assert login_id == self.codex_login["login_id"]
         return dict(self.codex_login)
 
     async def cancel_thread(self, thread_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- consume the Agent API's real `login_id` field in Telegram `/codex login`
- align worker and Agent API contract fixtures with the production response

## Root cause
The API created and persisted the device login, but the Telegram worker read `id` and failed before saving the login or sending the verification code.

## Verification
- `pytest tests/test_inference_service.py tests/test_v2_inference_routes.py tests/test_capability_worker_telegram.py tests/test_capability_worker_agent_api.py -q` (47 passed)
- `ruff check` on changed files
- `git diff --check`