### PR TITLE
Fix host rollback and control-plane consistency

### DIFF
--- a/src/opentulpa/capability_workers/telegram_controls.py
+++ b/src/opentulpa/capability_workers/telegram_controls.py
@@ -214,6 +214,13 @@ class TelegramInferenceControls:
                     "Codex is connected. Use /models codex to select a model.",
                 )
                 return
+            if login_status in {"expired", "failed"}:
+                self._state.set_codex_login(chat_id, None)
+                await self._send(
+                    chat_id,
+                    f"Codex login {login_status}. Run /codex login to start again.",
+                )
+                return
             await self._send(
                 chat_id,
                 (

--- a/src/opentulpa/host/app.py
+++ b/src/opentulpa/host/app.py
@@ -45,6 +45,22 @@ _HOST_HEADERS = {
 }
 
 
+def _resume_log_cursor(
+    *,
+    after: int,
+    last_event_id: str | None,
+    requested_stream_id: str | None,
+    current_stream_id: str,
+) -> int:
+    if requested_stream_id and requested_stream_id != current_stream_id:
+        return 0
+    cursor = max(0, after)
+    try:
+        return max(cursor, max(0, int(last_event_id or "0")))
+    except ValueError:
+        return cursor
+
+
 class _RequestModel(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
@@ -243,19 +259,29 @@ def create_host_app(
         session: Annotated[str | None, Cookie(alias=HOST_SESSION_COOKIE)] = None,
     ) -> dict[str, Any]:
         require_owner(request, authorization, session)
-        return {"logs": service.runtime.logs(after=max(0, after))}
+        return {
+            "stream_id": service.runtime.log_stream_id,
+            "logs": service.runtime.logs(after=max(0, after)),
+        }
 
     @app.get("/_host/api/logs/stream")
     async def log_stream(
         request: Request,
         after: int = 0,
+        stream_id: str | None = None,
+        last_event_id: Annotated[str | None, Header(alias="Last-Event-ID")] = None,
         authorization: Annotated[str | None, Header()] = None,
         session: Annotated[str | None, Cookie(alias=HOST_SESSION_COOKIE)] = None,
     ) -> StreamingResponse:
         require_owner(request, authorization, session)
 
         async def events() -> AsyncIterator[str]:
-            cursor = max(0, after)
+            cursor = _resume_log_cursor(
+                after=after,
+                last_event_id=last_event_id,
+                requested_stream_id=stream_id,
+                current_stream_id=service.runtime.log_stream_id,
+            )
             while not await request.is_disconnected():
                 entries = await service.runtime.wait_for_logs(after=cursor)
                 if not entries:

--- a/src/opentulpa/host/assets/app.js
+++ b/src/opentulpa/host/assets/app.js
@@ -2,6 +2,8 @@ const $ = (id) => document.getElementById(id);
 let current = null;
 let logSource = null;
 let logCount = 0;
+let logStreamId = "";
+let lastLogSequence = 0;
 
 $("connect-command").textContent = `opentulpa connect ${location.origin}`;
 
@@ -68,6 +70,15 @@ async function refresh() {
 }
 
 function addLog(entry) {
+  const incomingStreamId = String(entry.stream_id || "");
+  const incomingSequence = Number(entry.sequence || 0);
+  if (logStreamId && incomingStreamId && incomingStreamId !== logStreamId) {
+    $("logs").replaceChildren();
+    logCount = 0;
+    lastLogSequence = 0;
+  }
+  if (incomingStreamId) logStreamId = incomingStreamId;
+  if (incomingSequence <= lastLogSequence) return;
   const row = document.createElement("div");
   row.className = "log-line";
   const sequence = document.createElement("span");
@@ -82,6 +93,7 @@ function addLog(entry) {
   row.append(sequence, stream, text);
   $("logs").appendChild(row);
   while ($("logs").children.length > 500) $("logs").firstChild.remove();
+  lastLogSequence = incomingSequence;
   logCount += 1;
   $("log-count").textContent = `${logCount} LINES`;
   $("logs").scrollTop = $("logs").scrollHeight;
@@ -93,7 +105,10 @@ async function startLogs() {
     const payload = await request("/_host/api/logs");
     payload.logs.forEach(addLog);
     const last = payload.logs.at(-1)?.sequence || 0;
-    logSource = new EventSource(`/_host/api/logs/stream?after=${last}`);
+    const streamId = encodeURIComponent(payload.stream_id || "");
+    logSource = new EventSource(
+      `/_host/api/logs/stream?after=${last}&stream_id=${streamId}`
+    );
     logSource.onmessage = (event) => addLog(JSON.parse(event.data));
   } catch (_) { /* Session state will be refreshed by the next owner action. */ }
 }

--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import secrets
 import socket
 import sys
 from collections import deque
@@ -31,6 +32,7 @@ class RuntimeUnavailableError(RuntimeError):
 class RuntimeLogEntry(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    stream_id: str
     sequence: int
     timestamp: datetime
     stream: str
@@ -71,6 +73,7 @@ class RuntimeSupervisor:
         self._error: str | None = None
         self._logs: deque[RuntimeLogEntry] = deque(maxlen=2_000)
         self._redaction_values: set[str] = set()
+        self._log_stream_id = secrets.token_urlsafe(12)
         self._sequence = 0
         self._log_changed = asyncio.Condition()
         self._lock = asyncio.Lock()
@@ -88,6 +91,10 @@ class RuntimeSupervisor:
     @property
     def error(self) -> str | None:
         return self._error
+
+    @property
+    def log_stream_id(self) -> str:
+        return self._log_stream_id
 
     @property
     def revision(self) -> int | None:
@@ -311,6 +318,7 @@ class RuntimeSupervisor:
         for value in sorted(self._redaction_values, key=len, reverse=True):
             safe_text = safe_text.replace(value, "[redacted]")
         entry = RuntimeLogEntry(
+            stream_id=self._log_stream_id,
             sequence=self._sequence,
             timestamp=datetime.now(UTC),
             stream=stream,

--- a/src/opentulpa/host/service.py
+++ b/src/opentulpa/host/service.py
@@ -94,6 +94,9 @@ class HostService:
             elif self.runtime.revision != previous.revision:
                 with suppress(Exception):
                     await self.runtime.replace(previous, rollback=previous)
+                    await self._configure_telegram(previous)
+                    if previous.telegram_bot_token is None:
+                        self.runtime.clear_telegram_identity()
             raise HostActivationError(self._safe_error(exc)) from exc
         finally:
             self._activating = False

--- a/tests/test_capability_worker_agent_api.py
+++ b/tests/test_capability_worker_agent_api.py
@@ -358,7 +358,7 @@ async def test_interface_controls_use_scoped_agent_api_routes() -> None:
                 201,
                 json={
                     "login_id": "login-1",
-                    "verification_url": "https://auth.openai.com/device",
+                    "verification_url": "https://auth.openai.com/codex/device",
                     "user_code": "ABCD-EFGH",
                 },
             )

--- a/tests/test_capability_worker_telegram.py
+++ b/tests/test_capability_worker_telegram.py
@@ -144,7 +144,7 @@ class _Agent:
         self.codex_status: dict[str, Any] = {"codex": {"connected": False}}
         self.codex_login = {
             "login_id": "login-1",
-            "verification_url": "https://auth.openai.com/device",
+            "verification_url": "https://auth.openai.com/codex/device",
             "user_code": "ABCD-EFGH",
             "status": "pending",
         }
@@ -425,6 +425,34 @@ async def test_inference_and_codex_commands_use_agent_api_without_starting_runs(
         "Reasoning updated:",
         "Connect Codex:",
     ]
+
+
+@pytest.mark.parametrize("status", ["expired", "failed"])
+@pytest.mark.asyncio
+async def test_terminal_codex_login_status_starts_over(
+    tmp_path: Path,
+    status: str,
+) -> None:
+    telegram = _Telegram([_message(1, text="/codex status")])
+    agent = _Agent()
+    agent.codex_login["status"] = status
+    state = TelegramWorkerState(tmp_path / "worker.json")
+    state.pair(user_id=7, chat_id=9)
+    state.set_codex_login(9, "login-1")
+    worker = TelegramInterfaceWorker(
+        telegram=telegram,
+        agent=agent,
+        state=state,
+        pairing_code=None,
+        poll_timeout_seconds=1,
+    )
+
+    assert await worker.poll_once() == 1
+
+    assert state.codex_login(9) == ""
+    assert telegram.messages[-1]["text"] == (
+        f"Codex login {status}. Run /codex login to start again."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_host_app.py
+++ b/tests/test_host_app.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
-from opentulpa.host.app import create_host_app
+from opentulpa.host.app import _resume_log_cursor, create_host_app
 from opentulpa.host.models import HostConfigInput
 from opentulpa.host.store import HostStore
 from opentulpa.secrets.cipher import AesGcmHostKeyCipher
@@ -17,6 +17,7 @@ class _Runtime:
     revision = None
     error = None
     endpoint = None
+    log_stream_id = "stream-current"
 
     def logs(self, *, after: int = 0) -> list[Any]:
         return []
@@ -83,7 +84,29 @@ def test_unconfigured_host_stays_healthy_and_redirects_chat_to_setup(tmp_path: P
         assert "OPEN CHAT" not in console.text
         script = client.get("/_host/assets/app.js")
         assert "opentulpa connect" in script.text
+        assert "stream_id" in script.text
         assert "open-chat" not in script.text
+
+
+def test_log_cursor_resumes_same_host_and_resets_after_host_replacement() -> None:
+    assert (
+        _resume_log_cursor(
+            after=5,
+            last_event_id="9",
+            requested_stream_id="stream-current",
+            current_stream_id="stream-current",
+        )
+        == 9
+    )
+    assert (
+        _resume_log_cursor(
+            after=9,
+            last_event_id="12",
+            requested_stream_id="stream-previous",
+            current_stream_id="stream-current",
+        )
+        == 0
+    )
 
 
 def test_remote_claim_requires_setup_token_and_sets_owner_session(tmp_path: Path) -> None:
@@ -105,6 +128,10 @@ def test_remote_claim_requires_setup_token_and_sets_owner_session(tmp_path: Path
         status = client.get("/_host/api/status").json()
         assert status["claimed"] is True
         assert status["authenticated"] is True
+        assert client.get("/_host/api/logs").json() == {
+            "stream_id": "stream-current",
+            "logs": [],
+        }
 
 
 def test_owner_can_activate_first_config_without_exposing_secrets(tmp_path: Path) -> None:

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -63,6 +63,7 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
     assert "TELEGRAM_BOT_TOKEN" not in environment
     assert "TELEGRAM_WEBHOOK_SECRET" not in environment
     line = runtime.logs()[0].text
+    assert runtime.logs()[0].stream_id == runtime.log_stream_id
     assert "provider-secret-value" not in line
     assert "internal-owner-secret-value" not in line
     assert "hunter2" not in line

--- a/tests/test_host_service.py
+++ b/tests/test_host_service.py
@@ -52,7 +52,8 @@ class _Service(HostService):
             store=store,
             runtime=runtime,  # type: ignore[arg-type]
         )
-        self.fail_capability = False
+        self.fail_revision: int | None = None
+        self.configured_revisions: list[int] = []
 
     async def _validate_external(
         self, value: HostConfigInput, *, previous: HostConfig | None
@@ -60,7 +61,8 @@ class _Service(HostService):
         return None
 
     async def _configure_telegram(self, config: HostConfig) -> None:
-        if self.fail_capability:
+        self.configured_revisions.append(config.revision)
+        if config.revision == self.fail_revision:
             raise HostActivationError("Telegram worker failed readiness")
 
 
@@ -109,7 +111,7 @@ async def test_failed_candidate_keeps_previous_revision_and_runtime(tmp_path: Pa
     runtime = _Runtime()
     runtime.current = first
     service = _Service(store=store, runtime=runtime)
-    service.fail_capability = True
+    service.fail_revision = first.revision + 1
 
     with pytest.raises(HostActivationError, match="Telegram worker failed readiness"):
         await service.apply(
@@ -123,6 +125,7 @@ async def test_failed_candidate_keeps_previous_revision_and_runtime(tmp_path: Pa
     assert runtime.current is not None
     assert runtime.current.revision == first.revision
     assert runtime.replacements == [first.revision + 1, first.revision]
+    assert service.configured_revisions == [first.revision + 1, first.revision]
     assert store.get(first.revision + 1).status == "failed"  # type: ignore[union-attr]
     await service.shutdown()
 

--- a/tests/test_v2_inference_routes.py
+++ b/tests/test_v2_inference_routes.py
@@ -64,7 +64,7 @@ class _Inference:
         return {
             "login_id": "login-1",
             "status": "pending",
-            "verification_url": "https://auth.openai.com/device",
+            "verification_url": "https://auth.openai.com/codex/device",
             "user_code": "ABCD-EFGH",
             "interval_seconds": 5,
             "expires_at": "2026-01-01T00:10:00+00:00",


### PR DESCRIPTION
## Summary
- restore the previous Telegram capability binding when host activation rolls back
- treat expired and failed Codex device logins as terminal so users can restart login
- make host log streaming restart-safe with stream identities and Last-Event-ID support
- align Codex verification URL fixtures with the production route

## Verification
- 26 passed, 3 skipped: `tests/test_host_*.py`
- 105 passed: `tests/test_capability_*.py`
- 49 passed: `tests/test_v2_*.py`
- `ruff check` on changed Python files
- `node --check src/opentulpa/host/assets/app.js`
- `git diff --check`