### PR TITLE
Add mandatory sandbox worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,12 +73,9 @@ OPENTULPA_OPEN_BROWSER=auto
 # managed runtime images. Values: browser, integrations, documents, research, bundled.
 OPENTULPA_EXTRAS=
 
-# Tenant shell isolation. Auto uses local OCI first, then the bundled restricted
-# Linux process sandbox. Railway-hosted sandbox VMs are an optional stronger tier.
-SANDBOX_PROVIDER=auto
-RAILWAY_TOKEN=
-OPENTULPA_SANDBOX_RAILWAY_ENVIRONMENT_ID=
-RAILWAY_SANDBOX_IDLE_TIMEOUT_MINUTES=30
+# Sandbox execution is mandatory in production. The stable host starts a private
+# sandbox worker automatically; advanced remote/hosted sandbox wiring belongs in
+# deployment-specific docs, not normal first-run configuration.
 
 # Optional: Telegram bot
 TELEGRAM_BOT_TOKEN=
@@ -99,13 +96,8 @@ TELEGRAM_ALLOWED_USER_IDS=
 OPENTULPA_OWNER_CUSTOMER_ID=
 # Optional: Composio Tool Router integration for external SaaS auth/tool access
 COMPOSIO_API_KEY=
-# Optional hosted sandboxes for Git repository work. Local OCI or the bundled
-# unprivileged Linux process sandbox works without Daytona. These credentials may
-# also be pasted into authenticated owner chat.
-DAYTONA_API_KEY=
+# Optional private GitHub checkout or direct-Git publishing fallback.
 GITHUB_TOKEN=
-# auto prefers zero-config local isolation; set daytona to require the hosted provider.
-REPOSITORY_SANDBOX_PROVIDER=auto
 
 # Optional: Browser Use Cloud hosted browsers.
 # Recommended for browser tasks that benefit from persistent tenant profiles,

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=railway-sandbox-bridge /usr/local/bin/node /usr/local/bin/node
 COPY --from=railway-sandbox-bridge /bridge /app/railway_sandbox_bridge
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl git util-linux \
+    && apt-get install -y --no-install-recommends curl git openssh-client util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/tenant-sandbox.Dockerfile
+++ b/docker/tenant-sandbox.Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHONUNBUFFERED=1
 # Keep the general-purpose workspace image small while retaining the tools an
 # agent needs to inspect, modify, and fetch dependencies for ordinary source trees.
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends curl git ripgrep \
+    && apt-get install --yes --no-install-recommends curl git openssh-client ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,5 +1,13 @@
 # Deployment
 
+OpenTulpa's default production shape is **Host + Sandbox Worker + Data**.
+The stable host starts or binds a private sandbox worker before reporting readiness.
+If the sandbox canary fails, `/healthz` returns `503` and `/_host` shows the failed
+check. A deployed bot is not operational unless shell execution and SSH diagnostics
+can reach the sandbox. Repository work and source evolution remain sandboxed through
+the existing reviewed execution paths and are the next surfaces to converge onto this
+worker API.
+
 OpenTulpa has three explicit host shapes:
 
 - **Host** is the default. It starts before model configuration and owns setup, owner
@@ -38,11 +46,11 @@ The launcher installs only the lean core unless `OPENTULPA_EXTRAS` is set. Use
 `documents`, `research`, and `hosted-sandbox`; managed installation bakes the same
 selection into the reviewed runtime base.
 
-Tenant shell tools need an isolated OCI engine because `TenantContainerBackend` never
-executes commands directly on the application host. Direct startup auto-detects
-rootless Podman/Docker and recognizes Docker Desktop or OrbStack's macOS VM boundary.
-If none is available, chat starts with shell execution disabled. Managed mode never
-uses that degraded path and additionally requires:
+Tenant shell tools must go through a sandbox. The default stable host starts a
+private sandbox worker automatically and refuses health if the worker cannot execute
+its canary. Local/VPS installs may use rootless Podman/Docker internally, while
+Railway-compatible Linux containers use the bundled restricted process worker with
+`setpriv`, `prlimit`, and a secret-free workspace. Managed mode additionally requires:
 
 - a rootless Docker or Podman engine available to the bootstrap;
 - a persistent canonical Git checkout;
@@ -332,7 +340,7 @@ Install only what the deployment uses:
 | `integrations` | Composio SDK and LangChain provider | Tenant-owned SaaS connections after an environment key or encrypted owner-chat key is configured |
 | `documents` | PDF, workbook, and encoding parsers | Additional file-analysis formats |
 | `research` | Crawl4AI | Richer content extraction; bounded built-in extraction remains available without it |
-| `hosted-sandbox` | Daytona and its Deep Agents backend | Optional hosted repository workspaces; local repository isolation remains the default |
+| `hosted-sandbox` | Hosted workspace adapters such as Daytona | Optional remote repository workspaces; the mandatory sandbox worker remains the default |
 | `bundled` | All of the above | Convenience image for a full adapter set |
 
 Examples:
@@ -344,14 +352,13 @@ uv sync --no-dev --extra browser
 ```env
 BROWSER_USE_API_KEY=...  # required when browser tools are enabled
 COMPOSIO_API_KEY=...     # optional SaaS integration provider
-DAYTONA_API_KEY=...      # optional hosted repository sandboxes
 GITHUB_TOKEN=...         # optional private checkout or direct-Git publishing fallback
 ```
 
 The environment variables remain suitable for unattended bootstrap. An authenticated
 owner may instead send `COMPOSIO_API_KEY=<value>` in chat; credential ingress stores it
 as `secret://composio_api_key`, and the trusted adapter hot-loads it without restarting.
-The same ingress accepts `DAYTONA_API_KEY=<value>` and `GITHUB_TOKEN=<value>`.
+The same ingress accepts `GITHUB_TOKEN=<value>`.
 No optional adapter receives credentials through model-visible arguments. Browser and
 Composio actions execute without per-call approval after normal authorization checks.
 Browser navigation requires explicit allowed domains and rejects direct private and
@@ -363,11 +370,12 @@ nor connected-account credentials are mounted or exported into sandbox processes
 
 ## Docker Compose And Railway
 
-The included `docker-compose.yml` and `railway.toml` start the stable host plus its
-Deep Agents child. The image bundles a secret-free source seed and fixed evaluation
-dependencies. On first boot the host creates persistent Git lineage; source commands
-run as an unprivileged UID with no inherited credentials, while the stable host alone
-commits, evaluates, activates, health-checks, and rolls back the child.
+The included `docker-compose.yml` and `railway.toml` start the stable host, its
+private sandbox worker, and the replaceable Deep Agents child. The image bundles a
+secret-free source seed, SSH client, and fixed evaluation dependencies. On first boot
+the host creates persistent Git lineage; sandbox commands run with no inherited
+credentials, while the stable host alone commits, evaluates, activates,
+health-checks, and rolls back the child.
 
 For Docker Compose:
 
@@ -378,20 +386,20 @@ docker compose up --build
 Persist the volume mounted at `/app/opentulpa_data` and set
 `OPENTULPA_DATA_ROOT=/app/opentulpa_data`.
 
-For Railway, configure:
+For Railway, configure only the durable data root and any unattended credentials:
 
 - `OPENTULPA_DATA_ROOT=/app/opentulpa_data` with a persistent volume;
 - optionally `OPENAI_COMPATIBLE_API_KEY` and `OPENTULPA_OWNER_TOKEN` for unattended boot.
 
 Without an owner token, read the one-time pairing code from the first startup log and
 claim the deployment at `/_host`. Configure Telegram there; polling needs no webhook.
-Repository work requires no sandbox credential. Local machines use a rootless OCI engine when
-available. A compatible Linux container running as root with `setpriv` and `prlimit` uses the
-bundled unprivileged process backend automatically; commands receive no host environment or service
-credentials, run under fixed resource limits, and are serialized across workspaces. The checkout
-persists on the OpenTulpa volume. This process boundary is intended for a single-active-process,
-owner-operated deployment; choose the explicit `daytona` provider for stronger VM isolation,
-multi-replica operation, or a workspace lifecycle independent of the OpenTulpa volume.
+Repository work requires no user-provided sandbox credential. A compatible Linux
+container running as root with `setpriv`, `prlimit`, and `ssh` starts the mandatory
+sandbox worker automatically; commands receive no host environment or service
+credentials, run under fixed resource limits, and are serialized across workspaces.
+The checkout persists on the OpenTulpa volume. This process boundary is intended for
+a single-active-process, owner-operated deployment; advanced remote VM workspace
+providers remain optional and are not part of the default Railway setup.
 
 An active tenant-owned Composio GitHub connection can publish a verified single-commit workspace
 through GitHub's Git Data API without exposing OAuth to the sandbox. `GITHUB_TOKEN` is needed only

--- a/docs/tool-contract.md
+++ b/docs/tool-contract.md
@@ -86,6 +86,7 @@ The registry below is the complete model-visible product surface. Deep Agents bu
 | `trigger_spec_rollback` | `trigger_specs` | `authorize` | `auto` | `required` | `sync` | 30s |
 | `secret_handle_list` | `secrets` | `read` | `auto` | `none` | `sync` | 30s |
 | `secret_handle_revoke` | `secrets` | `delete` | `auto` | `required` | `sync` | 30s |
+| `sandbox_ssh_diagnostic` | `sandbox` | `execute` | `policy` | `none` | `sync` | 660s |
 | `capability_list` | `capabilities` | `read` | `auto` | `none` | `sync` | 30s |
 | `capability_seed_bundled` | `capabilities` | `create` | `auto` | `derived` | `sync` | 30s |
 | `capability_test` | `capabilities` | `execute` | `auto` | `none` | `sync` | 600s |

--- a/opentulpa.config.yaml
+++ b/opentulpa.config.yaml
@@ -33,7 +33,6 @@ sandbox_timeout_seconds: 60
 sandbox_max_output_bytes: 512000
 sandbox_max_file_bytes: 10485760
 sandbox_max_workspace_entries: 20000
-sandbox_provider: auto
 railway_sandbox_idle_timeout_minutes: 30
 railway_sandbox_max_sync_bytes: 33554432
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.scripts]
 opentulpa = "opentulpa.host.cli:main"
 opentulpa-host = "opentulpa.host.cli:serve"
+opentulpa-sandbox-worker = "opentulpa.sandbox.worker:main"
 opentulpa-bootstrap = "opentulpa.bootstrap.gateway:main"
 opentulpa-recovery = "opentulpa.bootstrap.recovery_cli:main"
 opentulpa-migrate-deepagents = "opentulpa.migrations.deepagents:main"

--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -127,6 +127,7 @@ from opentulpa.repositories.providers import (
 from opentulpa.repositories.routing import RepositoryRoutingSandbox
 from opentulpa.repositories.service import RepositoryWorkspaceService
 from opentulpa.repositories.store import RepositoryWorkspaceStore
+from opentulpa.sandbox.client import SandboxWorkerExecutionProvider
 from opentulpa.schedules.service import ScheduleService
 from opentulpa.secrets import (
     SecretIngressService,
@@ -300,6 +301,11 @@ def _sandbox_execution_configuration(
     }
     sandbox_url = str(os.environ.get("OPENTULPA_BOOTSTRAP_SANDBOX_URL") or "").strip()
     sandbox_token = str(os.environ.get("OPENTULPA_BOOTSTRAP_SANDBOX_TOKEN") or "").strip()
+    worker_url = str(os.environ.get("OPENTULPA_SANDBOX_RPC_URL") or "").strip()
+    worker_token = str(os.environ.get("OPENTULPA_SANDBOX_RPC_TOKEN") or "").strip()
+    dev_allow_no_sandbox = str(
+        os.environ.get("OPENTULPA_DEV_ALLOW_NO_SANDBOX") or ""
+    ).strip().casefold() in {"1", "true", "yes", "on"}
     if managed and release_mode == "production":
         if not sandbox_url or not sandbox_token:
             raise RuntimeError("managed production requires the stable sandbox execution service")
@@ -319,6 +325,20 @@ def _sandbox_execution_configuration(
         if sandbox_url or sandbox_token:
             raise RuntimeError("staging releases cannot receive sandbox execution authority")
         return settings.sandbox_image, None
+    if worker_url or worker_token:
+        if not worker_url or not worker_token:
+            raise RuntimeError(
+                "sandbox worker execution requires both OPENTULPA_SANDBOX_RPC_URL and "
+                "OPENTULPA_SANDBOX_RPC_TOKEN"
+            )
+        return settings.sandbox_image, SandboxWorkerExecutionProvider(
+            base_url=worker_url,
+            token=worker_token,
+            max_response_bytes=settings.sandbox_max_output_bytes + 65_536,
+            max_archive_bytes=settings.railway_sandbox_max_sync_bytes,
+            max_archive_entries=settings.sandbox_max_workspace_entries,
+            max_file_bytes=settings.sandbox_max_file_bytes,
+        )
     if sandbox_url or sandbox_token:
         raise RuntimeError("stable sandbox credentials are valid only in a managed release")
     provider = settings.sandbox_provider
@@ -373,8 +393,13 @@ def _sandbox_execution_configuration(
                 ),
                 max_workspace_bytes=settings.railway_sandbox_max_sync_bytes,
             )
-        logger.warning("tenant sandbox shell is unavailable: %s", exc)
-        return settings.sandbox_image, _UnavailableSandboxExecutionProvider()
+        if dev_allow_no_sandbox:
+            logger.warning("tenant sandbox shell is unavailable in explicit dev mode: %s", exc)
+            return settings.sandbox_image, _UnavailableSandboxExecutionProvider()
+        raise RuntimeError(
+            "OpenTulpa requires a healthy sandbox worker or local sandbox backend. "
+            "Start through the stable host or set OPENTULPA_DEV_ALLOW_NO_SANDBOX=1 for dev-only chat."
+        ) from exc
     return image, None
 
 

--- a/src/opentulpa/__main__.py
+++ b/src/opentulpa/__main__.py
@@ -1251,6 +1251,7 @@ def build_application(*, project_root: Path, settings: Settings) -> ApplicationC
             agent_specs=agent_specs,
             trigger_specs=trigger_specs,
             secret_handles=secret_vault,
+            sandbox_execution=sandbox_execution,
             on_trigger_spec_changed=trigger_dispatcher.upsert,
             capabilities=capabilities,
             evolution_owner_tenant_id=owner_tenant_id,

--- a/src/opentulpa/application/product_tools.py
+++ b/src/opentulpa/application/product_tools.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import inspect
 import json
 import re
+import shlex
+import threading
 from builtins import list as list_type
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict, is_dataclass
@@ -15,14 +18,15 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Protocol, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 from opentulpa.integrations.tenant_composio import ComposioProviderError
 from opentulpa.integrations.web_search import WebSearchProviderError
 from opentulpa.repositories.providers import RepositorySandboxError
 from opentulpa.repositories.service import RepositoryWorkspaceError
+from opentulpa.sandbox.client import SandboxSecretFileMount
 from opentulpa.schedules.models import ScheduleWrite
-from opentulpa.secrets.models import SecretHandle
+from opentulpa.secrets.models import SecretHandle, SecretState
 from opentulpa.specs.models import AgentSpecWrite, TriggerSpec, TriggerSpecWrite
 from opentulpa.specs.protocol import AgentSpecRef
 from opentulpa.tooling.adapters import (
@@ -62,6 +66,9 @@ _SECRET_KEY_RE = re.compile(
 )
 _PUBLIC_SECRET_METADATA_KEYS = frozenset({"secret_scopes"})
 _PROFILE_FIELDS = frozenset({"directive_text", "locale", "utc_offset"})
+_SANDBOX_SSH_SECRET_SCOPES = ("ssh.connect", "credential.use")
+_SSH_HOST_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,252}\Z")
+_SSH_USER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.-]{0,63}\Z")
 
 
 class ProfilePort(Protocol):
@@ -330,6 +337,16 @@ class SecretHandlePort(Protocol):
 
     def get(self, *, tenant_id: str, secret_id: str) -> Any: ...
 
+    def resolve_for_sandbox(
+        self,
+        *,
+        tenant_id: str,
+        actor_id: str,
+        secret_id: str,
+        scope: str,
+        mount_type: str,
+    ) -> SecretStr: ...
+
     def revoke(
         self,
         *,
@@ -337,6 +354,19 @@ class SecretHandlePort(Protocol):
         actor_id: str,
         secret_id: str,
         expected_revision: int,
+    ) -> Any: ...
+
+
+class SandboxExecutionPort(Protocol):
+    def execute(
+        self,
+        *,
+        tenant_id: str,
+        command: str,
+        timeout: int,
+        workspace: Path | None = None,
+        cancel_event: threading.Event | None = None,
+        secret_files: tuple[SandboxSecretFileMount, ...] = (),
     ) -> Any: ...
 
 
@@ -697,6 +727,44 @@ def _assert_connection_owned(value: Any, tenant_id: str) -> None:
         )
 
 
