### PR TITLE
Isolate hosted owner identities

### DIFF
--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -342,6 +342,9 @@ class RuntimeSupervisor:
     ) -> dict[str, str]:
         source_root = project_root or self._project_root
         environment = os.environ.copy()
+        owner_customer_id = (
+            str(environment.get("OPENTULPA_OWNER_CUSTOMER_ID") or "").strip() or "owner"
+        )
         for key in (
             "TELEGRAM_BOT_TOKEN",
             "TELEGRAM_ALLOWED_USER_IDS",
@@ -360,7 +363,7 @@ class RuntimeSupervisor:
                 "OPENAI_COMPATIBLE_BASE_URL": config.base_url,
                 "LLM_MODEL": config.model,
                 "OPENTULPA_OWNER_TOKEN": config.internal_runtime_token.get_secret_value(),
-                "OPENTULPA_OWNER_CUSTOMER_ID": "owner",
+                "OPENTULPA_OWNER_CUSTOMER_ID": owner_customer_id,
                 "OPENTULPA_INTERNAL_AGENT_API_URL": f"http://127.0.0.1:{port}",
                 "OPENTULPA_DYNAMIC_HOST": "1",
                 "PYTHONPATH": str(source_root / "src"),

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -36,6 +36,7 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
 ) -> None:
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "host-telegram-token")
     monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "host-webhook-secret")
+    monkeypatch.setenv("OPENTULPA_OWNER_CUSTOMER_ID", "opentulpa-gf")
     runtime = RuntimeSupervisor(project_root=tmp_path, data_root=tmp_path / "data")
     runtime.configure_evolution_control(
         base_url="http://127.0.0.1:8000/bootstrap/internal/v1/evolution",
@@ -55,6 +56,7 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
 
     assert environment["OPENAI_COMPATIBLE_API_KEY"] == "provider-secret-value"
     assert environment["OPENTULPA_OWNER_TOKEN"] == "internal-owner-secret-value"
+    assert environment["OPENTULPA_OWNER_CUSTOMER_ID"] == "opentulpa-gf"
     assert environment["OPENTULPA_BOOTSTRAP_EVOLUTION_TOKEN"] == "e" * 48
     assert environment["OPENTULPA_BOOTSTRAP_EVOLUTION_URL"].endswith(
         "/bootstrap/internal/v1/evolution"
@@ -68,6 +70,9 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
     assert "internal-owner-secret-value" not in line
     assert "hunter2" not in line
     assert line.count("[redacted]") == 3
+
+    monkeypatch.delenv("OPENTULPA_OWNER_CUSTOMER_ID")
+    assert runtime._child_environment(config, port=8124)["OPENTULPA_OWNER_CUSTOMER_ID"] == "owner"
     await runtime.shutdown()
 
 


### PR DESCRIPTION
## Summary
- let the stable host honor a trusted deployment-specific `OPENTULPA_OWNER_CUSTOMER_ID`
- preserve `owner` as the default for existing deployments
- prevent separate hosted instances sharing one Composio key from sharing the same external user namespace

## Verification
- `11 passed`: host runtime, app, and service tests
- `ruff check src/opentulpa/host/runtime.py tests/test_host_runtime.py`
- `git diff --check`