### PR TITLE
Restore zero-config tenant shell and harden integration listing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,11 +73,11 @@ OPENTULPA_OPEN_BROWSER=auto
 # managed runtime images. Values: browser, integrations, documents, research, bundled.
 OPENTULPA_EXTRAS=
 
-# Tenant shell isolation. Railway deployments receive the scoped token and
-# environment id from the OpenTulpa deployment dashboard.
+# Tenant shell isolation. Auto uses local OCI first, then the bundled restricted
+# Linux process sandbox. Railway-hosted sandbox VMs are an optional stronger tier.
 SANDBOX_PROVIDER=auto
 RAILWAY_TOKEN=
-RAILWAY_ENVIRONMENT_ID=
+OPENTULPA_SANDBOX_RAILWAY_ENVIRONMENT_ID=
 RAILWAY_SANDBOX_IDLE_TIMEOUT_MINUTES=30
 
 # Optional: Telegram bot

--- a/.github/workflows/tui.yml
+++ b/.github/workflows/tui.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - runner: macos-14
             target: darwin-arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             target: darwin-x64
           - runner: ubuntu-24.04-arm
             target: linux-arm64

--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -63,6 +63,7 @@ from opentulpa.core.config import (
 from opentulpa.core.public_urls import resolve_public_base_url
 from opentulpa.deep_agent.contracts import AgentRunRequest, AgentRunSnapshot
 from opentulpa.deep_agent.dynamic_tools import TenantDynamicToolRegistry
+from opentulpa.deep_agent.process_sandbox import RestrictedProcessExecutionProvider
 from opentulpa.deep_agent.railway_sandbox import RailwaySandboxExecutionProvider
 from opentulpa.deep_agent.sandbox import (
     TenantContainerPolicy,
@@ -352,6 +353,26 @@ def _sandbox_execution_configuration(
             allow_desktop_vm=allow_desktop_vm,
         )
     except (OSError, RuntimeError) as exc:
+        if provider == "auto" and RestrictedProcessExecutionProvider.supported():
+            logger.warning(
+                "isolated OCI sandbox is unavailable (%s); using the restricted "
+                "unprivileged process sandbox",
+                exc,
+            )
+            return settings.sandbox_image, RestrictedProcessExecutionProvider(
+                policy=TenantContainerPolicy(
+                    image=settings.sandbox_image,
+                    cpu_limit=settings.sandbox_cpu_limit,
+                    memory_limit=settings.sandbox_memory_limit,
+                    pid_limit=settings.sandbox_pid_limit,
+                    timeout_seconds=settings.sandbox_timeout_seconds,
+                    max_output_bytes=settings.sandbox_max_output_bytes,
+                    max_file_bytes=settings.sandbox_max_file_bytes,
+                    max_workspace_entries=settings.sandbox_max_workspace_entries,
+                    network_enabled=True,
+                ),
+                max_workspace_bytes=settings.railway_sandbox_max_sync_bytes,
+            )
         logger.warning("tenant sandbox shell is unavailable: %s", exc)
         return settings.sandbox_image, _UnavailableSandboxExecutionProvider()
     return image, None

--- a/src/opentulpa/application/product_tools.py
+++ b/src/opentulpa/application/product_tools.py
@@ -17,6 +17,7 @@ from typing import Any, Protocol, cast
 
 from pydantic import BaseModel
 
+from opentulpa.integrations.tenant_composio import ComposioProviderError
 from opentulpa.integrations.web_search import WebSearchProviderError
 from opentulpa.repositories.providers import RepositorySandboxError
 from opentulpa.repositories.service import RepositoryWorkspaceError
@@ -832,6 +833,12 @@ class ProductToolApplication:
             value = await _resolve(call())
         except ProductToolApplicationError:
             raise
+        except ComposioProviderError as exc:
+            raise ProductToolApplicationError(
+                "integration_provider_failed",
+                "The integration provider request failed.",
+                retryable=True,
+            ) from exc
         except PermissionError as exc:
             raise ProductToolApplicationError(
                 "not_found",

--- a/src/opentulpa/core/config.py
+++ b/src/opentulpa/core/config.py
@@ -134,7 +134,8 @@ class Settings(BaseSettings):
         default="auto",
         description=(
             "Tenant command provider: auto uses Railway when project credentials are present "
-            "and local OCI otherwise; railway and local require that provider explicitly."
+            "and otherwise prefers local OCI before the restricted Linux process sandbox; "
+            "railway and local require that provider explicitly."
         ),
     )
     railway_sandbox_idle_timeout_minutes: int = Field(default=30, ge=1, le=120)

--- a/src/opentulpa/deep_agent/process_sandbox.py
+++ b/src/opentulpa/deep_agent/process_sandbox.py
@@ -1,0 +1,93 @@
+"""Restricted zero-config command execution for single-host deployments."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from pathlib import Path
+
+from deepagents.backends.protocol import ExecuteResponse
+
+from opentulpa.deep_agent.sandbox import TenantContainerPolicy
+from opentulpa.evolution.sandbox import (
+    CandidateProcessBackend,
+    CandidateSandboxPolicy,
+)
+
+
+class RestrictedProcessExecutionProvider:
+    """Run tenant commands as a resource-limited user with a scrubbed environment."""
+
+    def __init__(
+        self,
+        *,
+        policy: TenantContainerPolicy,
+        max_workspace_bytes: int,
+    ) -> None:
+        self._policy = policy
+        self._max_workspace_bytes = max(max_workspace_bytes, policy.max_file_bytes)
+
+    @staticmethod
+    def supported() -> bool:
+        return CandidateProcessBackend.supported()
+
+    def execute(
+        self,
+        *,
+        tenant_id: str,
+        command: str,
+        timeout: int,
+        workspace: Path | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecuteResponse:
+        del tenant_id
+        if workspace is not None:
+            return self._execute(
+                workspace=workspace,
+                command=command,
+                timeout=timeout,
+                cancel_event=cancel_event,
+            )
+        with tempfile.TemporaryDirectory(prefix="opentulpa-tenant-process-") as temporary:
+            root = Path(temporary)
+            workspace_root = root / "workspace"
+            workspace_root.mkdir()
+            return self._execute(
+                workspace=workspace_root,
+                command=command,
+                timeout=timeout,
+                cancel_event=cancel_event,
+            )
+
+    def _execute(
+        self,
+        *,
+        workspace: Path,
+        command: str,
+        timeout: int,
+        cancel_event: threading.Event | None,
+    ) -> ExecuteResponse:
+        backend = CandidateProcessBackend(
+            workspace=workspace,
+            allowed_root=workspace.parent,
+            policy=CandidateSandboxPolicy(
+                image=self._policy.image,
+                cpu_limit=self._policy.cpu_limit,
+                memory_limit=self._policy.memory_limit,
+                pid_limit=self._policy.pid_limit,
+                timeout_seconds=self._policy.timeout_seconds,
+                max_output_bytes=self._policy.max_output_bytes,
+                max_file_bytes=self._policy.max_file_bytes,
+                max_total_bytes=self._max_workspace_bytes,
+                max_entries=max(100, self._policy.max_workspace_entries),
+                network_enabled=True,
+            ),
+        )
+        return backend.execute(
+            command,
+            timeout=timeout,
+            cancel_event=cancel_event,
+        )
+
+
+__all__ = ["RestrictedProcessExecutionProvider"]

--- a/src/opentulpa/evolution/sandbox.py
+++ b/src/opentulpa/evolution/sandbox.py
@@ -555,7 +555,13 @@ class CandidateProcessBackend(CandidateContainerBackend):
         # temporarily owned by that identity.
         self._lock = _PROCESS_SANDBOX_EXECUTION_LOCK
 
-    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecuteResponse:
         safe_command = str(command or "").strip()
         if not safe_command or "\x00" in safe_command:
             return ExecuteResponse(output="command is invalid", exit_code=2, truncated=False)
@@ -588,14 +594,19 @@ class CandidateProcessBackend(CandidateContainerBackend):
             traversal_modes: list[tuple[Path, int]] = []
             monitor_stop = threading.Event()
             workspace_invalid = threading.Event()
+            abort_requested = threading.Event()
             monitor: threading.Thread | None = None
 
             def monitor_workspace() -> None:
                 while not monitor_stop.wait(0.1):
+                    if cancel_event is not None and cancel_event.is_set():
+                        abort_requested.set()
+                        return
                     try:
                         self._scan_tree()
                     except (OSError, RuntimeError):
                         workspace_invalid.set()
+                        abort_requested.set()
                         return
 
             try:
@@ -623,7 +634,7 @@ class CandidateProcessBackend(CandidateContainerBackend):
                     },
                     timeout_seconds=effective_timeout,
                     max_output_bytes=self._policy.max_output_bytes,
-                    abort_event=workspace_invalid,
+                    abort_event=abort_requested,
                 )
                 monitor_stop.set()
                 monitor.join(timeout=5)
@@ -636,6 +647,12 @@ class CandidateProcessBackend(CandidateContainerBackend):
                     return ExecuteResponse(
                         output="command exceeded workspace safety limits; changes were reverted",
                         exit_code=126,
+                        truncated=False,
+                    )
+                if cancel_event is not None and cancel_event.is_set():
+                    return ExecuteResponse(
+                        output="sandbox execution was cancelled",
+                        exit_code=130,
                         truncated=False,
                     )
                 if completed.timed_out:

--- a/src/opentulpa/integrations/composio.py
+++ b/src/opentulpa/integrations/composio.py
@@ -321,41 +321,76 @@ class ComposioService:
         limit: int = 50,
         search: str | None = None,
     ) -> dict[str, Any]:
-        session = self._session(customer_id=customer_id, manage_connections=False)
-        result = session.toolkits(
-            toolkits=_coerce_toolkit_list(toolkits) or None,
-            is_connected=is_connected,
-            limit=max(1, min(int(limit), 100)),
-            search=str(search or "").strip() or None,
-        )
+        safe_customer = str(customer_id or "").strip()
+        requested_toolkits = {value.casefold() for value in _coerce_toolkit_list(toolkits)}
+        safe_search = str(search or "").strip().casefold()
+        safe_limit = max(1, min(int(limit), 100))
+        connections: dict[str, dict[str, Any]] = {}
+        if is_connected is not None:
+            connected = self.list_connected_accounts(
+                customer_id=safe_customer,
+                limit=100,
+            )
+            for account in connected.get("items", []):
+                slug = str(account.get("toolkit_slug", "") or "").casefold()
+                if slug:
+                    connections[slug] = account
+
         items: list[dict[str, Any]] = []
-        for item in list(getattr(result, "items", []) or []):
-            connection = getattr(item, "connection", None)
-            connected_account = (
-                getattr(connection, "connected_account", None) if connection else None
+        cursor: str | None = None
+        next_cursor: str | None = None
+        total_pages = 0
+        while len(items) < safe_limit:
+            result = self._sdk().toolkits.list(
+                cursor=cursor,
+                limit=100,
+                sort_by="alphabetically",
             )
-            auth_config = getattr(connection, "auth_config", None) if connection else None
-            items.append(
-                {
-                    "slug": str(getattr(item, "slug", "") or ""),
-                    "name": str(getattr(item, "name", "") or ""),
-                    "is_no_auth": bool(getattr(item, "is_no_auth", False)),
-                    "is_connected": bool(getattr(connection, "is_active", False))
-                    if connection
-                    else False,
-                    "connected_account_id": str(getattr(connected_account, "id", "") or "") or None,
-                    "connected_account_status": str(getattr(connected_account, "status", "") or "")
-                    or None,
-                    "auth_config_id": str(getattr(auth_config, "id", "") or "") or None,
-                    "auth_mode": str(getattr(auth_config, "mode", "") or "") or None,
-                }
-            )
+            total_pages = int(getattr(result, "total_pages", 0) or 0)
+            for item in list(getattr(result, "items", []) or []):
+                slug = str(getattr(item, "slug", "") or "")
+                name = str(getattr(item, "name", "") or "")
+                normalized_slug = slug.casefold()
+                if requested_toolkits and normalized_slug not in requested_toolkits:
+                    continue
+                if safe_search and safe_search not in f"{slug} {name}".casefold():
+                    continue
+                connection = connections.get(normalized_slug)
+                connected_now = connection is not None
+                if is_connected is not None and connected_now is not is_connected:
+                    continue
+                items.append(
+                    {
+                        "slug": slug,
+                        "name": name,
+                        "is_no_auth": bool(getattr(item, "no_auth", False)),
+                        "is_connected": connected_now,
+                        "connected_account_id": (
+                            str(connection.get("id", "") or "") or None
+                            if connection is not None
+                            else None
+                        ),
+                        "connected_account_status": (
+                            str(connection.get("status", "") or "") or None
+                            if connection is not None
+                            else None
+                        ),
+                        "auth_config_id": None,
+                        "auth_mode": None,
+                    }
+                )
+                if len(items) >= safe_limit:
+                    break
+            next_cursor = str(getattr(result, "next_cursor", "") or "") or None
+            if len(items) >= safe_limit or next_cursor is None or next_cursor == cursor:
+                break
+            cursor = next_cursor
         return {
             "ok": True,
-            "customer_id": str(customer_id),
+            "customer_id": safe_customer,
             "items": items,
-            "next_cursor": str(getattr(result, "next_cursor", "") or "") or None,
-            "total_pages": int(getattr(result, "total_pages", 0) or 0),
+            "next_cursor": next_cursor,
+            "total_pages": total_pages,
         }
 
     def list_connected_accounts(

--- a/src/opentulpa/integrations/tenant_composio.py
+++ b/src/opentulpa/integrations/tenant_composio.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from opentulpa.jobs import (
 from opentulpa.persistence.idempotency import IdempotencyStore
 
 _T = TypeVar("_T")
+logger = logging.getLogger(__name__)
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,299}$")
 _SECRET_KEY_RE = re.compile(
     r"authorization|api[_-]?key|secret|token|password|passwd|cookie|credential",
@@ -484,14 +486,6 @@ class TenantComposioService:
     ) -> dict[str, JsonValue]:
         tenant = self._required(tenant_id, "tenant_id")
         search = str(query or "").strip()[:500] or None
-        payload = await self._provider_call(
-            lambda: self._provider.list_toolkits(
-                customer_id=tenant,
-                limit=100,
-                search=search,
-            )
-        )
-        mapping = self._provider_mapping(payload)
         connections = await self.list_connections(tenant_id=tenant, integration_id=None)
         raw_connections = connections.get("items")
         owned = raw_connections if isinstance(raw_connections, list) else []
@@ -503,8 +497,50 @@ class TenantComposioService:
             if integration_id:
                 by_integration[integration_id] = item
 
+        try:
+            payload = await self._provider_call(
+                lambda: self._provider.list_toolkits(
+                    customer_id=tenant,
+                    limit=100,
+                    search=search,
+                )
+            )
+            mapping = self._provider_mapping(payload)
+        except ComposioProviderError:
+            fallback_items: list[JsonValue] = []
+            normalized_search = str(search or "").casefold()
+            for fallback_connection in by_integration.values():
+                integration_id = str(
+                    fallback_connection.get("integration_id", "") or ""
+                ).strip()
+                name = str(
+                    fallback_connection.get("integration_name", "") or integration_id
+                ).strip()
+                if normalized_search and normalized_search not in (
+                    f"{integration_id} {name}".casefold()
+                ):
+                    continue
+                fallback_items.append(
+                    {
+                        "id": integration_id,
+                        "name": name[:500],
+                        "connected": True,
+                        "connection_id": str(fallback_connection.get("id", "") or ""),
+                        "connection_status": str(
+                            fallback_connection.get("status", "") or ""
+                        ),
+                        "requires_authentication": True,
+                    }
+                )
+            return {
+                "tenant_id": tenant,
+                "items": fallback_items,
+                "catalog_available": False,
+                "warning": "The integration catalog is temporarily unavailable.",
+            }
+
         raw_items = mapping.get("items")
-        items: list[JsonValue] = []
+        catalog_items: list[JsonValue] = []
         for raw in raw_items if isinstance(raw_items, list) else []:
             if not isinstance(raw, Mapping):
                 continue
@@ -513,7 +549,7 @@ class TenantComposioService:
                 continue
             connection = by_integration.get(integration_id.casefold())
             no_auth = bool(raw.get("is_no_auth", False))
-            items.append(
+            catalog_items.append(
                 {
                     "id": integration_id,
                     "name": str(raw.get("name", "") or integration_id)[:500],
@@ -529,7 +565,11 @@ class TenantComposioService:
                     "requires_authentication": not no_auth,
                 }
             )
-        return {"tenant_id": tenant, "items": items}
+        return {
+            "tenant_id": tenant,
+            "items": catalog_items,
+            "catalog_available": True,
+        }
 
     async def connect(
         self,
@@ -827,7 +867,11 @@ class TenantComposioService:
             return await asyncio.to_thread(callback)
         except (ComposioProviderError, IntegrationConnectionNotFoundError):
             raise
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "integration provider request failed (%s)",
+                type(exc).__name__,
+            )
             raise ComposioProviderError("integration provider request failed") from None
 
     @staticmethod

--- a/start.sh
+++ b/start.sh
@@ -915,6 +915,10 @@ install_tenant_sandbox_image() {
       log "tenant sandbox image build skipped; using Railway-hosted sandbox VMs."
       return 0
     fi
+    if process_tenant_sandbox_configured; then
+      log "tenant sandbox image build skipped; using the bundled restricted process sandbox."
+      return 0
+    fi
     log "tenant sandbox image build skipped; chat will start with shell execution unavailable."
     return 0
   fi
@@ -1209,6 +1213,13 @@ process_repository_sandbox_available() {
     && command -v prlimit >/dev/null 2>&1
 }
 
+process_tenant_sandbox_configured() {
+  local provider
+  provider="$(config_value "SANDBOX_PROVIDER" "sandbox_provider")"
+  provider="$(printf '%s' "${provider:-auto}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${provider}" == "auto" ]] && process_repository_sandbox_available
+}
+
 railway_tenant_sandbox_configured() {
   local provider
   provider="$(config_value "SANDBOX_PROVIDER" "sandbox_provider")"
@@ -1219,8 +1230,10 @@ railway_tenant_sandbox_configured() {
 }
 
 warn_without_container_engine() {
-  if process_repository_sandbox_available; then
-    warn "no isolated OCI engine was found; general tenant shell commands are unavailable, but repository work will use the bundled unprivileged process sandbox."
+  if process_tenant_sandbox_configured; then
+    warn "no isolated OCI engine was found; tenant and repository commands will use the bundled restricted process sandbox."
+  elif process_repository_sandbox_available; then
+    warn "no isolated OCI engine was found; general tenant shell commands are unavailable, but repository work will use the bundled restricted process sandbox."
   else
     warn "no isolated OCI engine was found; chat will start but sandbox shell commands will be unavailable (tenant workspace only; source evolution uses the stable host)."
   fi
@@ -1360,6 +1373,8 @@ run_doctor() {
       local railway_bridge
       railway_bridge="$(railway_bridge_dir)"
       doctor_check "Railway sandbox bridge dependencies are installed" "$([[ -f "${railway_bridge}/node_modules/railway/package.json" ]] && echo 1 || echo 0)" "run ./start.sh install ${runtime}" || failures=$((failures + 1))
+    elif process_tenant_sandbox_configured; then
+      echo "[doctor] ok: bundled restricted process sandbox is available for tenant commands"
     else
       direct_engine="${OPENTULPA_CONTAINER_CLI:-docker}"
       direct_tenant_image="$(config_value "SANDBOX_IMAGE" "sandbox_image")"

--- a/tests/test_composio_service.py
+++ b/tests/test_composio_service.py
@@ -181,6 +181,53 @@ def test_composio_hot_loads_and_rotates_a_vault_backed_api_key(monkeypatch) -> N
     assert keys == ["first-composio-key", "rotated-composio-key"]
 
 
+def test_list_toolkits_uses_catalog_api_and_filters_across_pages(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def list_toolkits(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if kwargs["cursor"] is None:
+            return SimpleNamespace(
+                items=[SimpleNamespace(slug="gmail", name="Gmail", no_auth=False)],
+                next_cursor="page-2",
+                total_pages=2,
+            )
+        return SimpleNamespace(
+            items=[SimpleNamespace(slug="slack", name="Slack", no_auth=False)],
+            next_cursor=None,
+            total_pages=2,
+        )
+
+    monkeypatch.setattr(
+        ComposioService,
+        "_sdk",
+        lambda self: SimpleNamespace(
+            toolkits=SimpleNamespace(list=list_toolkits),
+        ),
+    )
+    service = ComposioService(api_key="test-key")
+
+    result = service.list_toolkits(
+        customer_id="tenant-a",
+        search="slack",
+        limit=10,
+    )
+
+    assert result["items"] == [
+        {
+            "slug": "slack",
+            "name": "Slack",
+            "is_no_auth": False,
+            "is_connected": False,
+            "connected_account_id": None,
+            "connected_account_status": None,
+            "auth_config_id": None,
+            "auth_mode": None,
+        }
+    ]
+    assert [call["cursor"] for call in calls] == [None, "page-2"]
+
+
 def test_composio_proxy_uses_connected_account_without_exposing_headers(
     monkeypatch,
 ) -> None:

--- a/tests/test_main_composition.py
+++ b/tests/test_main_composition.py
@@ -12,6 +12,7 @@ from opentulpa.bootstrap.evolution_api import EvolutionClient
 from opentulpa.bootstrap.sandbox_api import SandboxExecutionClient
 from opentulpa.capabilities import SubprocessWorkerHost
 from opentulpa.core.config import Settings
+from opentulpa.deep_agent.process_sandbox import RestrictedProcessExecutionProvider
 from opentulpa.deep_agent.railway_sandbox import RailwaySandboxExecutionProvider
 from opentulpa.deep_agent.service import DeepAgentService
 from opentulpa.integrations.browser_use_cloud import BrowserUseCloudSessionProvider
@@ -384,6 +385,11 @@ def test_direct_runtime_keeps_chat_available_when_sandbox_is_unavailable(
         raise RuntimeError("configured OCI engine must operate in rootless mode")
 
     monkeypatch.setattr(main_module, "resolve_local_oci_image", unavailable)
+    monkeypatch.setattr(
+        main_module.RestrictedProcessExecutionProvider,
+        "supported",
+        lambda: False,
+    )
 
     image, execution = main_module._sandbox_execution_configuration(  # noqa: SLF001
         project_root=tmp_path,
@@ -394,6 +400,29 @@ def test_direct_runtime_keeps_chat_available_when_sandbox_is_unavailable(
     assert execution is not None
     with pytest.raises(RuntimeError, match="sandbox execution is unavailable"):
         execution.execute(tenant_id="tenant", command="pwd", timeout=1)
+
+
+def test_direct_runtime_uses_restricted_process_sandbox_without_oci(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(**_: Any) -> str:
+        raise RuntimeError("configured OCI engine must operate in rootless mode")
+
+    monkeypatch.setattr(main_module, "resolve_local_oci_image", unavailable)
+    monkeypatch.setattr(
+        main_module.RestrictedProcessExecutionProvider,
+        "supported",
+        lambda: True,
+    )
+
+    image, execution = main_module._sandbox_execution_configuration(  # noqa: SLF001
+        project_root=tmp_path,
+        settings=_settings(tmp_path),
+    )
+
+    assert image == "opentulpa-tenant-sandbox:test"
+    assert isinstance(execution, RestrictedProcessExecutionProvider)
 
 
 def test_direct_railway_runtime_uses_hosted_sandbox_provider(

--- a/tests/test_process_sandbox.py
+++ b/tests/test_process_sandbox.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+from deepagents.backends.protocol import ExecuteResponse
+
+from opentulpa.deep_agent import process_sandbox
+from opentulpa.deep_agent.process_sandbox import RestrictedProcessExecutionProvider
+from opentulpa.deep_agent.sandbox import TenantContainerPolicy
+
+
+def test_restricted_process_provider_maps_tenant_policy_and_cancellation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeBackend:
+        @staticmethod
+        def supported() -> bool:
+            return True
+
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def execute(self, command: str, **kwargs: Any) -> ExecuteResponse:
+            captured["command"] = command
+            captured.update(kwargs)
+            return ExecuteResponse(output="ok", exit_code=0, truncated=False)
+
+    monkeypatch.setattr(process_sandbox, "CandidateProcessBackend", FakeBackend)
+    policy = TenantContainerPolicy(
+        image="opentulpa-tenant-sandbox:test",
+        memory_limit="256m",
+        pid_limit=64,
+        timeout_seconds=30,
+        max_output_bytes=8_192,
+        max_file_bytes=4_096,
+        max_workspace_entries=250,
+        network_enabled=True,
+    )
+    provider = RestrictedProcessExecutionProvider(
+        policy=policy,
+        max_workspace_bytes=1_000_000,
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    cancellation = threading.Event()
+
+    result = provider.execute(
+        tenant_id="tenant-a",
+        command="pwd",
+        timeout=12,
+        workspace=workspace,
+        cancel_event=cancellation,
+    )
+
+    candidate_policy = captured["policy"]
+    assert result.output == "ok"
+    assert captured["workspace"] == workspace
+    assert captured["allowed_root"] == tmp_path
+    assert candidate_policy.memory_limit == "256m"
+    assert candidate_policy.pid_limit == 64
+    assert candidate_policy.max_total_bytes == 1_000_000
+    assert captured["command"] == "pwd"
+    assert captured["timeout"] == 12
+    assert captured["cancel_event"] is cancellation

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -594,6 +594,33 @@ def test_direct_start_without_container_engine_keeps_chat_available(tmp_path: Pa
     assert "chat will start but sandbox shell commands will be unavailable" in result.stderr
 
 
+def test_direct_start_reports_restricted_process_sandbox_when_available(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "start.sh"
+    script.write_text((REPO_ROOT / "start.sh").read_text(encoding="utf-8"), encoding="utf-8")
+    script.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "source ./start.sh; "
+            "process_repository_sandbox_available() { return 0; }; "
+            "warn_without_container_engine",
+        ],
+        cwd=tmp_path,
+        env={**os.environ, "SANDBOX_PROVIDER": "auto"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "tenant and repository commands will use" in result.stderr
+    assert "restricted process sandbox" in result.stderr
+    assert "shell commands will be unavailable" not in result.stderr
+
+
 def test_direct_start_recognizes_railway_hosted_sandbox(tmp_path: Path) -> None:
     script = tmp_path / "start.sh"
     script.write_text((REPO_ROOT / "start.sh").read_text(encoding="utf-8"), encoding="utf-8")

--- a/tests/test_tenant_composio.py
+++ b/tests/test_tenant_composio.py
@@ -22,7 +22,7 @@ from opentulpa.persistence.idempotency import (
     IdempotencyStore,
 )
 from opentulpa.specs import AgentSpecRef, OriginRef
-from opentulpa.tooling.adapters import ProductToolInvocation
+from opentulpa.tooling.adapters import ProductToolApplicationError, ProductToolInvocation
 from opentulpa.tooling.contract import (
     TOOL_SPEC_BY_NAME,
     AgentChannel,
@@ -54,6 +54,8 @@ class _Provider:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.worker_threads: list[int] = []
         self.fail_authorize = False
+        self.fail_toolkits = False
+        self.fail_connections = False
 
     def _record(self, name: str, **kwargs: Any) -> None:
         self.calls.append((name, kwargs))
@@ -61,6 +63,8 @@ class _Provider:
 
     def list_toolkits(self, **kwargs: Any) -> dict[str, Any]:
         self._record("list_toolkits", **kwargs)
+        if self.fail_toolkits:
+            raise RuntimeError("api_key=provider-secret")
         return {
             "items": [
                 {"slug": "gmail", "name": "Gmail", "is_no_auth": False},
@@ -82,6 +86,8 @@ class _Provider:
 
     def list_connected_accounts(self, **kwargs: Any) -> dict[str, Any]:
         self._record("list_connected_accounts", **kwargs)
+        if self.fail_connections:
+            raise RuntimeError("api_key=provider-secret")
         toolkits = {str(item).casefold() for item in kwargs.get("toolkits") or []}
         items = [
             dict(item)
@@ -300,6 +306,66 @@ async def test_provider_errors_are_sanitized_and_failed_keys_do_not_retry(tmp_pa
             idempotency_key="provider-failure",
         )
     assert [name for name, _ in provider.calls].count("authorize_toolkit") == 1
+
+
+@pytest.mark.asyncio
+async def test_integration_list_keeps_connected_accounts_when_catalog_fails(
+    tmp_path: Path,
+) -> None:
+    service, provider, _ = _adapter(tmp_path)
+    provider.fail_toolkits = True
+
+    result = await service.list_integrations(
+        tenant_id="tenant-a",
+        query=None,
+    )
+
+    assert result == {
+        "tenant_id": "tenant-a",
+        "items": [
+            {
+                "id": "gmail",
+                "name": "Gmail",
+                "connected": True,
+                "connection_id": "connection-own",
+                "connection_status": "ACTIVE",
+                "requires_authentication": True,
+            }
+        ],
+        "catalog_available": False,
+        "warning": "The integration catalog is temporarily unavailable.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_product_application_maps_composio_provider_failures(
+    tmp_path: Path,
+) -> None:
+    service, provider, store = _adapter(tmp_path)
+    provider.fail_connections = True
+    unused = _UnusedPort()
+    application = ProductToolApplication(
+        profiles=unused,
+        files=unused,
+        artifacts=unused,
+        knowledge=unused,
+        research=unused,
+        browser=unused,
+        integrations=service,
+        intake=unused,
+        schedules=unused,
+        jobs=unused,
+        idempotency=store,
+    )
+
+    with pytest.raises(ProductToolApplicationError) as error:
+        await application.integration_list(
+            _invocation("integration_list", {"query": None}, "integration-list")
+        )
+
+    assert error.value.code == "integration_provider_failed"
+    assert error.value.public_message == "The integration provider request failed."
+    assert error.value.retryable is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use the existing restricted process sandbox when auto mode has no Railway credentials or local OCI engine
- switch Composio toolkit listing to the stable catalog API and preserve connected integrations during catalog outages
- surface sanitized retryable provider errors and correct the Railway sandbox environment variable example

## Verification
- 160 affected/adjacent tests passed, 4 skipped
- full suite: 1045 passed; 3 environment-only failures (2 passed with venv on PATH, 1 existing DNS-dependent browser test)
- ruff check src tests
- mypy on changed source modules