### PR TITLE
Fix Railway sandbox in evolved runtimes

### DIFF
--- a/src/opentulpa/deep_agent/railway_sandbox.py
+++ b/src/opentulpa/deep_agent/railway_sandbox.py
@@ -68,6 +68,9 @@ class RailwaySandboxExecutionProvider:
             / "bridge.mjs"
         )
         default_bridge = packaged_bridge if packaged_bridge.is_file() else source_bridge
+        stable_bridge = str(
+            os.environ.get("OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH") or ""
+        ).strip()
         self._token = safe_token
         self._environment_id = safe_environment
         self._max_output_bytes = int(max_output_bytes)
@@ -75,7 +78,9 @@ class RailwaySandboxExecutionProvider:
         self._max_workspace_entries = int(max_workspace_entries)
         self._max_file_bytes = int(max_file_bytes)
         self._idle_timeout_minutes = int(idle_timeout_minutes)
-        self._bridge_path = Path(bridge_path or default_bridge).expanduser().resolve()
+        self._bridge_path = Path(
+            bridge_path or stable_bridge or default_bridge
+        ).expanduser().resolve()
         self._node_binary = str(node_binary or "node").strip() or "node"
         if runner is None:
             if not self._bridge_path.is_file():

--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 import secrets
@@ -19,6 +20,8 @@ from pydantic import BaseModel, ConfigDict
 
 from opentulpa.host.models import HostConfig
 from opentulpa.persistence.tenant_namespace import tenant_namespace_label
+
+logger = logging.getLogger(__name__)
 
 _SECRET_LINE = re.compile(
     r"(?i)(api[_-]?key|authorization|bot[_-]?token|secret|password)(\s*[:=]\s*)(\S+)"
@@ -61,6 +64,8 @@ class RuntimeSupervisor:
         client: httpx.AsyncClient | None = None,
     ) -> None:
         self._project_root = project_root.resolve()
+        bridge_path = self._project_root / "railway_sandbox_bridge" / "bridge.mjs"
+        self._railway_sandbox_bridge = bridge_path.resolve() if bridge_path.is_file() else None
         self._data_root = data_root.resolve()
         self._startup_timeout = startup_timeout_seconds
         self._shutdown_timeout = shutdown_timeout_seconds
@@ -269,6 +274,7 @@ class RuntimeSupervisor:
             self._status = "failed"
             self._error = self._safe_error(exc)
             self._append_log("host", f"runtime failed: {self._error}")
+            logger.error("child runtime failed: %s", self._error)
             raise RuntimeUnavailableError(self._error) from exc
         self._status = "ready"
         self._append_log("host", f"runtime revision {config.revision} is ready")
@@ -352,6 +358,7 @@ class RuntimeSupervisor:
             "TELEGRAM_WEBHOOK_SECRET",
             "PUBLIC_BASE_URL",
             "RAILWAY_PUBLIC_DOMAIN",
+            "OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH",
         ):
             environment.pop(key, None)
         environment.update(
@@ -369,6 +376,10 @@ class RuntimeSupervisor:
                 "PYTHONPATH": str(source_root / "src"),
             }
         )
+        if self._railway_sandbox_bridge is not None:
+            environment["OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH"] = str(
+                self._railway_sandbox_bridge
+            )
         if self._evolution_url is not None and self._evolution_token is not None:
             environment.update(
                 {

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -77,6 +77,36 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
 
 
 @pytest.mark.asyncio
+async def test_evolved_runtime_uses_stable_host_railway_bridge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = tmp_path / "railway_sandbox_bridge" / "bridge.mjs"
+    bridge.parent.mkdir()
+    bridge.write_text("", encoding="utf-8")
+    candidate_root = tmp_path / "candidate"
+    package = candidate_root / "src" / "opentulpa"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setenv(
+        "OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH",
+        "/untrusted/inherited/bridge.mjs",
+    )
+    runtime = RuntimeSupervisor(project_root=tmp_path, data_root=tmp_path / "data")
+
+    runtime.set_project_root(candidate_root)
+    environment = runtime._child_environment(
+        _config(),
+        port=8123,
+        project_root=candidate_root,
+    )
+
+    assert environment["PYTHONPATH"] == str(candidate_root / "src")
+    assert environment["OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH"] == str(bridge)
+    await runtime.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_host_seeds_owner_identity_in_runtime_telegram_state(tmp_path: Path) -> None:
     data_root = tmp_path / "data"
     runtime = RuntimeSupervisor(project_root=tmp_path, data_root=data_root)

--- a/tests/test_railway_sandbox.py
+++ b/tests/test_railway_sandbox.py
@@ -190,6 +190,31 @@ def test_bridge_environment_does_not_inherit_host_secrets(
     assert "telegram-secret" not in str(environment)
 
 
+def test_provider_uses_stable_host_bridge_from_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = tmp_path / "stable-bridge" / "bridge.mjs"
+    bridge.parent.mkdir()
+    bridge.write_text("", encoding="utf-8")
+    dependency = bridge.parent / "node_modules" / "railway"
+    dependency.mkdir(parents=True)
+    (dependency / "package.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH", str(bridge))
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/node")
+
+    provider = RailwaySandboxExecutionProvider(
+        token="project-token",
+        environment_id="environment-id",
+        max_output_bytes=4_096,
+        max_workspace_archive_bytes=1_000_000,
+        max_workspace_entries=100,
+        max_file_bytes=100_000,
+    )
+
+    assert provider._bridge_path == bridge  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_tenant_backend_cancels_remote_provider_without_committing_workspace(
     tmp_path: Path,


### PR DESCRIPTION
## Root cause
Host evolution runs the child from a source worktree. That worktree contains the bridge source but not its installed Node dependencies, so Railway sandbox initialization aborts the entire child runtime.

## Fix
- preserve the immutable host's installed Railway bridge path across source swaps
- make the child provider prefer that host-owned path
- emit sanitized child startup failures to Railway logs
- cover the host-to-evolved-runtime boundary with regression tests

## Verification
- ................s.ss........................                             [100%]
41 passed, 3 skipped in 5.15s (41 passed, 3 skipped)
- focused Ruff check
- focused mypy check