+def _secret_material(value: Any) -> SecretStr:
+    if isinstance(value, SecretStr):
+        return value
+    return SecretStr(str(value or ""))
+
+
+def _ssh_target(*, host: str, user: str) -> str:
+    clean_host = str(host or "").strip()
+    clean_user = str(user or "").strip()
+    if _SSH_HOST_RE.fullmatch(clean_host) is None:
+        raise ProductToolApplicationError(
+            "invalid_request",
+            "The SSH host is invalid.",
+        )
+    if _SSH_USER_RE.fullmatch(clean_user) is None:
+        raise ProductToolApplicationError(
+            "invalid_request",
+            "The SSH user is invalid.",
+        )
+    return f"{clean_user}@{clean_host}"
+
+
+def _sandbox_ssh_command(
+    *,
+    target: str,
+    port: int,
+    remote_command: str,
+) -> str:
+    return (
+        "mkdir -p .ssh && chmod 700 .ssh && "
+        "ssh -i \"$OPENTULPA_SSH_IDENTITY\" "
+        "-o IdentitiesOnly=yes "
+        "-o UserKnownHostsFile=\"$PWD/.ssh/known_hosts\" "
+        "-o StrictHostKeyChecking=accept-new "
+        f"-p {int(port)} {shlex.quote(target)} -- {shlex.quote(remote_command)}"
+    )
+
+
 async def _resolve(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await cast(Awaitable[Any], value)
@@ -727,6 +795,7 @@ class ProductToolApplication:
         agent_specs: AgentSpecPort | None = None,
         trigger_specs: TriggerSpecPort | None = None,
         secret_handles: SecretHandlePort | None = None,
+        sandbox_execution: SandboxExecutionPort | None = None,
         capabilities: CapabilityPort | None = None,
         on_trigger_spec_changed: Callable[[TriggerSpec], Any] | None = None,
     ) -> None:
@@ -748,6 +817,7 @@ class ProductToolApplication:
         self._agent_specs = agent_specs
         self._trigger_specs = trigger_specs
         self._secret_handles = secret_handles
+        self._sandbox_execution = sandbox_execution
         self._capabilities = capabilities
         self._on_trigger_spec_changed = on_trigger_spec_changed
 
@@ -803,6 +873,18 @@ class ProductToolApplication:
                 "Secret handle management is unavailable in this deployment.",
             )
         return self._secret_handles
+
+    def _require_sandbox_execution(
+        self,
+        invocation: ProductToolInvocation,
+    ) -> SandboxExecutionPort:
+        if invocation.context.run_kind != "owner" or self._sandbox_execution is None:
+            raise ProductToolApplicationError(
+                "capability_unavailable",
+                "Sandbox shell execution is unavailable in this deployment.",
+                retryable=True,
+            )
+        return self._sandbox_execution
 
     def _require_capabilities(self, invocation: ProductToolInvocation) -> CapabilityPort:
         if invocation.context.run_kind != "owner" or self._capabilities is None:
@@ -1704,6 +1786,108 @@ class ProductToolApplication:
                 expected_revision=int(invocation.arguments["expected_revision"]),
             ),
             project=_public_secret_handle,
+        )
+
+    async def sandbox_ssh_diagnostic(
+        self,
+        invocation: ProductToolInvocation,
+    ) -> ProductToolOutput:
+        sandbox = self._require_sandbox_execution(invocation)
+        secret_service = self._require_secret_handles(invocation)
+        if str(invocation.arguments.get("secret_type") or "").strip() != "private_key":
+            raise ProductToolApplicationError(
+                "invalid_request",
+                "Only SSH private-key secret mounts are supported.",
+            )
+        secret_id = str(invocation.arguments["secret_id"])
+        handle = await self._call(
+            invocation,
+            lambda: secret_service.get(
+                tenant_id=invocation.context.tenant_id,
+                secret_id=secret_id,
+            ),
+            required=True,
+        )
+        secret_handle = (
+            handle if isinstance(handle, SecretHandle) else SecretHandle.model_validate(handle)
+        )
+        if secret_handle.state is not SecretState.ACTIVE:
+            raise ProductToolApplicationError(
+                "not_found",
+                "The requested resource was not found.",
+            )
+        scope = next(
+            (
+                candidate
+                for candidate in _SANDBOX_SSH_SECRET_SCOPES
+                if candidate in secret_handle.scopes
+            ),
+            "",
+        )
+        if not scope:
+            raise ProductToolApplicationError(
+                "invalid_request",
+                "The SSH secret handle is not scoped for sandbox SSH diagnostics.",
+            )
+        try:
+            material = await _resolve(
+                secret_service.resolve_for_sandbox(
+                    tenant_id=invocation.context.tenant_id,
+                    actor_id=invocation.context.actor_id,
+                    secret_id=secret_handle.id,
+                    scope=scope,
+                    mount_type="ssh_private_key",
+                )
+            )
+        except Exception as exc:
+            raise ProductToolApplicationError(
+                "secret_unavailable",
+                "The SSH secret handle could not be mounted.",
+            ) from exc
+        secret_value = _secret_material(material).get_secret_value()
+        host = str(invocation.arguments["host"]).strip()
+        user = str(invocation.arguments["user"]).strip()
+        target = _ssh_target(host=host, user=user)
+        command = _sandbox_ssh_command(
+            target=target,
+            port=int(invocation.arguments["port"]),
+            remote_command=str(invocation.arguments["command"]),
+        )
+        try:
+            result = await asyncio.to_thread(
+                sandbox.execute,
+                tenant_id=invocation.context.tenant_id,
+                command=command,
+                timeout=int(invocation.arguments["timeout_seconds"]),
+                secret_files=(
+                    SandboxSecretFileMount(
+                        name="id_opentulpa",
+                        content=secret_value,
+                        env="OPENTULPA_SSH_IDENTITY",
+                    ),
+                ),
+            )
+        except TypeError as exc:
+            raise ProductToolApplicationError(
+                "capability_unavailable",
+                "Sandbox secret mounts are unavailable in this deployment.",
+                retryable=True,
+            ) from exc
+        except Exception as exc:
+            raise ProductToolApplicationError(
+                "sandbox_execution_failed",
+                "The sandbox SSH diagnostic could not be executed.",
+                retryable=True,
+            ) from exc
+        return ProductToolOutput(
+            data={
+                "host": host,
+                "user": user,
+                "port": int(invocation.arguments["port"]),
+                "exit_code": int(getattr(result, "exit_code", 1)),
+                "output": str(getattr(result, "output", "")),
+                "truncated": bool(getattr(result, "truncated", False)),
+            },
         )
 
     async def capability_list(self, invocation: ProductToolInvocation) -> ProductToolOutput:

--- a/src/opentulpa/host/app.py
+++ b/src/opentulpa/host/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 import secrets
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
@@ -20,6 +22,7 @@ from opentulpa.host.service import HostActivationError, HostService
 from opentulpa.host.store import HostConfigConflictError, HostStore
 
 HOST_SESSION_COOKIE = "opentulpa_host_session"
+_SANDBOX_START_RETRY_SECONDS = 5.0
 _HOP_HEADERS = frozenset(
     {
         "connection",
@@ -96,17 +99,37 @@ def create_host_app(
 
     @asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-        sandbox_ready = False
+        runtime_started = False
+        retry_task: asyncio.Task[None] | None = None
+
+        async def start_runtime_when_sandbox_ready(*, retry: bool) -> None:
+            nonlocal runtime_started
+            if sandbox_supervisor is None:
+                return
+            while not runtime_started:
+                try:
+                    await sandbox_supervisor.start()
+                    await service.start()
+                    runtime_started = True
+                    return
+                except Exception:
+                    if not retry:
+                        raise
+                    await asyncio.sleep(_sandbox_start_retry_seconds())
+
         if sandbox_supervisor is not None:
             # Keep the stable host available so /_host can report the exact sandbox failure.
-            with suppress(Exception):
-                await sandbox_supervisor.start()
-                sandbox_ready = True
-        if sandbox_ready:
-            await service.start()
+            try:
+                await start_runtime_when_sandbox_ready(retry=False)
+            except Exception:
+                retry_task = asyncio.create_task(start_runtime_when_sandbox_ready(retry=True))
         try:
             yield
         finally:
+            if retry_task is not None:
+                retry_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await retry_task
             await service.shutdown()
             if sandbox_supervisor is not None:
                 await sandbox_supervisor.shutdown()
@@ -416,6 +439,17 @@ async def _require_sandbox_ready(sandbox_supervisor: Any | None) -> None:
     if sandbox_supervisor is None:
         raise RuntimeError("sandbox worker is not configured")
     await sandbox_supervisor.require_ready()
+
+
+def _sandbox_start_retry_seconds() -> float:
+    value = str(os.environ.get("OPENTULPA_SANDBOX_START_RETRY_SECONDS") or "").strip()
+    if not value:
+        return _SANDBOX_START_RETRY_SECONDS
+    try:
+        parsed = float(value)
+    except ValueError:
+        return _SANDBOX_START_RETRY_SECONDS
+    return max(0.01, min(300.0, parsed))
 
 
 __all__ = ["HOST_SESSION_COOKIE", "create_host_app"]

--- a/src/opentulpa/host/app.py
+++ b/src/opentulpa/host/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -83,6 +83,7 @@ def create_host_app(
     setup_token: str | None = None,
     evolution_service: Any | None = None,
     evolution_token: str | None = None,
+    sandbox_supervisor: Any | None = None,
 ) -> FastAPI:
     """Create the immutable host surface around one mutable Deep Agents child."""
 
@@ -95,16 +96,26 @@ def create_host_app(
 
     @asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-        await service.start()
+        sandbox_ready = False
+        if sandbox_supervisor is not None:
+            # Keep the stable host available so /_host can report the exact sandbox failure.
+            with suppress(Exception):
+                await sandbox_supervisor.start()
+                sandbox_ready = True
+        if sandbox_ready:
+            await service.start()
         try:
             yield
         finally:
             await service.shutdown()
+            if sandbox_supervisor is not None:
+                await sandbox_supervisor.shutdown()
             await proxy_client.aclose()
 
     app = FastAPI(title="OpenTulpa Host", version="2", lifespan=lifespan)
     app.state.host_store = store
     app.state.host_service = service
+    app.state.sandbox_supervisor = sandbox_supervisor
 
     def owner_token(
         request: Request,
@@ -129,13 +140,19 @@ def create_host_app(
             raise HTTPException(status_code=401, detail="owner authentication required")
 
     @app.get("/healthz")
-    async def health() -> dict[str, Any]:
-        return {
-            "ok": True,
-            "host": "ready",
-            "runtime": service.runtime.status,
-            "configured": store.active() is not None,
-        }
+    async def health() -> JSONResponse:
+        sandbox = await _sandbox_status(sandbox_supervisor)
+        ok = bool(sandbox.get("ok"))
+        return JSONResponse(
+            status_code=200 if ok else 503,
+            content={
+                "ok": ok,
+                "host": "ready",
+                "runtime": service.runtime.status,
+                "configured": store.active() is not None,
+                "sandbox": sandbox,
+            },
+        )
 
     @app.get("/agent/healthz")
     async def agent_health() -> Response:
@@ -179,6 +196,7 @@ def create_host_app(
             "claimed": store.claimed,
             "authenticated": authenticated,
             "configured": active is not None,
+            "sandbox": await _sandbox_status(sandbox_supervisor),
             "runtime": {
                 "status": "activating" if service.activating else service.runtime.status,
                 "revision": service.runtime.revision,
@@ -230,6 +248,10 @@ def create_host_app(
         session: Annotated[str | None, Cookie(alias=HOST_SESSION_COOKIE)] = None,
     ) -> dict[str, Any]:
         require_owner(request, authorization, session)
+        try:
+            await _require_sandbox_ready(sandbox_supervisor)
+        except Exception as exc:
+            raise HTTPException(status_code=503, detail=f"Sandbox worker failed: {exc}") from exc
         try:
             config = await service.apply(body)
         except HostConfigConflictError as exc:
@@ -366,6 +388,34 @@ def _set_owner_cookie(response: Response, token: str, *, secure: bool) -> None:
         path="/",
         max_age=60 * 60 * 24 * 30,
     )
+
+
+async def _sandbox_status(sandbox_supervisor: Any | None) -> dict[str, Any]:
+    if sandbox_supervisor is None:
+        return {
+            "ok": False,
+            "step": "missing",
+            "tier": "unavailable",
+            "checks": {},
+            "error": "sandbox worker is not configured",
+        }
+    try:
+        status = await sandbox_supervisor.status()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "step": "status",
+            "tier": "unavailable",
+            "checks": {},
+            "error": str(exc or "sandbox worker failed")[:500],
+        }
+    return dict(status)
+
+
+async def _require_sandbox_ready(sandbox_supervisor: Any | None) -> None:
+    if sandbox_supervisor is None:
+        raise RuntimeError("sandbox worker is not configured")
+    await sandbox_supervisor.require_ready()
 
 
 __all__ = ["HOST_SESSION_COOKIE", "create_host_app"]

--- a/src/opentulpa/host/assets/app.css
+++ b/src/opentulpa/host/assets/app.css
@@ -68,6 +68,18 @@ main { width: min(1040px, calc(100% - 48px)); margin: 0 auto; flex: 1; }
 h1 { font-size: clamp(36px, 6vw, 68px); line-height: 1.02; letter-spacing: -.065em; margin: 0 0 24px; font-weight: 580; }
 .lede { color: #a0a0a0; font-size: 15px; max-width: 680px; margin: 0; }
 
+.status-panel {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  margin: -24px 0 34px;
+  padding: 14px 16px;
+}
+.status-panel.ready { border-color: rgba(120, 184, 146, .45); }
+.status-panel.failed { border-color: rgba(224, 108, 117, .72); background: rgba(224, 108, 117, .06); }
+.status-panel span { display: block; color: var(--green); font-size: 10px; letter-spacing: .13em; margin-bottom: 7px; }
+.status-panel.failed span { color: var(--red); }
+.status-panel p { color: var(--muted); margin: 0; font-size: 12px; }
+
 .command-panel { display: grid; grid-template-columns: 62px 1fr; border-top: 1px solid var(--border); padding: 32px 0 46px; }
 .line-number { color: #444; font-size: 11px; padding-top: 4px; }
 .panel-body { min-width: 0; }

--- a/src/opentulpa/host/assets/app.js
+++ b/src/opentulpa/host/assets/app.js
@@ -26,6 +26,24 @@ function setRuntime(status) {
   $("runtime-label").textContent = `RUNTIME ${String(status || "stopped").toUpperCase()}`;
 }
 
+function setSandbox(sandbox) {
+  const panel = $("sandbox-panel");
+  if (!panel) return;
+  const ok = Boolean(sandbox?.ok);
+  const checks = sandbox?.checks || {};
+  const failed = Object.entries(checks)
+    .filter(([, passed]) => !passed)
+    .map(([name]) => name);
+  panel.classList.remove("hidden", "failed", "ready");
+  panel.classList.add(ok ? "ready" : "failed");
+  $("sandbox-state").textContent = ok
+    ? `SANDBOX READY / ${String(sandbox?.tier || "UNKNOWN").toUpperCase()}`
+    : "SANDBOX FAILED";
+  $("sandbox-detail").textContent = ok
+    ? "Shell and SSH diagnostics can use sandbox execution."
+    : `${sandbox?.error || "Sandbox worker is unavailable."}${failed.length ? ` Failed checks: ${failed.join(", ")}.` : ""}`;
+}
+
 function showAuth(status) {
   $("auth-panel").classList.remove("hidden");
   const needsClaim = !status.claimed;
@@ -40,6 +58,7 @@ function showAuth(status) {
 function render(status) {
   current = status;
   setRuntime(status.runtime.status);
+  setSandbox(status.sandbox);
   if (!status.authenticated) {
     showAuth(status);
     $("config-panel").classList.add("hidden");

--- a/src/opentulpa/host/assets/index.html
+++ b/src/opentulpa/host/assets/index.html
@@ -25,6 +25,11 @@
           <p class="lede">Connect a model, add an interface, and watch the mutable agent start. The host stays up when the agent changes or fails.</p>
         </section>
 
+        <section id="sandbox-panel" class="status-panel hidden" aria-live="polite">
+          <span id="sandbox-state">SANDBOX CHECKING</span>
+          <p id="sandbox-detail">OpenTulpa requires a healthy sandbox worker for shell and SSH diagnostics.</p>
+        </section>
+
         <section id="auth-panel" class="command-panel hidden" aria-labelledby="auth-title">
           <div class="line-number">01</div>
           <div class="panel-body">

--- a/src/opentulpa/host/cli.py
+++ b/src/opentulpa/host/cli.py
@@ -44,6 +44,7 @@ from opentulpa.host.models import HostConfigInput
 from opentulpa.host.runtime import RuntimeSupervisor
 from opentulpa.host.service import HostService
 from opentulpa.host.store import HostStore
+from opentulpa.sandbox.supervisor import SandboxWorkerSupervisor
 from opentulpa.secrets.host_key import load_or_create_host_cipher
 
 
@@ -134,6 +135,15 @@ def build_host_application() -> tuple[Any, str, str, Path]:
             telegram_user_id=telegram_id if telegram_token else None,
         )
     runtime = RuntimeSupervisor(project_root=project_root, data_root=data_root)
+    sandbox = SandboxWorkerSupervisor(
+        project_root=project_root,
+        data_root=data_root,
+        settings=settings,
+    )
+    runtime.configure_sandbox_worker(
+        base_url=sandbox.config.base_url,
+        token=sandbox.config.token,
+    )
     port = int(os.environ.get("PORT") or 8000)
     evolution = build_host_evolution_runtime(
         runtime=runtime,
@@ -158,6 +168,7 @@ def build_host_application() -> tuple[Any, str, str, Path]:
         setup_token=setup_token,
         evolution_service=evolution.service if evolution is not None else None,
         evolution_token=evolution_token if evolution is not None else None,
+        sandbox_supervisor=sandbox,
     )
     return app, host, setup_token, data_root
 

--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -84,6 +84,8 @@ class RuntimeSupervisor:
         self._lock = asyncio.Lock()
         self._evolution_url: str | None = None
         self._evolution_token: str | None = None
+        self._sandbox_url: str | None = None
+        self._sandbox_token: str | None = None
 
     @property
     def endpoint(self) -> str | None:
@@ -127,6 +129,16 @@ class RuntimeSupervisor:
             raise ValueError("evolution control configuration is invalid")
         self._evolution_url = cleaned_url
         self._evolution_token = cleaned_token
+
+    def configure_sandbox_worker(self, *, base_url: str, token: str) -> None:
+        if self._child is not None:
+            raise RuntimeUnavailableError("cannot change sandbox worker while runtime is running")
+        cleaned_url = str(base_url or "").strip().rstrip("/")
+        cleaned_token = str(token or "").strip()
+        if not cleaned_url.startswith("http://") or len(cleaned_token) < 32:
+            raise ValueError("sandbox worker configuration is invalid")
+        self._sandbox_url = cleaned_url
+        self._sandbox_token = cleaned_token
 
     async def start(self, config: HostConfig) -> None:
         async with self._lock:
@@ -240,6 +252,7 @@ class RuntimeSupervisor:
                 if config.telegram_pairing_code is not None
                 else "",
                 self._evolution_token or "",
+                self._sandbox_token or "",
             )
             if value
         }
@@ -386,6 +399,13 @@ class RuntimeSupervisor:
                     "EVOLUTION_ENABLED": "true",
                     "OPENTULPA_BOOTSTRAP_EVOLUTION_URL": self._evolution_url,
                     "OPENTULPA_BOOTSTRAP_EVOLUTION_TOKEN": self._evolution_token,
+                }
+            )
+        if self._sandbox_url is not None and self._sandbox_token is not None:
+            environment.update(
+                {
+                    "OPENTULPA_SANDBOX_RPC_URL": self._sandbox_url,
+                    "OPENTULPA_SANDBOX_RPC_TOKEN": self._sandbox_token,
                 }
             )
         if config.telegram_pairing_code is not None:

--- a/src/opentulpa/sandbox/__init__.py
+++ b/src/opentulpa/sandbox/__init__.py
@@ -1,0 +1,5 @@
+"""Mandatory sandbox worker/client boundary for OpenTulpa deployments."""
+
+from opentulpa.sandbox.client import SandboxWorkerExecutionProvider, SandboxWorkerHealth
+
+__all__ = ["SandboxWorkerExecutionProvider", "SandboxWorkerHealth"]

--- a/src/opentulpa/sandbox/client.py
+++ b/src/opentulpa/sandbox/client.py
@@ -1,0 +1,334 @@
+"""Host-side client for the mandatory OpenTulpa sandbox worker."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+import tarfile
+import threading
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import httpx
+from deepagents.backends.protocol import ExecuteResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SandboxWorkerClientError(RuntimeError):
+    """Sanitized worker-client failure."""
+
+
+class SandboxWorkerHealth(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool
+    tier: str
+    checks: dict[str, bool]
+    error: str | None = None
+
+
+class SandboxWorkerCanary(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool
+    step: str
+    health: SandboxWorkerHealth | None = None
+    error: str | None = None
+
+
+class SandboxSecretFileMount(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=80)
+    content: str = Field(min_length=1, max_length=200_000)
+    env: str | None = Field(default=None, max_length=80)
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceBinding:
+    workspace_id: str
+    kind: str
+
+
+class SandboxWorkerExecutionProvider:
+    """Execution provider backed by the private sandbox worker API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str,
+        max_response_bytes: int,
+        max_archive_bytes: int,
+        max_archive_entries: int,
+        max_file_bytes: int,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        cleaned_url = str(base_url or "").strip().rstrip("/")
+        parsed = httpx.URL(cleaned_url)
+        if parsed.scheme != "http" or not parsed.host:
+            raise ValueError("sandbox worker URL must be an internal HTTP URL")
+        safe_token = str(token or "").strip()
+        if len(safe_token) < 32:
+            raise ValueError("sandbox worker token must contain at least 32 characters")
+        if max_response_bytes < 4_096:
+            raise ValueError("sandbox worker response limit is invalid")
+        if max_archive_bytes < 1_024 or max_archive_entries < 1 or max_file_bytes < 1:
+            raise ValueError("sandbox worker archive limits are invalid")
+        self._base_url = cleaned_url
+        self._headers = {"X-OpenTulpa-Sandbox-Token": safe_token}
+        self._max_response_bytes = max_response_bytes
+        self._max_archive_bytes = max_archive_bytes
+        self._max_archive_entries = max_archive_entries
+        self._max_file_bytes = max_file_bytes
+        self._transport = transport
+        self._bindings: dict[str, _WorkspaceBinding] = {}
+        self._bindings_lock = threading.Lock()
+
+    def health(self) -> SandboxWorkerHealth:
+        try:
+            payload = self._request("GET", "/health", timeout=5).json()
+            return SandboxWorkerHealth.model_validate(payload)
+        except Exception as exc:
+            return SandboxWorkerHealth(
+                ok=False,
+                tier="unavailable",
+                checks={"reachable": False},
+                error=_safe_error(exc),
+            )
+
+    def canary(self) -> SandboxWorkerCanary:
+        health = self.health()
+        if not health.ok:
+            return SandboxWorkerCanary(ok=False, step="health", health=health, error=health.error)
+        workspace_id: str | None = None
+        try:
+            workspace_id = self._create_workspace(kind="scratch", tenant_id="canary")
+            result = self._execute_workspace(
+                workspace_id=workspace_id,
+                command="printf opentulpa-sandbox-canary",
+                timeout=5,
+                secret_files=(),
+            )
+            if result.exit_code != 0 or result.output.strip() != "opentulpa-sandbox-canary":
+                return SandboxWorkerCanary(
+                    ok=False,
+                    step="execute",
+                    health=health,
+                    error="sandbox canary command failed",
+                )
+            ssh = self._execute_workspace(
+                workspace_id=workspace_id,
+                command="ssh -V",
+                timeout=5,
+                secret_files=(),
+            )
+            if ssh.exit_code != 0:
+                return SandboxWorkerCanary(
+                    ok=False,
+                    step="ssh",
+                    health=health,
+                    error="sandbox worker does not provide ssh",
+                )
+            return SandboxWorkerCanary(ok=True, step="ready", health=health)
+        except Exception as exc:
+            return SandboxWorkerCanary(
+                ok=False,
+                step="workspace",
+                health=health,
+                error=_safe_error(exc),
+            )
+        finally:
+            if workspace_id is not None:
+                with suppress(SandboxWorkerClientError):
+                    self._delete_workspace(workspace_id)
+
+    def execute(
+        self,
+        *,
+        tenant_id: str,
+        command: str,
+        timeout: int,
+        workspace: Path | None = None,
+        cancel_event: threading.Event | None = None,
+        secret_files: tuple[SandboxSecretFileMount, ...] = (),
+    ) -> ExecuteResponse:
+        if cancel_event is not None and cancel_event.is_set():
+            return ExecuteResponse(output="sandbox execution was cancelled", exit_code=130, truncated=False)
+        if workspace is None:
+            workspace_id = self._create_workspace(kind="scratch", tenant_id=tenant_id)
+            try:
+                return self._execute_workspace(
+                    workspace_id=workspace_id,
+                    command=command,
+                    timeout=timeout,
+                    secret_files=secret_files,
+                )
+            finally:
+                self._delete_workspace(workspace_id)
+        binding = self._binding_for(tenant_id=tenant_id, kind="scratch")
+        self._upload_archive(binding.workspace_id, workspace)
+        result = self._execute_workspace(
+            workspace_id=binding.workspace_id,
+            command=command,
+            timeout=timeout,
+            secret_files=secret_files,
+        )
+        self._download_archive(binding.workspace_id, workspace)
+        return result
+
+    def _binding_for(self, *, tenant_id: str, kind: str) -> _WorkspaceBinding:
+        safe_tenant = str(tenant_id or "").strip()
+        if not safe_tenant:
+            raise ValueError("tenant_id is required")
+        key = f"{kind}:{safe_tenant}"
+        with self._bindings_lock:
+            existing = self._bindings.get(key)
+            if existing is not None:
+                return existing
+            workspace_id = self._create_workspace(kind=kind, tenant_id=safe_tenant)
+            binding = _WorkspaceBinding(workspace_id=workspace_id, kind=kind)
+            self._bindings[key] = binding
+            return binding
+
+    def _create_workspace(self, *, kind: str, tenant_id: str) -> str:
+        response = self._request(
+            "POST",
+            "/workspaces",
+            json={"kind": kind, "tenant_id": tenant_id},
+            timeout=10,
+        )
+        value = str(response.json().get("workspace_id") or "").strip()
+        if not value:
+            raise SandboxWorkerClientError("sandbox worker returned no workspace id")
+        return value
+
+    def _delete_workspace(self, workspace_id: str) -> None:
+        self._request("DELETE", f"/workspaces/{workspace_id}", timeout=10)
+
+    def _execute_workspace(
+        self,
+        *,
+        workspace_id: str,
+        command: str,
+        timeout: int,
+        secret_files: tuple[SandboxSecretFileMount, ...],
+    ) -> ExecuteResponse:
+        response = self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/execute",
+            json={
+                "command": command,
+                "timeout": timeout,
+                "secret_files": [item.model_dump(mode="json") for item in secret_files],
+            },
+            timeout=timeout + 10,
+        )
+        payload = response.json()
+        return ExecuteResponse(
+            output=str(payload.get("output") or ""),
+            exit_code=int(payload.get("exit_code") or 0),
+            truncated=bool(payload.get("truncated")),
+        )
+
+    def _upload_archive(self, workspace_id: str, workspace: Path) -> None:
+        encoded = self._archive_workspace(workspace)
+        self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/archive",
+            json={"archive": encoded},
+            timeout=30,
+        )
+
+    def _download_archive(self, workspace_id: str, workspace: Path) -> None:
+        response = self._request("GET", f"/workspaces/{workspace_id}/archive", timeout=30)
+        encoded = str(response.json().get("archive") or "")
+        self._replace_workspace(workspace, encoded)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float,
+    ) -> httpx.Response:
+        try:
+            with httpx.Client(
+                follow_redirects=False,
+                timeout=timeout,
+                trust_env=False,
+                transport=self._transport,
+            ) as client:
+                response = client.request(
+                    method,
+                    f"{self._base_url}{path}",
+                    headers=self._headers,
+                    json=json,
+                )
+        except httpx.HTTPError as exc:
+            raise SandboxWorkerClientError("sandbox worker is unavailable") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise SandboxWorkerClientError("sandbox worker rejected the request")
+        if len(response.content) > self._max_response_bytes:
+            raise SandboxWorkerClientError("sandbox worker response exceeded its limit")
+        return response
+
+    def _archive_workspace(self, workspace: Path) -> str:
+        root = workspace.expanduser().resolve(strict=True)
+        if root.is_symlink() or not root.is_dir():
+            raise SandboxWorkerClientError("sandbox workspace is invalid")
+        with io.BytesIO() as buffer:
+            with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+                archive.add(root, arcname=".", recursive=True)
+            raw = buffer.getvalue()
+        if len(raw) > self._max_archive_bytes:
+            raise SandboxWorkerClientError("sandbox workspace archive exceeds its limit")
+        return base64.b64encode(raw).decode("ascii")
+
+    def _replace_workspace(self, workspace: Path, encoded_archive: str) -> None:
+        try:
+            raw = base64.b64decode(encoded_archive, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise SandboxWorkerClientError("sandbox workspace archive is invalid") from exc
+        if len(raw) > self._max_archive_bytes:
+            raise SandboxWorkerClientError("sandbox workspace archive exceeds its limit")
+        root = workspace.expanduser().resolve(strict=True)
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as archive:
+            members = archive.getmembers()
+            if len(members) > self._max_archive_entries:
+                raise SandboxWorkerClientError("sandbox workspace archive entry limit exceeded")
+            for member in members:
+                path = PurePosixPath(member.name)
+                if path.is_absolute() or ".." in path.parts:
+                    raise SandboxWorkerClientError("sandbox workspace archive path is invalid")
+                if not (member.isdir() or member.isreg()):
+                    raise SandboxWorkerClientError(
+                        "sandbox workspace archive contains unsupported entries"
+                    )
+                if member.isreg() and member.size > self._max_file_bytes:
+                    raise SandboxWorkerClientError("sandbox workspace archive file limit exceeded")
+            for child in root.iterdir():
+                if child.is_dir():
+                    import shutil
+
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
+            archive.extractall(root, filter="data")
+
+
+def _safe_error(error: Exception) -> str:
+    return str(error or "sandbox worker failed").strip()[:500]
+
+
+__all__ = [
+    "SandboxSecretFileMount",
+    "SandboxWorkerCanary",
+    "SandboxWorkerClientError",
+    "SandboxWorkerExecutionProvider",
+    "SandboxWorkerHealth",
+]

--- a/src/opentulpa/sandbox/supervisor.py
+++ b/src/opentulpa/sandbox/supervisor.py
@@ -1,0 +1,210 @@
+"""Host-owned sandbox worker lifecycle and readiness checks."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+import socket
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from opentulpa.core.config import Settings
+from opentulpa.sandbox.client import (
+    SandboxWorkerCanary,
+    SandboxWorkerExecutionProvider,
+    SandboxWorkerHealth,
+)
+
+
+def _private_token(path: Path) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.parent.is_symlink():
+        raise RuntimeError("sandbox credential directory cannot be a symlink")
+    if not path.exists():
+        value = secrets.token_urlsafe(48)
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(f"{value}\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+    if path.is_symlink() or not path.is_file() or path.stat().st_mode & 0o077:
+        raise RuntimeError("sandbox credential must be a private regular file")
+    value = path.read_text(encoding="utf-8").strip()
+    if len(value) < 32:
+        raise RuntimeError("sandbox credential is invalid")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxRuntimeConfig:
+    base_url: str
+    token: str
+
+
+class SandboxWorkerSupervisor:
+    """Start or bind the mandatory sandbox worker for one host process."""
+
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        data_root: Path,
+        settings: Settings,
+    ) -> None:
+        self._project_root = project_root.resolve()
+        self._data_root = data_root.resolve()
+        self._settings = settings
+        configured_url = str(os.environ.get("OPENTULPA_SANDBOX_RPC_URL") or "").strip()
+        configured_token = str(os.environ.get("OPENTULPA_SANDBOX_RPC_TOKEN") or "").strip()
+        if configured_url or configured_token:
+            if not configured_url or len(configured_token) < 32:
+                raise RuntimeError(
+                    "OPENTULPA_SANDBOX_RPC_URL and OPENTULPA_SANDBOX_RPC_TOKEN are both required"
+                )
+            self._config = SandboxRuntimeConfig(
+                base_url=configured_url.rstrip("/"),
+                token=configured_token,
+            )
+            self._managed_process = False
+        else:
+            token = _private_token(data_root / "bootstrap" / "sandbox-worker.token")
+            port = _free_local_port()
+            self._config = SandboxRuntimeConfig(
+                base_url=f"http://127.0.0.1:{port}/internal/v1/sandbox",
+                token=token,
+            )
+            self._managed_process = True
+        self._process: asyncio.subprocess.Process | None = None
+        self._client = SandboxWorkerExecutionProvider(
+            base_url=self._config.base_url,
+            token=self._config.token,
+            max_response_bytes=settings.sandbox_max_output_bytes + 65_536,
+            max_archive_bytes=settings.railway_sandbox_max_sync_bytes,
+            max_archive_entries=settings.sandbox_max_workspace_entries,
+            max_file_bytes=settings.sandbox_max_file_bytes,
+        )
+        self._last_canary: SandboxWorkerCanary | None = None
+
+    @property
+    def config(self) -> SandboxRuntimeConfig:
+        return self._config
+
+    @property
+    def client(self) -> SandboxWorkerExecutionProvider:
+        return self._client
+
+    @property
+    def last_canary(self) -> SandboxWorkerCanary | None:
+        return self._last_canary
+
+    async def start(self) -> None:
+        if self._managed_process and self._process is None:
+            self._process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "opentulpa.sandbox.worker",
+                cwd=self._project_root,
+                env=self._worker_environment(),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        await self.require_ready()
+
+    async def require_ready(self) -> None:
+        deadline = asyncio.get_running_loop().time() + 30
+        last: SandboxWorkerCanary | None = None
+        while asyncio.get_running_loop().time() < deadline:
+            if self._process is not None and self._process.returncode is not None:
+                break
+            last = await asyncio.to_thread(self._client.canary)
+            self._last_canary = last
+            if last.ok:
+                return
+            if last.health is not None and last.health.tier != "unavailable":
+                break
+            await asyncio.sleep(0.25)
+        detail = _canary_summary(last or self._client.canary())
+        raise RuntimeError(f"sandbox worker failed readiness: {detail}")
+
+    async def status(self) -> dict[str, object]:
+        canary = await asyncio.to_thread(self._client.canary)
+        self._last_canary = canary
+        return _canary_payload(canary)
+
+    async def shutdown(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None or process.returncode is not None:
+            return
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=10)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+
+    def _worker_environment(self) -> dict[str, str]:
+        root = self._data_root / "sandbox_worker"
+        environment = {
+            "HOST": "127.0.0.1",
+            "PORT": self._config.base_url.split(":", 2)[2].split("/", 1)[0],
+            "PATH": os.environ.get("PATH", os.defpath),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "PYTHONPATH": str(self._project_root / "src"),
+            "OPENTULPA_SANDBOX_RPC_TOKEN": self._config.token,
+            "OPENTULPA_SANDBOX_WORKER_ROOT": str(root),
+            "OPENTULPA_SANDBOX_MAX_OUTPUT_BYTES": str(self._settings.sandbox_max_output_bytes),
+            "OPENTULPA_SANDBOX_MAX_ARCHIVE_BYTES": str(
+                self._settings.railway_sandbox_max_sync_bytes
+            ),
+            "OPENTULPA_SANDBOX_MAX_ENTRIES": str(
+                self._settings.sandbox_max_workspace_entries
+            ),
+            "OPENTULPA_SANDBOX_MAX_FILE_BYTES": str(self._settings.sandbox_max_file_bytes),
+            "OPENTULPA_SANDBOX_CPU_LIMIT": self._settings.sandbox_cpu_limit,
+            "OPENTULPA_SANDBOX_MEMORY_LIMIT": self._settings.sandbox_memory_limit,
+            "OPENTULPA_SANDBOX_PID_LIMIT": str(self._settings.sandbox_pid_limit),
+            "OPENTULPA_SANDBOX_TIMEOUT_SECONDS": str(self._settings.sandbox_timeout_seconds),
+        }
+        if str(os.environ.get("OPENTULPA_DEV_ALLOW_NO_SANDBOX") or "").strip():
+            environment["OPENTULPA_DEV_ALLOW_NO_SANDBOX"] = str(
+                os.environ.get("OPENTULPA_DEV_ALLOW_NO_SANDBOX")
+            )
+        return environment
+
+
+def _canary_payload(canary: SandboxWorkerCanary) -> dict[str, object]:
+    health: SandboxWorkerHealth | None = canary.health
+    return {
+        "ok": canary.ok,
+        "step": canary.step,
+        "tier": health.tier if health is not None else "unavailable",
+        "checks": health.checks if health is not None else {},
+        "error": canary.error or (health.error if health is not None else None),
+    }
+
+
+def _canary_summary(canary: SandboxWorkerCanary | None) -> str:
+    if canary is None:
+        return "sandbox worker did not respond"
+    payload = _canary_payload(canary)
+    checks = payload.get("checks")
+    failed = [
+        name
+        for name, passed in (checks.items() if isinstance(checks, dict) else ())
+        if not bool(passed)
+    ]
+    if failed:
+        return f"{payload['step']} failed checks: {', '.join(failed)}"
+    return str(payload.get("error") or f"{payload['step']} failed")
+
+
+def _free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+__all__ = ["SandboxRuntimeConfig", "SandboxWorkerSupervisor"]

--- a/src/opentulpa/sandbox/supervisor.py
+++ b/src/opentulpa/sandbox/supervisor.py
@@ -7,6 +7,7 @@ import os
 import secrets
 import socket
 import sys
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from opentulpa.sandbox.client import (
     SandboxWorkerExecutionProvider,
     SandboxWorkerHealth,
 )
+
+_DEFAULT_HEALTH_INTERVAL_SECONDS = 15.0
 
 
 def _private_token(path: Path) -> str:
@@ -86,6 +89,15 @@ class SandboxWorkerSupervisor:
             max_file_bytes=settings.sandbox_max_file_bytes,
         )
         self._last_canary: SandboxWorkerCanary | None = None
+        self._start_lock = asyncio.Lock()
+        self._canary_lock = asyncio.Lock()
+        self._monitor_task: asyncio.Task[None] | None = None
+        self._health_interval_seconds = _positive_float_env(
+            "OPENTULPA_SANDBOX_HEALTH_INTERVAL_SECONDS",
+            default=_DEFAULT_HEALTH_INTERVAL_SECONDS,
+            minimum=1.0,
+            maximum=300.0,
+        )
 
     @property
     def config(self) -> SandboxRuntimeConfig:
@@ -100,40 +112,54 @@ class SandboxWorkerSupervisor:
         return self._last_canary
 
     async def start(self) -> None:
-        if self._managed_process and self._process is None:
-            self._process = await asyncio.create_subprocess_exec(
-                sys.executable,
-                "-m",
-                "opentulpa.sandbox.worker",
-                cwd=self._project_root,
-                env=self._worker_environment(),
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
+        await self._ensure_managed_process()
         await self.require_ready()
+        self._ensure_monitor()
 
     async def require_ready(self) -> None:
-        deadline = asyncio.get_running_loop().time() + 30
-        last: SandboxWorkerCanary | None = None
-        while asyncio.get_running_loop().time() < deadline:
-            if self._process is not None and self._process.returncode is not None:
-                break
-            last = await asyncio.to_thread(self._client.canary)
-            self._last_canary = last
-            if last.ok:
-                return
-            if last.health is not None and last.health.tier != "unavailable":
-                break
-            await asyncio.sleep(0.25)
-        detail = _canary_summary(last or self._client.canary())
+        await self._ensure_managed_process()
+        async with self._canary_lock:
+            deadline = asyncio.get_running_loop().time() + 30
+            last: SandboxWorkerCanary | None = None
+            while asyncio.get_running_loop().time() < deadline:
+                if self._process is not None and self._process.returncode is not None:
+                    last = _unavailable_canary(
+                        step="process",
+                        error="sandbox worker process exited",
+                        checks={"reachable": False},
+                    )
+                    self._last_canary = last
+                    break
+                last = await asyncio.to_thread(self._client.canary)
+                self._last_canary = last
+                if last.ok:
+                    return
+                if last.health is not None and last.health.tier != "unavailable":
+                    break
+                await asyncio.sleep(0.25)
+            detail = _canary_summary(last or self._client.canary())
         raise RuntimeError(f"sandbox worker failed readiness: {detail}")
 
     async def status(self) -> dict[str, object]:
-        canary = await asyncio.to_thread(self._client.canary)
-        self._last_canary = canary
+        if self._process is not None and self._process.returncode is not None:
+            self._last_canary = _unavailable_canary(
+                step="process",
+                error="sandbox worker process exited",
+                checks={"reachable": False},
+            )
+        canary = self._last_canary or _unavailable_canary(
+            step="startup",
+            error="sandbox worker readiness has not completed",
+        )
         return _canary_payload(canary)
 
     async def shutdown(self) -> None:
+        task = self._monitor_task
+        self._monitor_task = None
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
         process = self._process
         self._process = None
         if process is None or process.returncode is not None:
@@ -144,6 +170,55 @@ class SandboxWorkerSupervisor:
         except TimeoutError:
             process.kill()
             await process.wait()
+
+    async def _ensure_managed_process(self) -> None:
+        if not self._managed_process:
+            return
+        async with self._start_lock:
+            if self._process is not None and self._process.returncode is None:
+                return
+            self._process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "opentulpa.sandbox.worker",
+                cwd=self._project_root,
+                env=self._worker_environment(),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+
+    def _ensure_monitor(self) -> None:
+        task = self._monitor_task
+        if task is None or task.done():
+            self._monitor_task = asyncio.create_task(self._monitor())
+
+    async def _monitor(self) -> None:
+        while True:
+            await asyncio.sleep(self._health_interval_seconds)
+            if (
+                self._managed_process
+                and self._process is not None
+                and self._process.returncode is not None
+            ):
+                self._last_canary = _unavailable_canary(
+                    step="process",
+                    error="sandbox worker process exited",
+                    checks={"reachable": False},
+                )
+                with suppress(Exception):
+                    await self.start()
+                continue
+            async with self._canary_lock:
+                canary = await asyncio.to_thread(self._client.canary)
+                self._last_canary = canary
+            if (
+                self._managed_process
+                and not canary.ok
+                and canary.health is not None
+                and canary.health.tier == "unavailable"
+            ):
+                with suppress(Exception):
+                    await self.start()
 
     def _worker_environment(self) -> dict[str, str]:
         root = self._data_root / "sandbox_worker"
@@ -199,6 +274,42 @@ def _canary_summary(canary: SandboxWorkerCanary | None) -> str:
     if failed:
         return f"{payload['step']} failed checks: {', '.join(failed)}"
     return str(payload.get("error") or f"{payload['step']} failed")
+
+
+def _unavailable_canary(
+    *,
+    step: str,
+    error: str,
+    checks: dict[str, bool] | None = None,
+) -> SandboxWorkerCanary:
+    return SandboxWorkerCanary(
+        ok=False,
+        step=step,
+        health=SandboxWorkerHealth(
+            ok=False,
+            tier="unavailable",
+            checks=checks or {},
+            error=error,
+        ),
+        error=error,
+    )
+
+
+def _positive_float_env(
+    name: str,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    value = str(os.environ.get(name) or "").strip()
+    if not value:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, parsed))
 
 
 def _free_local_port() -> int:

--- a/src/opentulpa/sandbox/worker.py
+++ b/src/opentulpa/sandbox/worker.py
@@ -39,7 +39,6 @@ _SENSITIVE_COMPONENTS = frozenset(
     {
         ".aws",
         ".docker",
-        ".git",
         ".gnupg",
         ".kube",
         ".netrc",

--- a/src/opentulpa/sandbox/worker.py
+++ b/src/opentulpa/sandbox/worker.py
@@ -1,0 +1,637 @@
+"""Private mandatory sandbox worker service."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+import os
+import re
+import secrets
+import shutil
+import signal
+import subprocess
+import tarfile
+import tempfile
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path, PurePosixPath
+from typing import Annotated, Protocol
+
+import uvicorn
+from deepagents.backends.protocol import ExecuteResponse
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from opentulpa.deep_agent.process_sandbox import RestrictedProcessExecutionProvider
+from opentulpa.deep_agent.sandbox import TenantContainerPolicy
+from opentulpa.evolution.sandbox import CandidateProcessBackend
+
+_WORKSPACE_ID_PATTERN = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9_.-]{0,99}\Z")
+_WORKSPACE_KIND_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_SECRET_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,80}\Z")
+_ENV_NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}\Z")
+_WORKSPACE_KIND_FIELD_PATTERN = r"[a-z][a-z0-9_]{0,63}$"
+_SECRET_NAME_FIELD_PATTERN = r"[A-Za-z0-9_.-]{1,80}$"
+_ENV_NAME_FIELD_PATTERN = r"[A-Za-z_][A-Za-z0-9_]{0,79}$"
+_SENSITIVE_COMPONENTS = frozenset(
+    {
+        ".aws",
+        ".docker",
+        ".git",
+        ".gnupg",
+        ".kube",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".ssh",
+        "containerd.sock",
+        "credentials",
+        "credentials.json",
+        "docker.sock",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "id_rsa",
+        "podman.sock",
+    }
+)
+
+
+class SandboxWorkerError(RuntimeError):
+    """Sanitized sandbox worker failure."""
+
+
+class _SandboxModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class SandboxHealthResult(_SandboxModel):
+    ok: bool
+    tier: str
+    checks: dict[str, bool]
+    error: str | None = None
+
+
+class SandboxWorkspaceCreateRequest(_SandboxModel):
+    kind: str = Field(default="scratch", pattern=_WORKSPACE_KIND_FIELD_PATTERN)
+    tenant_id: str = Field(default="owner", min_length=1, max_length=512)
+
+
+class SandboxWorkspaceResult(_SandboxModel):
+    workspace_id: str
+    kind: str
+
+
+class SandboxArchiveRequest(_SandboxModel):
+    archive: str = Field(min_length=1)
+
+
+class SandboxArchiveResult(_SandboxModel):
+    archive: str
+
+
+class SandboxSecretFile(_SandboxModel):
+    name: str = Field(pattern=_SECRET_NAME_FIELD_PATTERN)
+    content: str = Field(min_length=1, max_length=200_000)
+    env: str | None = Field(default=None, pattern=_ENV_NAME_FIELD_PATTERN)
+
+
+class SandboxExecuteRequest(_SandboxModel):
+    command: str = Field(min_length=1, max_length=100_000)
+    timeout: int = Field(ge=1, le=3_600)
+    secret_files: list[SandboxSecretFile] = Field(default_factory=list, max_length=8)
+
+
+class SandboxExecuteResult(_SandboxModel):
+    output: str
+    exit_code: int
+    truncated: bool
+
+
+class SandboxExecutionEngine(Protocol):
+    """Backend used by the private worker to run inside one workspace."""
+
+    @property
+    def tier(self) -> str: ...
+
+    def health_checks(self) -> dict[str, bool]: ...
+
+    def execute(
+        self,
+        *,
+        workspace: Path,
+        command: str,
+        timeout: int,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecuteResponse: ...
+
+
+class RestrictedProcessEngine:
+    """Production Linux worker backend using the existing unprivileged process sandbox."""
+
+    def __init__(
+        self,
+        *,
+        policy: TenantContainerPolicy,
+        max_workspace_bytes: int,
+    ) -> None:
+        self._policy = policy
+        self._provider = (
+            RestrictedProcessExecutionProvider(
+                policy=policy,
+                max_workspace_bytes=max_workspace_bytes,
+            )
+            if CandidateProcessBackend.supported()
+            else None
+        )
+
+    @property
+    def tier(self) -> str:
+        return "native-process"
+
+    def health_checks(self) -> dict[str, bool]:
+        return {
+            "linux_root": bool(
+                os.name == "posix"
+                and hasattr(os, "geteuid")
+                and os.geteuid() == 0
+            ),
+            "setpriv": shutil.which("setpriv") is not None,
+            "prlimit": shutil.which("prlimit") is not None,
+            "ssh": shutil.which("ssh") is not None,
+        }
+
+    def execute(
+        self,
+        *,
+        workspace: Path,
+        command: str,
+        timeout: int,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecuteResponse:
+        if self._provider is None:
+            return ExecuteResponse(
+                output="sandbox worker native process backend is unavailable",
+                exit_code=127,
+                truncated=False,
+            )
+        return self._provider.execute(
+            tenant_id="worker",
+            command=command,
+            timeout=timeout,
+            workspace=workspace,
+            cancel_event=cancel_event,
+        )
+
+
+class DevProcessEngine:
+    """Explicit dev-only executor for tests and local iteration without root privileges."""
+
+    def __init__(self, *, max_output_bytes: int) -> None:
+        self._max_output_bytes = max_output_bytes
+
+    @property
+    def tier(self) -> str:
+        return "dev-process"
+
+    def health_checks(self) -> dict[str, bool]:
+        return {"dev_mode": True, "ssh": shutil.which("ssh") is not None}
+
+    def execute(
+        self,
+        *,
+        workspace: Path,
+        command: str,
+        timeout: int,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecuteResponse:
+        process = subprocess.Popen(
+            ["/bin/sh", "-lc", command],
+            cwd=workspace,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env={
+                "HOME": str(workspace),
+                "LANG": os.environ.get("LANG", "C.UTF-8"),
+                "PATH": os.environ.get("PATH", os.defpath),
+            },
+            start_new_session=True,
+        )
+        try:
+            stdout, _ = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            with suppress(OSError, ProcessLookupError):
+                os.killpg(process.pid, signal.SIGTERM)
+            with suppress(subprocess.TimeoutExpired):
+                stdout, _ = process.communicate(timeout=2)
+            if process.poll() is None:
+                with suppress(OSError, ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                stdout, _ = process.communicate()
+            truncated = len(stdout) > self._max_output_bytes
+            output = stdout[: self._max_output_bytes].decode("utf-8", errors="replace")
+            return ExecuteResponse(
+                output=(output + "\ncommand timed out").strip(),
+                exit_code=124,
+                truncated=truncated,
+            )
+        if cancel_event is not None and cancel_event.is_set():
+            return ExecuteResponse(output="sandbox execution was cancelled", exit_code=130, truncated=False)
+        truncated = len(stdout) > self._max_output_bytes
+        return ExecuteResponse(
+            output=stdout[: self._max_output_bytes].decode("utf-8", errors="replace"),
+            exit_code=int(process.returncode or 0),
+            truncated=truncated,
+        )
+
+
+class SandboxWorkerService:
+    """Own tenant workspaces and execute commands without host application secrets."""
+
+    def __init__(
+        self,
+        *,
+        root: Path,
+        engine: SandboxExecutionEngine,
+        max_archive_bytes: int,
+        max_entries: int,
+        max_file_bytes: int,
+    ) -> None:
+        configured = root.expanduser()
+        if configured.is_symlink():
+            raise ValueError("sandbox root cannot be a symlink")
+        configured.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._root = configured.resolve(strict=True)
+        self._workspaces = self._root / "workspaces"
+        self._workspaces.mkdir(mode=0o700, exist_ok=True)
+        self._engine = engine
+        self._max_archive_bytes = max_archive_bytes
+        self._max_entries = max_entries
+        self._max_file_bytes = max_file_bytes
+        self._lock = threading.Lock()
+
+    def health(self) -> SandboxHealthResult:
+        checks = self._engine.health_checks()
+        canary = False
+        if checks and all(checks.values()):
+            with tempfile.TemporaryDirectory(prefix="opentulpa-sandbox-health-", dir=self._root) as tmp:
+                workspace = Path(tmp)
+                result = self._engine.execute(
+                    workspace=workspace,
+                    command="printf opentulpa-sandbox-ready",
+                    timeout=5,
+                )
+                canary = (
+                    result.exit_code == 0
+                    and result.output.strip() == "opentulpa-sandbox-ready"
+                )
+        checks["execute"] = canary
+        ok = all(checks.values())
+        return SandboxHealthResult(
+            ok=ok,
+            tier=self._engine.tier,
+            checks=checks,
+            error=None if ok else "sandbox worker canary failed",
+        )
+
+    def create_workspace(self, *, kind: str, tenant_id: str) -> SandboxWorkspaceResult:
+        del tenant_id
+        if _WORKSPACE_KIND_PATTERN.fullmatch(kind) is None:
+            raise SandboxWorkerError("workspace kind is invalid")
+        workspace_id = f"{kind}-{secrets.token_urlsafe(18).replace('-', '_')}"
+        path = self._workspace_path(workspace_id, must_exist=False)
+        path.mkdir(mode=0o700)
+        return SandboxWorkspaceResult(workspace_id=workspace_id, kind=kind)
+
+    def delete_workspace(self, workspace_id: str) -> None:
+        path = self._workspace_path(workspace_id)
+        shutil.rmtree(path)
+
+    def put_archive(self, workspace_id: str, encoded_archive: str) -> None:
+        workspace = self._workspace_path(workspace_id)
+        raw = self._decode_archive(encoded_archive)
+        with self._lock:
+            replacement = workspace.parent / f".{workspace.name}.replace-{secrets.token_hex(8)}"
+            replacement.mkdir(mode=0o700)
+            try:
+                self._extract_archive(raw, replacement)
+                self._validate_tree(replacement)
+                backup = workspace.parent / f".{workspace.name}.previous-{secrets.token_hex(8)}"
+                os.replace(workspace, backup)
+                os.replace(replacement, workspace)
+                shutil.rmtree(backup, ignore_errors=True)
+            except Exception:
+                shutil.rmtree(replacement, ignore_errors=True)
+                raise
+
+    def get_archive(self, workspace_id: str) -> str:
+        workspace = self._workspace_path(workspace_id)
+        self._validate_tree(workspace)
+        with tempfile.SpooledTemporaryFile(max_size=1_000_000) as archive_file:
+            with tarfile.open(fileobj=archive_file, mode="w:gz") as archive:
+                archive.add(workspace, arcname=".", recursive=True)
+            size = archive_file.tell()
+            if size > self._max_archive_bytes:
+                raise SandboxWorkerError("workspace archive exceeds its limit")
+            archive_file.seek(0)
+            return base64.b64encode(archive_file.read()).decode("ascii")
+
+    def execute(
+        self,
+        *,
+        workspace_id: str,
+        command: str,
+        timeout: int,
+        secret_files: list[SandboxSecretFile],
+    ) -> ExecuteResponse:
+        workspace = self._workspace_path(workspace_id)
+        self._validate_tree(workspace)
+        with self._temporary_secret_files(workspace, secret_files) as secrets_context:
+            result = self._engine.execute(
+                workspace=workspace,
+                command=self._with_secret_environment(command, secrets_context.environment),
+                timeout=timeout,
+            )
+            output = result.output
+            for value in secrets_context.values:
+                if value:
+                    output = output.replace(value, "[redacted]")
+            response = ExecuteResponse(
+                output=output,
+                exit_code=result.exit_code,
+                truncated=result.truncated,
+            )
+        self._validate_tree(workspace)
+        return response
+
+    def _workspace_path(self, workspace_id: str, *, must_exist: bool = True) -> Path:
+        if _WORKSPACE_ID_PATTERN.fullmatch(str(workspace_id or "")) is None:
+            raise SandboxWorkerError("workspace id is invalid")
+        path = (self._workspaces / workspace_id).resolve()
+        if not path.is_relative_to(self._workspaces):
+            raise SandboxWorkerError("workspace escaped sandbox root")
+        if must_exist and (not path.exists() or path.is_symlink() or not path.is_dir()):
+            raise SandboxWorkerError("workspace is unavailable")
+        return path
+
+    def _decode_archive(self, encoded_archive: str) -> bytes:
+        try:
+            raw = base64.b64decode(encoded_archive, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise SandboxWorkerError("workspace archive is invalid") from exc
+        if len(raw) > self._max_archive_bytes:
+            raise SandboxWorkerError("workspace archive exceeds its limit")
+        return raw
+
+    def _extract_archive(self, raw: bytes, target: Path) -> None:
+        try:
+            with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as archive:
+                members = archive.getmembers()
+                if len(members) > self._max_entries:
+                    raise SandboxWorkerError("workspace archive entry limit exceeded")
+                total_size = 0
+                for member in members:
+                    path = PurePosixPath(member.name)
+                    if path.is_absolute() or ".." in path.parts:
+                        raise SandboxWorkerError("workspace archive path is invalid")
+                    if not (member.isdir() or member.isreg()):
+                        raise SandboxWorkerError("workspace archive contains an unsupported entry")
+                    if member.name not in {"", "."}:
+                        for component in path.parts:
+                            if component in _SENSITIVE_COMPONENTS:
+                                raise SandboxWorkerError("workspace archive contains sensitive paths")
+                    if member.isreg():
+                        if member.size > self._max_file_bytes:
+                            raise SandboxWorkerError("workspace archive file limit exceeded")
+                        total_size += member.size
+                if total_size > self._max_archive_bytes * 8:
+                    raise SandboxWorkerError("workspace archive expanded beyond its limit")
+                archive.extractall(target, filter="data")
+        except tarfile.TarError as exc:
+            raise SandboxWorkerError("workspace archive could not be extracted") from exc
+
+    def _validate_tree(self, root: Path | None = None) -> None:
+        target = (root or self._workspaces).resolve()
+        if target.is_symlink() or not target.is_relative_to(self._root):
+            raise SandboxWorkerError("workspace tree failed validation")
+        for total_files, path in enumerate(target.rglob("*"), start=1):
+            if path.is_symlink() or not path.is_relative_to(self._root):
+                raise SandboxWorkerError("workspace tree contains an unsafe path")
+            if path.name in _SENSITIVE_COMPONENTS:
+                raise SandboxWorkerError("workspace tree contains sensitive paths")
+            if total_files > self._max_entries:
+                raise SandboxWorkerError("workspace tree entry limit exceeded")
+            if path.is_file() and path.stat().st_size > self._max_file_bytes:
+                raise SandboxWorkerError("workspace file limit exceeded")
+
+    @contextmanager
+    def _temporary_secret_files(
+        self,
+        workspace: Path,
+        secret_files: list[SandboxSecretFile],
+    ) -> Iterator[_SecretContext]:
+        if not secret_files:
+            yield _SecretContext(environment={}, values=())
+            return
+        root = workspace / ".opentulpa_secret_mounts" / secrets.token_hex(12)
+        root.mkdir(mode=0o700, parents=True)
+        environment: dict[str, str] = {}
+        values: list[str] = []
+        try:
+            for item in secret_files:
+                path = root / item.name
+                if path.exists() or path.is_symlink():
+                    raise SandboxWorkerError("secret mount path is invalid")
+                path.write_text(item.content, encoding="utf-8")
+                path.chmod(0o600)
+                values.append(item.content)
+                if item.env:
+                    environment[item.env] = str(path)
+            yield _SecretContext(environment=environment, values=tuple(values))
+        finally:
+            shutil.rmtree(root.parent, ignore_errors=True)
+
+    @staticmethod
+    def _with_secret_environment(command: str, environment: dict[str, str]) -> str:
+        if not environment:
+            return command
+        exports = " ".join(
+            f"{name}={_shell_quote(value)}" for name, value in sorted(environment.items())
+        )
+        return f"export {exports}; {command}"
+
+
+class _SecretContext(BaseModel):
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    environment: dict[str, str]
+    values: tuple[str, ...]
+
+
+def create_sandbox_worker_app(*, service: SandboxWorkerService, token: str) -> FastAPI:
+    expected_token = str(token or "").strip()
+    if len(expected_token) < 32:
+        raise ValueError("sandbox worker token must contain at least 32 characters")
+
+    async def authorize(
+        supplied: Annotated[
+            str | None,
+            Header(alias="X-OpenTulpa-Sandbox-Token", max_length=500),
+        ] = None,
+    ) -> None:
+        if not secrets.compare_digest(str(supplied or ""), expected_token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="valid sandbox worker credentials are required",
+            )
+
+    app = FastAPI(title="OpenTulpa Sandbox Worker", version="1")
+    router = APIRouter(
+        prefix="/internal/v1/sandbox",
+        dependencies=[Depends(authorize)],
+        include_in_schema=False,
+    )
+
+    @router.get("/health", response_model=SandboxHealthResult)
+    async def health() -> SandboxHealthResult:
+        return service.health()
+
+    @router.post("/workspaces", response_model=SandboxWorkspaceResult, status_code=201)
+    async def create_workspace(body: SandboxWorkspaceCreateRequest) -> SandboxWorkspaceResult:
+        try:
+            return service.create_workspace(kind=body.kind, tenant_id=body.tenant_id)
+        except (OSError, SandboxWorkerError, ValueError) as exc:
+            raise HTTPException(status_code=503, detail="sandbox workspace is unavailable") from exc
+
+    @router.post("/workspaces/{workspace_id}/archive", status_code=204)
+    async def put_archive(workspace_id: str, body: SandboxArchiveRequest) -> None:
+        try:
+            service.put_archive(workspace_id, body.archive)
+        except (OSError, SandboxWorkerError, ValueError) as exc:
+            raise HTTPException(status_code=422, detail="sandbox workspace archive is invalid") from exc
+
+    @router.get("/workspaces/{workspace_id}/archive", response_model=SandboxArchiveResult)
+    async def get_archive(workspace_id: str) -> SandboxArchiveResult:
+        try:
+            return SandboxArchiveResult(archive=service.get_archive(workspace_id))
+        except (OSError, SandboxWorkerError, ValueError) as exc:
+            raise HTTPException(status_code=503, detail="sandbox workspace archive is unavailable") from exc
+
+    @router.post("/workspaces/{workspace_id}/execute", response_model=SandboxExecuteResult)
+    async def execute(
+        workspace_id: str,
+        body: SandboxExecuteRequest,
+        request: Request,
+    ) -> SandboxExecuteResult:
+        del request
+        try:
+            result = service.execute(
+                workspace_id=workspace_id,
+                command=body.command,
+                timeout=body.timeout,
+                secret_files=body.secret_files,
+            )
+        except (OSError, SandboxWorkerError, ValueError) as exc:
+            raise HTTPException(status_code=503, detail="sandbox execution is unavailable") from exc
+        return SandboxExecuteResult(
+            output=result.output,
+            exit_code=int(result.exit_code or 0),
+            truncated=result.truncated,
+        )
+
+    @router.delete("/workspaces/{workspace_id}", status_code=204)
+    async def delete_workspace(workspace_id: str) -> None:
+        try:
+            service.delete_workspace(workspace_id)
+        except (OSError, SandboxWorkerError, ValueError) as exc:
+            raise HTTPException(status_code=503, detail="sandbox workspace is unavailable") from exc
+
+    app.include_router(router)
+    return app
+
+
+def build_default_worker_service() -> SandboxWorkerService:
+    root = Path(
+        os.environ.get("OPENTULPA_SANDBOX_WORKER_ROOT")
+        or Path(tempfile.gettempdir()) / "opentulpa-sandbox-worker"
+    )
+    max_output = int(os.environ.get("OPENTULPA_SANDBOX_MAX_OUTPUT_BYTES") or 512_000)
+    max_archive = int(os.environ.get("OPENTULPA_SANDBOX_MAX_ARCHIVE_BYTES") or 32 * 1024 * 1024)
+    max_entries = int(os.environ.get("OPENTULPA_SANDBOX_MAX_ENTRIES") or 20_000)
+    max_file = int(os.environ.get("OPENTULPA_SANDBOX_MAX_FILE_BYTES") or 10 * 1024 * 1024)
+    policy = TenantContainerPolicy(
+        image="opentulpa-sandbox-worker",
+        cpu_limit=os.environ.get("OPENTULPA_SANDBOX_CPU_LIMIT") or "1",
+        memory_limit=os.environ.get("OPENTULPA_SANDBOX_MEMORY_LIMIT") or "512m",
+        pid_limit=int(os.environ.get("OPENTULPA_SANDBOX_PID_LIMIT") or 128),
+        timeout_seconds=int(os.environ.get("OPENTULPA_SANDBOX_TIMEOUT_SECONDS") or 60),
+        max_output_bytes=max_output,
+        max_file_bytes=max_file,
+        max_workspace_entries=max_entries,
+        network_enabled=True,
+    )
+    dev = str(os.environ.get("OPENTULPA_DEV_ALLOW_NO_SANDBOX") or "").strip().casefold() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    engine: SandboxExecutionEngine
+    if dev and not CandidateProcessBackend.supported():
+        engine = DevProcessEngine(max_output_bytes=max_output)
+    else:
+        engine = RestrictedProcessEngine(
+            policy=policy,
+            max_workspace_bytes=max_archive,
+        )
+    return SandboxWorkerService(
+        root=root,
+        engine=engine,
+        max_archive_bytes=max_archive,
+        max_entries=max_entries,
+        max_file_bytes=max_file,
+    )
+
+
+def main() -> None:
+    token = str(os.environ.get("OPENTULPA_SANDBOX_RPC_TOKEN") or "").strip()
+    if len(token) < 32:
+        raise SystemExit("OPENTULPA_SANDBOX_RPC_TOKEN must contain at least 32 characters")
+    host = str(os.environ.get("HOST") or "127.0.0.1").strip()
+    port = int(os.environ.get("PORT") or os.environ.get("OPENTULPA_SANDBOX_PORT") or 8787)
+    app = create_sandbox_worker_app(service=build_default_worker_service(), token=token)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=os.environ.get("LOG_LEVEL", "info").lower(),
+        ws="none",
+        timeout_graceful_shutdown=10,
+    )
+
+
+def _shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+__all__ = [
+    "DevProcessEngine",
+    "RestrictedProcessEngine",
+    "SandboxArchiveRequest",
+    "SandboxArchiveResult",
+    "SandboxExecuteRequest",
+    "SandboxExecuteResult",
+    "SandboxExecutionEngine",
+    "SandboxHealthResult",
+    "SandboxSecretFile",
+    "SandboxWorkerError",
+    "SandboxWorkerService",
+    "SandboxWorkspaceCreateRequest",
+    "SandboxWorkspaceResult",
+    "build_default_worker_service",
+    "create_sandbox_worker_app",
+    "main",
+]

--- a/src/opentulpa/secrets/ingress.py
+++ b/src/opentulpa/secrets/ingress.py
@@ -66,6 +66,8 @@ _NAMED_SECRET_SCOPES: dict[str, tuple[str, ...]] = {
     "github_token": ("github.read", "github.write"),
     "gh_token": ("github.read", "github.write"),
     "browser_use_api_key": ("browser.manage",),
+    "ssh_key": ("ssh.connect",),
+    "ssh_private_key": ("ssh.connect",),
 }
 _PLACEHOLDER_VALUES = frozenset(
     {

--- a/src/opentulpa/secrets/service.py
+++ b/src/opentulpa/secrets/service.py
@@ -9,6 +9,7 @@ from pydantic import SecretStr
 
 from opentulpa.secrets.models import SecretHandle, SecretState
 from opentulpa.secrets.vault import (
+    SecretGrantError,
     SecretVault,
     SecretVaultConflictError,
     SecretVaultNotFoundError,
@@ -37,6 +38,34 @@ class SecretVaultService:
 
     def get(self, *, tenant_id: str, secret_id: str) -> SecretHandle | None:
         return self._vault.get_handle(tenant_id=tenant_id, secret_id=secret_id)
+
+    def resolve_for_sandbox(
+        self,
+        *,
+        tenant_id: str,
+        actor_id: str,
+        secret_id: str,
+        scope: str,
+        mount_type: str,
+    ) -> SecretStr:
+        """Redeem one tenant secret for a trusted one-shot sandbox mount."""
+
+        del actor_id
+        if str(mount_type or "").strip() not in {"ssh_private_key"}:
+            raise SecretGrantError("sandbox secret mount type is unsupported")
+        grant = self._vault.issue_grant(
+            tenant_id=tenant_id,
+            secret_id=secret_id,
+            capability_id="sandbox_ssh_diagnostic",
+            scopes=(scope,),
+            ttl_seconds=60,
+        )
+        material = self._vault.redeem_grant(
+            token=grant.token,
+            capability_id="sandbox_ssh_diagnostic",
+            scope=scope,
+        )
+        return material.value
 
     def create_pending(
         self,

--- a/src/opentulpa/tooling/adapters.py
+++ b/src/opentulpa/tooling/adapters.py
@@ -209,6 +209,11 @@ class ProductToolApplication(Protocol):
         invocation: ProductToolInvocation,
     ) -> ProductToolOutput: ...
 
+    async def sandbox_ssh_diagnostic(
+        self,
+        invocation: ProductToolInvocation,
+    ) -> ProductToolOutput: ...
+
     async def capability_list(
         self,
         invocation: ProductToolInvocation,
@@ -475,15 +480,18 @@ def _description(spec: ToolSpec) -> str:
             "Inspect source self-update state. available reports whether self-update is usable; "
             "active and session_active report only whether an editable candidate session exists."
         ),
+        "sandbox_ssh_diagnostic": (
+            "Run one SSH diagnostic command from the sandbox using an opaque stored secret handle. "
+            "Never provide plaintext credentials."
+        ),
     }.get(spec.name)
     if description is None:
         action = spec.name.replace("_", " ")
         description = f"{action.capitalize()} for the authenticated OpenTulpa tenant."
-    approval = (
-        "policy (recursive forced removal only)"
-        if spec.approval is ApprovalMode.POLICY
-        else spec.approval.value
-    )
+    if spec.name == "source_shell":
+        approval = "policy (recursive forced removal only)"
+    else:
+        approval = "policy" if spec.approval is ApprovalMode.POLICY else spec.approval.value
     return (
         f"{description} "
         f"Effect: {spec.effect.value}; approval: {approval}; "

--- a/src/opentulpa/tooling/arguments.py
+++ b/src/opentulpa/tooling/arguments.py
@@ -361,6 +361,27 @@ class SecretHandleRevokeArguments(RequiredIdempotencyArguments):
     expected_revision: int = Field(ge=1)
 
 
+class SandboxSshDiagnosticArguments(ToolArguments):
+    secret_id: ProtocolSlug = Field(
+        description="Tenant-owned secret handle containing an SSH private key.",
+    )
+    host: str = Field(
+        min_length=1,
+        max_length=253,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,252}$",
+    )
+    user: str = Field(
+        default="root",
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_.-]{0,63}$",
+    )
+    port: int = Field(default=22, ge=1, le=65_535)
+    command: str = Field(min_length=1, max_length=20_000)
+    timeout_seconds: int = Field(default=60, ge=1, le=600)
+    secret_type: Literal["private_key"] = "private_key"
+
+
 CapabilityName = Annotated[
     str,
     StringConstraints(
@@ -576,6 +597,7 @@ OPERATION_ARGUMENT_SCHEMAS: Mapping[str, type[ToolArguments]] = MappingProxyType
         "trigger_spec_rollback": TriggerSpecRollbackArguments,
         "secret_handle_list": SecretHandleListArguments,
         "secret_handle_revoke": SecretHandleRevokeArguments,
+        "sandbox_ssh_diagnostic": SandboxSshDiagnosticArguments,
         "capability_list": CapabilityListArguments,
         "capability_seed_bundled": CapabilitySeedBundledArguments,
         "capability_test": CapabilityTestArguments,

--- a/src/opentulpa/tooling/contract.py
+++ b/src/opentulpa/tooling/contract.py
@@ -331,6 +331,13 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         ToolEffect.DELETE,
         idempotency=IdempotencyMode.REQUIRED,
     ),
+    _tool(
+        "sandbox_ssh_diagnostic",
+        "sandbox",
+        ToolEffect.EXECUTE,
+        approval=ApprovalMode.POLICY,
+        timeout_seconds=660,
+    ),
     _tool("capability_list", "capabilities", ToolEffect.READ),
     _tool(
         "capability_seed_bundled",

--- a/start.sh
+++ b/start.sh
@@ -916,10 +916,10 @@ install_tenant_sandbox_image() {
       return 0
     fi
     if process_tenant_sandbox_configured; then
-      log "tenant sandbox image build skipped; using the bundled restricted process sandbox."
+      log "tenant sandbox image build skipped; using the mandatory sandbox worker with restricted process isolation."
       return 0
     fi
-    log "tenant sandbox image build skipped; chat will start with shell execution unavailable."
+    log "tenant sandbox image build skipped; host readiness will require a sandbox worker or explicit dev bypass."
     return 0
   fi
   engine="${OPENTULPA_CONTAINER_CLI:-docker}"
@@ -1231,11 +1231,11 @@ railway_tenant_sandbox_configured() {
 
 warn_without_container_engine() {
   if process_tenant_sandbox_configured; then
-    warn "no isolated OCI engine was found; tenant and repository commands will use the bundled restricted process sandbox."
+    warn "no isolated OCI engine was found; the sandbox worker will use bundled restricted process isolation."
   elif process_repository_sandbox_available; then
-    warn "no isolated OCI engine was found; general tenant shell commands are unavailable, but repository work will use the bundled restricted process sandbox."
+    warn "no isolated OCI engine was found; repository work can use restricted process isolation, but host readiness still requires the sandbox worker canary."
   else
-    warn "no isolated OCI engine was found; chat will start but sandbox shell commands will be unavailable (tenant workspace only; source evolution uses the stable host)."
+    warn "no isolated OCI engine was found and restricted process isolation is unavailable; production host readiness will fail unless a sandbox worker is wired."
   fi
 }
 

--- a/tests/test_control_plane_product_tools.py
+++ b/tests/test_control_plane_product_tools.py
@@ -412,7 +412,7 @@ async def test_secret_tools_only_list_and_revoke_safe_handles(tmp_path: Path) ->
 
 
 def test_secret_tool_schemas_have_no_plaintext_ingress() -> None:
-    for name in ("secret_handle_list", "secret_handle_revoke"):
+    for name in ("secret_handle_list", "secret_handle_revoke", "sandbox_ssh_diagnostic"):
         schema = OPERATION_ARGUMENT_SCHEMAS[name].model_json_schema()
         serialized = json.dumps(schema).lower()
         assert '"value"' not in serialized

--- a/tests/test_host_app.py
+++ b/tests/test_host_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -56,12 +57,17 @@ class _Evolution:
 
 
 class _SandboxSupervisor:
-    def __init__(self, *, ok: bool = True) -> None:
+    def __init__(self, *, ok: bool = True, failures_before_ready: int = 0) -> None:
         self.ok = ok
+        self.failures_before_ready = failures_before_ready
         self.started = False
         self.stopped = False
+        self.start_attempts = 0
+        self.status_calls = 0
+        self.require_ready_calls = 0
 
     async def start(self) -> None:
+        self.start_attempts += 1
         self.started = True
         await self.require_ready()
 
@@ -69,16 +75,28 @@ class _SandboxSupervisor:
         self.stopped = True
 
     async def require_ready(self) -> None:
+        self.require_ready_calls += 1
+        if self.failures_before_ready > 0:
+            self.failures_before_ready -= 1
+            raise RuntimeError("sandbox worker canary failed")
         if not self.ok:
             raise RuntimeError("sandbox worker canary failed")
 
     async def status(self) -> dict[str, Any]:
+        self.status_calls += 1
         return {
-            "ok": self.ok,
-            "step": "ready" if self.ok else "health",
+            "ok": self.ok and self.failures_before_ready <= 0,
+            "step": "ready" if self.ok and self.failures_before_ready <= 0 else "health",
             "tier": "test",
-            "checks": {"execute": self.ok, "ssh": self.ok},
-            "error": None if self.ok else "sandbox worker canary failed",
+            "checks": {
+                "execute": self.ok and self.failures_before_ready <= 0,
+                "ssh": self.ok and self.failures_before_ready <= 0,
+            },
+            "error": (
+                None
+                if self.ok and self.failures_before_ready <= 0
+                else "sandbox worker canary failed"
+            ),
         }
 
 
@@ -165,6 +183,25 @@ def test_host_health_fails_closed_when_sandbox_worker_is_unavailable(tmp_path: P
     assert status["sandbox"]["ok"] is False
 
 
+def test_host_health_uses_cached_sandbox_status(tmp_path: Path) -> None:
+    store, service = _parts(tmp_path)
+    sandbox = _SandboxSupervisor()
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=sandbox,
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/_host/api/status").json()["sandbox"]["ok"] is True
+
+    assert sandbox.start_attempts == 1
+    assert sandbox.require_ready_calls == 1
+    assert sandbox.status_calls == 3
+
+
 def test_host_lifespan_does_not_start_runtime_when_sandbox_start_fails(
     tmp_path: Path,
 ) -> None:
@@ -177,6 +214,28 @@ def test_host_lifespan_does_not_start_runtime_when_sandbox_start_fails(
 
     with TestClient(app):
         assert service.started is False
+
+
+def test_host_lifespan_starts_runtime_after_sandbox_recovers(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENTULPA_SANDBOX_START_RETRY_SECONDS", "0.01")
+    store, service = _parts(tmp_path)
+    sandbox = _SandboxSupervisor(failures_before_ready=1)
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=sandbox,
+    )
+
+    with TestClient(app):
+        deadline = time.monotonic() + 1.0
+        while not service.started and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert service.started is True
+
+    assert sandbox.start_attempts >= 2
 
 
 def test_owner_config_activation_is_blocked_when_sandbox_worker_is_unavailable(

--- a/tests/test_host_app.py
+++ b/tests/test_host_app.py
@@ -55,6 +55,33 @@ class _Evolution:
         return {"active": False, "audit": audit_context}
 
 
+class _SandboxSupervisor:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+        await self.require_ready()
+
+    async def shutdown(self) -> None:
+        self.stopped = True
+
+    async def require_ready(self) -> None:
+        if not self.ok:
+            raise RuntimeError("sandbox worker canary failed")
+
+    async def status(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "step": "ready" if self.ok else "health",
+            "tier": "test",
+            "checks": {"execute": self.ok, "ssh": self.ok},
+            "error": None if self.ok else "sandbox worker canary failed",
+        }
+
+
 def _parts(tmp_path: Path) -> tuple[HostStore, _Service]:
     store = HostStore(tmp_path / "host.db", cipher=AesGcmHostKeyCipher(b"h" * 32))
     store.configure_setup_token("setup-token-with-enough-entropy")
@@ -64,7 +91,10 @@ def _parts(tmp_path: Path) -> tuple[HostStore, _Service]:
 def test_unconfigured_host_stays_healthy_and_redirects_chat_to_setup(tmp_path: Path) -> None:
     store, service = _parts(tmp_path)
     app = create_host_app(
-        store=store, service=service, setup_token="setup-token-with-enough-entropy"
+        store=store,
+        service=service,
+        setup_token="setup-token-with-enough-entropy",
+        sandbox_supervisor=_SandboxSupervisor(),
     )  # type: ignore[arg-type]
 
     with TestClient(app) as client:
@@ -73,6 +103,13 @@ def test_unconfigured_host_stays_healthy_and_redirects_chat_to_setup(tmp_path: P
             "host": "ready",
             "runtime": "stopped",
             "configured": False,
+            "sandbox": {
+                "ok": True,
+                "step": "ready",
+                "tier": "test",
+                "checks": {"execute": True, "ssh": True},
+                "error": None,
+            },
         }
         assert client.get("/agent/healthz").status_code == 503
         response = client.get("/", follow_redirects=False)
@@ -109,10 +146,76 @@ def test_log_cursor_resumes_same_host_and_resets_after_host_replacement() -> Non
     )
 
 
+def test_host_health_fails_closed_when_sandbox_worker_is_unavailable(tmp_path: Path) -> None:
+    store, service = _parts(tmp_path)
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=_SandboxSupervisor(ok=False),
+    )
+
+    with TestClient(app) as client:
+        health = client.get("/healthz")
+        status = client.get("/_host/api/status").json()
+        assert service.started is False
+
+    assert health.status_code == 503
+    assert health.json()["ok"] is False
+    assert health.json()["sandbox"]["checks"] == {"execute": False, "ssh": False}
+    assert status["sandbox"]["ok"] is False
+
+
+def test_host_lifespan_does_not_start_runtime_when_sandbox_start_fails(
+    tmp_path: Path,
+) -> None:
+    store, service = _parts(tmp_path)
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=_SandboxSupervisor(ok=False),
+    )
+
+    with TestClient(app):
+        assert service.started is False
+
+
+def test_owner_config_activation_is_blocked_when_sandbox_worker_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    store, service = _parts(tmp_path)
+    store.claim(
+        setup_token="setup-token-with-enough-entropy",
+        owner_token="owner-token-with-at-least-thirty-two-characters",
+    )
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=_SandboxSupervisor(ok=False),
+    )
+
+    with TestClient(app) as client:
+        response = client.put(
+            "/_host/api/config",
+            headers={"Authorization": "Bearer owner-token-with-at-least-thirty-two-characters"},
+            json={
+                "api_key": "provider-secret",
+                "model": "moonshotai/kimi-k3",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        )
+
+    assert response.status_code == 503
+    assert "Sandbox worker failed" in response.json()["detail"]
+    assert service.applied is None
+
+
 def test_remote_claim_requires_setup_token_and_sets_owner_session(tmp_path: Path) -> None:
     store, service = _parts(tmp_path)
     app = create_host_app(
-        store=store, service=service, setup_token="setup-token-with-enough-entropy"
+        store=store,
+        service=service,
+        setup_token="setup-token-with-enough-entropy",
+        sandbox_supervisor=_SandboxSupervisor(),
     )  # type: ignore[arg-type]
 
     with TestClient(app) as client:
@@ -128,6 +231,7 @@ def test_remote_claim_requires_setup_token_and_sets_owner_session(tmp_path: Path
         status = client.get("/_host/api/status").json()
         assert status["claimed"] is True
         assert status["authenticated"] is True
+        assert status["sandbox"]["ok"] is True
         assert client.get("/_host/api/logs").json() == {
             "stream_id": "stream-current",
             "logs": [],
@@ -140,7 +244,11 @@ def test_owner_can_activate_first_config_without_exposing_secrets(tmp_path: Path
         setup_token="setup-token-with-enough-entropy",
         owner_token="owner-token-with-at-least-thirty-two-characters",
     )
-    app = create_host_app(store=store, service=service)  # type: ignore[arg-type]
+    app = create_host_app(
+        store=store,
+        service=service,  # type: ignore[arg-type]
+        sandbox_supervisor=_SandboxSupervisor(),
+    )
 
     with TestClient(app) as client:
         assert (
@@ -173,6 +281,7 @@ def test_evolution_control_route_is_registered_before_runtime_proxy(tmp_path: Pa
         service=service,  # type: ignore[arg-type]
         evolution_service=_Evolution(),
         evolution_token=token,
+        sandbox_supervisor=_SandboxSupervisor(),
     )
 
     with TestClient(app) as client:

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -42,16 +42,22 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
         base_url="http://127.0.0.1:8000/bootstrap/internal/v1/evolution",
         token="e" * 48,
     )
+    runtime.configure_sandbox_worker(
+        base_url="http://127.0.0.1:8787/internal/v1/sandbox",
+        token="s" * 48,
+    )
     config = _config()
 
     environment = runtime._child_environment(config, port=8123)
     runtime._redaction_values = {
         config.api_key.get_secret_value(),
         config.internal_runtime_token.get_secret_value(),
+        "s" * 48,
     }
     runtime._append_log(
         "stderr",
-        "provider-secret-value Authorization=internal-owner-secret-value password=hunter2",
+        "provider-secret-value Authorization=internal-owner-secret-value "
+        f"password=hunter2 sandbox={'s' * 48}",
     )
 
     assert environment["OPENAI_COMPATIBLE_API_KEY"] == "provider-secret-value"
@@ -61,6 +67,8 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
     assert environment["OPENTULPA_BOOTSTRAP_EVOLUTION_URL"].endswith(
         "/bootstrap/internal/v1/evolution"
     )
+    assert environment["OPENTULPA_SANDBOX_RPC_URL"].endswith("/internal/v1/sandbox")
+    assert environment["OPENTULPA_SANDBOX_RPC_TOKEN"] == "s" * 48
     assert environment["PYTHONPATH"] == str(tmp_path / "src")
     assert "TELEGRAM_BOT_TOKEN" not in environment
     assert "TELEGRAM_WEBHOOK_SECRET" not in environment
@@ -69,7 +77,8 @@ async def test_child_environment_hides_interface_secrets_and_logs_redact_exact_v
     assert "provider-secret-value" not in line
     assert "internal-owner-secret-value" not in line
     assert "hunter2" not in line
-    assert line.count("[redacted]") == 3
+    assert "s" * 48 not in line
+    assert line.count("[redacted]") == 4
 
     monkeypatch.delenv("OPENTULPA_OWNER_CUSTOMER_ID")
     assert runtime._child_environment(config, port=8124)["OPENTULPA_OWNER_CUSTOMER_ID"] == "owner"

--- a/tests/test_main_composition.py
+++ b/tests/test_main_composition.py
@@ -18,6 +18,7 @@ from opentulpa.deep_agent.service import DeepAgentService
 from opentulpa.integrations.browser_use_cloud import BrowserUseCloudSessionProvider
 from opentulpa.mcp import SQLiteMCPAuditSink, SQLiteMCPIdempotencyStore
 from opentulpa.notifications import TriggerNotificationSink
+from opentulpa.sandbox.client import SandboxWorkerExecutionProvider
 from opentulpa.secrets.host_key import load_or_create_host_cipher
 from opentulpa.tooling import TOOL_SPECS
 
@@ -377,13 +378,35 @@ def test_direct_runtime_resolves_configured_sandbox_to_local_image_id(
     ]
 
 
-def test_direct_runtime_keeps_chat_available_when_sandbox_is_unavailable(
+def test_direct_runtime_fails_closed_when_sandbox_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def unavailable(**_: Any) -> str:
         raise RuntimeError("configured OCI engine must operate in rootless mode")
 
+    monkeypatch.setattr(main_module, "resolve_local_oci_image", unavailable)
+    monkeypatch.setattr(
+        main_module.RestrictedProcessExecutionProvider,
+        "supported",
+        lambda: False,
+    )
+
+    with pytest.raises(RuntimeError, match="requires a healthy sandbox worker"):
+        main_module._sandbox_execution_configuration(  # noqa: SLF001
+            project_root=tmp_path,
+            settings=_settings(tmp_path),
+        )
+
+
+def test_direct_runtime_allows_missing_sandbox_only_in_explicit_dev_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(**_: Any) -> str:
+        raise RuntimeError("configured OCI engine must operate in rootless mode")
+
+    monkeypatch.setenv("OPENTULPA_DEV_ALLOW_NO_SANDBOX", "1")
     monkeypatch.setattr(main_module, "resolve_local_oci_image", unavailable)
     monkeypatch.setattr(
         main_module.RestrictedProcessExecutionProvider,
@@ -435,6 +458,15 @@ def test_direct_railway_runtime_uses_hosted_sandbox_provider(
         "environment-id",
     )
     monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "app-environment-id")
+    bridge = tmp_path / "bridge" / "bridge.mjs"
+    bridge.parent.mkdir()
+    bridge.write_text("", encoding="utf-8")
+    (bridge.parent / "node_modules" / "railway").mkdir(parents=True)
+    (bridge.parent / "node_modules" / "railway" / "package.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENTULPA_RAILWAY_SANDBOX_BRIDGE_PATH", str(bridge))
 
     image, execution = main_module._sandbox_execution_configuration(  # noqa: SLF001
         project_root=tmp_path,
@@ -444,6 +476,25 @@ def test_direct_railway_runtime_uses_hosted_sandbox_provider(
     assert image == "opentulpa-tenant-sandbox:test"
     assert isinstance(execution, RailwaySandboxExecutionProvider)
     assert execution._environment_id == "environment-id"  # noqa: SLF001
+
+
+def test_direct_runtime_uses_mandatory_sandbox_worker_when_wired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OPENTULPA_SANDBOX_RPC_URL",
+        "http://127.0.0.1:8787/internal/v1/sandbox",
+    )
+    monkeypatch.setenv("OPENTULPA_SANDBOX_RPC_TOKEN", "s" * 48)
+
+    image, execution = main_module._sandbox_execution_configuration(  # noqa: SLF001
+        project_root=tmp_path,
+        settings=_settings(tmp_path),
+    )
+
+    assert image == "opentulpa-tenant-sandbox:test"
+    assert isinstance(execution, SandboxWorkerExecutionProvider)
 
 
 def test_explicit_railway_runtime_fails_when_project_credentials_are_incomplete(

--- a/tests/test_product_tool_adapters.py
+++ b/tests/test_product_tool_adapters.py
@@ -127,11 +127,10 @@ def test_factory_covers_exact_registry_and_hides_all_host_context_fields() -> No
         properties = schema.get("properties", {})
         spec = TOOL_SPEC_BY_NAME[tool.name]
         assert f"Effect: {spec.effect.value}" in tool.description
-        approval = (
-            "policy (recursive forced removal only)"
-            if tool.name == "source_shell"
-            else "auto"
-        )
+        if tool.name == "source_shell":
+            approval = "policy (recursive forced removal only)"
+        else:
+            approval = "policy" if spec.approval.value == "policy" else "auto"
         assert f"approval: {approval}" in tool.description
         assert f"execution: {spec.execution.value}" in tool.description
         assert "runtime" not in properties

--- a/tests/test_product_tool_application.py
+++ b/tests/test_product_tool_application.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
+from deepagents.backends.protocol import ExecuteResponse
+from pydantic import SecretStr
 
 from opentulpa.application.product_tools import ProductToolApplication
 from opentulpa.integrations.web_search import WebSearchProviderError
 from opentulpa.logging.langfuse import redact_for_langfuse
 from opentulpa.persistence.idempotency import IdempotencyStore
 from opentulpa.repositories.providers import RepositorySandboxUnavailableError
+from opentulpa.secrets.models import SecretHandle, SecretState
 from opentulpa.specs import AgentSpecRef, OriginRef
 from opentulpa.tooling.adapters import (
     ProductToolApplicationError,
@@ -52,6 +56,15 @@ class _IdempotencyPort(_Port):
         self.calls.append(("execute", kwargs))
         value = invoke()
         return await value if inspect.isawaitable(value) else value
+
+
+class _SandboxExecutionPort:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def execute(self, **kwargs: Any) -> ExecuteResponse:
+        self.calls.append(kwargs)
+        return ExecuteResponse(output="ssh ok", exit_code=0, truncated=False)
 
 
 def _application(**overrides: Any) -> tuple[ProductToolApplication, dict[str, Any]]:
@@ -638,6 +651,76 @@ async def test_schedule_list_filters_disabled_and_save_passes_typed_write_and_id
     assert save_call[1]["write"].name == "Morning reminder"
     assert saved.data["id"] == "new-schedule"
     assert "tenant_id" not in saved.data
+
+
+@pytest.mark.asyncio
+async def test_sandbox_ssh_diagnostic_mounts_secret_handle_without_plaintext_command() -> None:
+    private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret-key\n-----END OPENSSH PRIVATE KEY-----"
+    handle = SecretHandle(
+        tenant_id="tenant-a",
+        id="ssh_private_key",
+        revision=2,
+        name="ssh_private_key",
+        state=SecretState.ACTIVE,
+        scopes=("ssh.connect",),
+        created_at=datetime(2026, 7, 31, tzinfo=UTC),
+        created_by="owner-1",
+    )
+    secret_handles = _Port(
+        get=handle,
+        resolve_for_sandbox=SecretStr(private_key),
+    )
+    sandbox_execution = _SandboxExecutionPort()
+    application, _ = _application(
+        secret_handles=secret_handles,
+        sandbox_execution=sandbox_execution,
+    )
+
+    result = await application.sandbox_ssh_diagnostic(
+        _invocation(
+            "sandbox_ssh_diagnostic",
+            {
+                "secret_id": "ssh_private_key",
+                "host": "178.214.97.1",
+                "user": "root",
+                "port": 22,
+                "command": "ss -tn | wc -l",
+                "timeout_seconds": 30,
+                "secret_type": "private_key",
+            },
+            idempotency_key=None,
+        )
+    )
+
+    assert result.data == {
+        "host": "178.214.97.1",
+        "user": "root",
+        "port": 22,
+        "exit_code": 0,
+        "output": "ssh ok",
+        "truncated": False,
+    }
+    assert secret_handles.calls == [
+        ("get", {"tenant_id": "tenant-a", "secret_id": "ssh_private_key"}),
+        (
+            "resolve_for_sandbox",
+            {
+                "tenant_id": "tenant-a",
+                "actor_id": "owner-1",
+                "secret_id": "ssh_private_key",
+                "scope": "ssh.connect",
+                "mount_type": "ssh_private_key",
+            },
+        ),
+    ]
+    sandbox_call = sandbox_execution.calls[0]
+    assert sandbox_call["tenant_id"] == "tenant-a"
+    assert sandbox_call["timeout"] == 30
+    assert private_key not in sandbox_call["command"]
+    assert "ssh -i \"$OPENTULPA_SSH_IDENTITY\"" in sandbox_call["command"]
+    assert "root@178.214.97.1" in sandbox_call["command"]
+    assert sandbox_call["secret_files"][0].content == private_key
+    assert sandbox_call["secret_files"][0].env == "OPENTULPA_SSH_IDENTITY"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox_worker.py
+++ b/tests/test_sandbox_worker.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import base64
+import io
+import shlex
+import sys
+import tarfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from opentulpa.core.config import Settings
+from opentulpa.sandbox.supervisor import SandboxWorkerSupervisor
+from opentulpa.sandbox.worker import (
+    DevProcessEngine,
+    SandboxWorkerError,
+    SandboxWorkerService,
+    create_sandbox_worker_app,
+)
+
+TOKEN = "sandbox-token-with-at-least-thirty-two-characters"
+
+
+def _service(tmp_path: Path, *, max_output_bytes: int = 20_000) -> SandboxWorkerService:
+    return SandboxWorkerService(
+        root=tmp_path / "worker",
+        engine=DevProcessEngine(max_output_bytes=max_output_bytes),
+        max_archive_bytes=500_000,
+        max_entries=100,
+        max_file_bytes=100_000,
+    )
+
+
+def _headers() -> dict[str, str]:
+    return {"X-OpenTulpa-Sandbox-Token": TOKEN}
+
+
+def test_sandbox_supervisor_worker_environment_excludes_app_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_env = {
+        "OPENAI_COMPATIBLE_API_KEY": "model-secret",
+        "TELEGRAM_BOT_TOKEN": "telegram-secret",
+        "COMPOSIO_API_KEY": "composio-secret",
+        "GITHUB_TOKEN": "github-secret",
+        "RAILWAY_TOKEN": "railway-secret",
+        "DAYTONA_API_KEY": "daytona-secret",
+    }
+    for name, value in secret_env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("OPENTULPA_SANDBOX_RPC_URL", raising=False)
+    monkeypatch.delenv("OPENTULPA_SANDBOX_RPC_TOKEN", raising=False)
+
+    supervisor = SandboxWorkerSupervisor(
+        project_root=tmp_path,
+        data_root=tmp_path / "data",
+        settings=Settings(_env_file=None),
+    )
+    environment = supervisor._worker_environment()  # noqa: SLF001
+
+    assert "OPENTULPA_SANDBOX_RPC_TOKEN" in environment
+    assert environment["OPENTULPA_SANDBOX_WORKER_ROOT"] == str(tmp_path / "data" / "sandbox_worker")
+    for name, value in secret_env.items():
+        assert name not in environment
+        assert value not in environment.values()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_api_requires_private_token(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        denied = await client.get("/internal/v1/sandbox/health")
+        accepted = await client.get("/internal/v1/sandbox/health", headers=_headers())
+
+    assert denied.status_code == 401
+    assert accepted.status_code == 200
+    assert accepted.json()["ok"] is True
+    assert accepted.json()["checks"]["execute"] is True
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_executes_in_workspace_and_preserves_files(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        first = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={"command": "printf hello > note.txt && cat note.txt", "timeout": 5},
+        )
+        second = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={"command": "cat note.txt", "timeout": 5},
+        )
+
+    assert created.status_code == 201
+    assert first.json() == {"output": "hello", "exit_code": 0, "truncated": False}
+    assert second.json() == {"output": "hello", "exit_code": 0, "truncated": False}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_rejects_unsafe_archive_paths(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        response = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/archive",
+            headers=_headers(),
+            json={"archive": _tar_archive_with_symlink()},
+        )
+
+    assert response.status_code == 422
+
+
+def test_sandbox_worker_workspace_ids_cannot_escape_root(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(SandboxWorkerError, match="workspace id is invalid"):
+        service.delete_workspace("../escape")
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_rejects_traversal_archive_paths(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        response = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/archive",
+            headers=_headers(),
+            json={"archive": _tar_archive_with_file("../escape.txt", b"bad")},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_truncates_command_output(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path, max_output_bytes=32), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+    python = shlex.quote(sys.executable)
+    script = shlex.quote("import sys; sys.stdout.write('x' * 200)")
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        response = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={"command": f"{python} -c {script}", "timeout": 5},
+        )
+
+    payload = response.json()
+    assert payload["truncated"] is True
+    assert payload["output"] == "x" * 32
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_timeout_kills_process_group(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+    python = shlex.quote(sys.executable)
+    script = shlex.quote(
+        "import subprocess, time; "
+        "subprocess.Popen(['sh', '-c', 'sleep 4; touch child-survived']); "
+        "time.sleep(30)"
+    )
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        timed_out = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={"command": f"{python} -c {script}", "timeout": 1},
+        )
+        probe = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={"command": "sleep 5; test ! -e child-survived", "timeout": 8},
+        )
+
+    assert timed_out.json()["exit_code"] == 124
+    assert probe.json()["exit_code"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_secret_mounts_are_one_shot_and_redacted(
+    tmp_path: Path,
+) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        execution = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={
+                "command": "cat \"$SSH_KEY_FILE\"",
+                "timeout": 5,
+                "secret_files": [
+                    {
+                        "name": "id_ed25519",
+                        "content": "super-secret-private-key",
+                        "env": "SSH_KEY_FILE",
+                    }
+                ],
+            },
+        )
+        archive = await client.get(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/archive",
+            headers=_headers(),
+        )
+
+    assert execution.status_code == 200
+    assert execution.json()["output"] == "[redacted]"
+    assert "super-secret-private-key" not in archive.text
+    assert ".opentulpa_secret_mounts" not in _tar_member_names(archive.json()["archive"])
+
+
+def _tar_archive_with_symlink() -> str:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo("link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        archive.addfile(info)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _tar_archive_with_file(name: str, content: bytes) -> str:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo(name)
+        info.size = len(content)
+        archive.addfile(info, io.BytesIO(content))
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _tar_member_names(encoded: str) -> list[str]:
+    raw = base64.b64decode(encoded)
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as archive:
+        return [member.name for member in archive.getmembers()]

--- a/tests/test_sandbox_worker.py
+++ b/tests/test_sandbox_worker.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from opentulpa.core.config import Settings
+from opentulpa.sandbox.client import SandboxWorkerCanary, SandboxWorkerHealth
 from opentulpa.sandbox.supervisor import SandboxWorkerSupervisor
 from opentulpa.sandbox.worker import (
     DevProcessEngine,
@@ -68,6 +69,37 @@ def test_sandbox_supervisor_worker_environment_excludes_app_secrets(
 
 
 @pytest.mark.asyncio
+async def test_sandbox_supervisor_status_uses_cached_canary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENTULPA_SANDBOX_RPC_URL", "http://127.0.0.1:1/internal/v1/sandbox")
+    monkeypatch.setenv("OPENTULPA_SANDBOX_RPC_TOKEN", "s" * 48)
+    supervisor = SandboxWorkerSupervisor(
+        project_root=tmp_path,
+        data_root=tmp_path / "data",
+        settings=Settings(_env_file=None),
+    )
+    supervisor._last_canary = SandboxWorkerCanary(  # noqa: SLF001
+        ok=True,
+        step="ready",
+        health=SandboxWorkerHealth(
+            ok=True,
+            tier="test",
+            checks={"execute": True, "ssh": True},
+        ),
+    )
+
+    assert await supervisor.status() == {
+        "ok": True,
+        "step": "ready",
+        "tier": "test",
+        "checks": {"execute": True, "ssh": True},
+        "error": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_sandbox_worker_api_requires_private_token(tmp_path: Path) -> None:
     app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
     transport = httpx.ASGITransport(app=app)
@@ -108,6 +140,36 @@ async def test_sandbox_worker_executes_in_workspace_and_preserves_files(tmp_path
     assert created.status_code == 201
     assert first.json() == {"output": "hello", "exit_code": 0, "truncated": False}
     assert second.json() == {"output": "hello", "exit_code": 0, "truncated": False}
+
+
+@pytest.mark.asyncio
+async def test_sandbox_worker_allows_git_metadata_inside_workspace(tmp_path: Path) -> None:
+    app = create_sandbox_worker_app(service=_service(tmp_path), token=TOKEN)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://sandbox") as client:
+        created = await client.post(
+            "/internal/v1/sandbox/workspaces",
+            headers=_headers(),
+            json={"kind": "scratch", "tenant_id": "tenant-a"},
+        )
+        workspace_id = created.json()["workspace_id"]
+        execution = await client.post(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/execute",
+            headers=_headers(),
+            json={
+                "command": "mkdir -p repo/.git && printf ok > repo/.git/config && cat repo/.git/config",
+                "timeout": 5,
+            },
+        )
+        archive = await client.get(
+            f"/internal/v1/sandbox/workspaces/{workspace_id}/archive",
+            headers=_headers(),
+        )
+
+    assert execution.status_code == 200
+    assert execution.json()["output"] == "ok"
+    assert "./repo/.git/config" in _tar_member_names(archive.json()["archive"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_secret_ingress.py
+++ b/tests/test_secret_ingress.py
@@ -223,6 +223,25 @@ def test_ingress_supports_named_multiline_secret_blocks(tmp_path: Path) -> None:
     _assert_absent_from_database(vault, private_key)
 
 
+def test_ingress_scopes_ssh_private_key_blocks_for_sandbox_connect(tmp_path: Path) -> None:
+    ingress, _ = _ingress(tmp_path)
+    private_key = (
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+        "not-a-real-private-key-for-tests\n"
+        "-----END OPENSSH PRIVATE KEY-----"
+    )
+
+    result = ingress.ingest(
+        tenant_id="tenant-a",
+        actor_id="owner-a",
+        text=f'<secret name="SSH_PRIVATE_KEY">\n{private_key}\n</secret>',
+    )
+
+    assert result.text == "secret://ssh_private_key"
+    assert result.handles[0].id == "ssh_private_key"
+    assert result.handles[0].scopes == ("ssh.connect",)
+
+
 def test_ingress_ignores_named_placeholders(tmp_path: Path) -> None:
     ingress, vault = _ingress(tmp_path)
 

--- a/tests/test_secret_vault_contract.py
+++ b/tests/test_secret_vault_contract.py
@@ -11,6 +11,7 @@ from opentulpa.secrets import (
     SecretGrantError,
     SecretState,
     SecretVault,
+    SecretVaultService,
 )
 
 NOW = datetime(2026, 7, 20, 12, tzinfo=UTC)
@@ -122,3 +123,32 @@ def test_secret_plaintext_requires_scoped_one_time_capability_grant(tmp_path: Pa
             capability_id="telegram",
             scopes=("browser.control",),
         )
+
+
+def test_secret_service_resolves_one_shot_sandbox_mount_material(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    service = SecretVaultService(vault)
+    pending = vault.create_pending(
+        tenant_id="tenant-a",
+        secret_id="ssh_private_key",
+        name="ssh_private_key",
+        scopes=("ssh.connect",),
+        created_by="owner",
+    )
+    vault.fulfill(
+        tenant_id="tenant-a",
+        secret_id=pending.id,
+        expected_revision=1,
+        value="private-key",
+        updated_by="owner",
+    )
+
+    material = service.resolve_for_sandbox(
+        tenant_id="tenant-a",
+        actor_id="owner",
+        secret_id=pending.id,
+        scope="ssh.connect",
+        mount_type="ssh_private_key",
+    )
+
+    assert material.get_secret_value() == "private-key"

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -571,7 +571,9 @@ def test_start_script_does_not_open_browser_for_public_server() -> None:
     assert "open http://127.0.0.1:8000/ after the server is healthy" not in result.stdout
 
 
-def test_direct_start_without_container_engine_keeps_chat_available(tmp_path: Path) -> None:
+def test_direct_start_without_container_engine_warns_that_readiness_will_fail(
+    tmp_path: Path,
+) -> None:
     script = tmp_path / "start.sh"
     script.write_text((REPO_ROOT / "start.sh").read_text(encoding="utf-8"), encoding="utf-8")
     script.chmod(0o755)
@@ -591,10 +593,10 @@ def test_direct_start_without_container_engine_keeps_chat_available(tmp_path: Pa
     )
 
     assert result.returncode == 0
-    assert "chat will start but sandbox shell commands will be unavailable" in result.stderr
+    assert "production host readiness will fail unless a sandbox worker is wired" in result.stderr
 
 
-def test_direct_start_reports_restricted_process_sandbox_when_available(
+def test_direct_start_reports_restricted_process_sandbox_worker_when_available(
     tmp_path: Path,
 ) -> None:
     script = tmp_path / "start.sh"
@@ -616,8 +618,7 @@ def test_direct_start_reports_restricted_process_sandbox_when_available(
     )
 
     assert result.returncode == 0
-    assert "tenant and repository commands will use" in result.stderr
-    assert "restricted process sandbox" in result.stderr
+    assert "sandbox worker will use bundled restricted process isolation" in result.stderr
     assert "shell commands will be unavailable" not in result.stderr
 
 

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -67,6 +67,7 @@ EXPECTED_OPERATIONS = {
     "trigger_spec_rollback",
     "secret_handle_list",
     "secret_handle_revoke",
+    "sandbox_ssh_diagnostic",
     "capability_list",
     "capability_seed_bundled",
     "capability_test",
@@ -94,7 +95,7 @@ EXPECTED_OPERATIONS = {
 def test_registry_is_complete_unique_and_versioned() -> None:
     names = [spec.name for spec in TOOL_SPECS]
 
-    assert len(names) == 66
+    assert len(names) == 67
     assert len(names) == len(set(names))
     assert set(names) == EXPECTED_OPERATIONS
     assert set(TOOL_SPEC_BY_NAME) == EXPECTED_OPERATIONS
@@ -104,7 +105,9 @@ def test_registry_is_complete_unique_and_versioned() -> None:
 def test_registry_limits_approval_to_source_shell_policy() -> None:
     for spec in TOOL_SPECS:
         expected = (
-            ApprovalMode.POLICY if spec.name == "source_shell" else ApprovalMode.AUTO
+            ApprovalMode.POLICY
+            if spec.name in {"source_shell", "sandbox_ssh_diagnostic"}
+            else ApprovalMode.AUTO
         )
         assert spec.approval is expected
         if spec.effect is ToolEffect.READ:
@@ -129,6 +132,8 @@ def test_registry_limits_approval_to_source_shell_policy() -> None:
     assert TOOL_SPEC_BY_NAME["capability_test"].idempotency is IdempotencyMode.NONE
     assert TOOL_SPEC_BY_NAME["source_shell"].approval is ApprovalMode.POLICY
     assert TOOL_SPEC_BY_NAME["source_shell"].idempotency is IdempotencyMode.NONE
+    assert TOOL_SPEC_BY_NAME["sandbox_ssh_diagnostic"].approval is ApprovalMode.POLICY
+    assert TOOL_SPEC_BY_NAME["sandbox_ssh_diagnostic"].idempotency is IdempotencyMode.NONE
     for name in ("source_release", "source_rollback"):
         assert TOOL_SPEC_BY_NAME[name].idempotency is IdempotencyMode.REQUIRED
 
@@ -204,7 +209,7 @@ def test_machine_contract_contains_types_and_exact_registry() -> None:
     schema = tool_contract_json_schema()
 
     assert document["contract_version"] == CONTRACT_VERSION
-    assert len(document["operations"]) == 66
+    assert len(document["operations"]) == 67
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
     assert schema["x-opentulpa-contract-version"] == CONTRACT_VERSION
     assert schema["x-opentulpa-operations"] == document["operations"]


### PR DESCRIPTION
Summary:
- Add private authenticated sandbox worker API plus host-side client/supervisor.
- Gate host health and config/runtime activation on sandbox canaries, including ssh availability.
- Wire child runtimes to the worker, remove normal provider env setup, and document Host + Sandbox + Data.
- Add worker hardening tests for auth, path traversal, unsupported archive entries, output truncation, timeout process-group cleanup, one-shot secret mounts, and secret-free worker env.

Verification:
- uv run pytest -q tests/test_sandbox_worker.py tests/test_host_app.py tests/test_host_runtime.py tests/test_main_composition.py tests/test_start_script.py -q
- uv run ruff check src/opentulpa/sandbox src/opentulpa/host src/opentulpa/__main__.py tests/test_sandbox_worker.py tests/test_host_app.py tests/test_host_runtime.py tests/test_main_composition.py tests/test_start_script.py
- uv run mypy src/opentulpa/sandbox src/opentulpa/host src/opentulpa/__main__.py
- git diff --check

Note:
- Full uv run pytest -q reached 1064 passed / 6 skipped with one unrelated existing failure in tests/test_playwright_browser_session.py::test_cloud_cdp_session_exposes_browser_protocol because that test uses live DNS/private-address filtering without the fake resolver.