### PR TITLE
Guard Telegram group chatter

### DIFF
--- a/src/opentulpa/capability_workers/telegram_worker.py
+++ b/src/opentulpa/capability_workers/telegram_worker.py
@@ -430,6 +430,7 @@ class TelegramInterfaceWorker:
         self._poll_timeout_seconds = poll_timeout_seconds
         self._retry_delay_seconds = retry_delay_seconds
         self._bot_id: int | None = None
+        self._bot_username: str | None = None
         self._webhook_cleared = False
         self._commands_registered = False
         self._normal_update_lock = asyncio.Lock()
@@ -718,6 +719,16 @@ class TelegramInterfaceWorker:
             return
 
         text = str(message.get("text") or message.get("caption") or "").strip()
+        non_private_chat = _is_non_private_chat(chat)
+        if non_private_chat and not _message_addresses_bot(
+            message,
+            bot_id=self._bot_id,
+            bot_username=self._bot_username,
+        ):
+            self._complete(update_id=update_id, source_event_id=source_event_id)
+            return
+        if non_private_chat:
+            text = _strip_leading_bot_mention(text, self._bot_username)
         paired = self._state.paired_identity()
         if paired is None:
             await self._handle_pairing(
@@ -728,8 +739,10 @@ class TelegramInterfaceWorker:
                 source_event_id=source_event_id,
             )
             return
-        if paired != (user_id, chat_id):
-            await self._telegram.send_message(chat_id=chat_id, text="Unauthorized.")
+        paired_user_id, paired_chat_id = paired
+        if user_id != paired_user_id or (not non_private_chat and chat_id != paired_chat_id):
+            if not non_private_chat:
+                await self._telegram.send_message(chat_id=chat_id, text="Unauthorized.")
             self._complete(update_id=update_id, source_event_id=source_event_id)
             return
 
@@ -902,7 +915,9 @@ class TelegramInterfaceWorker:
         if not callback_id or chat_id is None or user_id is None:
             self._complete(update_id=update_id, source_event_id=source_event_id)
             return
-        if self._state.paired_identity() != (user_id, chat_id):
+        paired = self._state.paired_identity()
+        non_private_chat = _is_non_private_chat(chat)
+        if paired is None or user_id != paired[0] or (not non_private_chat and chat_id != paired[1]):
             await self._telegram.answer_callback_query(
                 callback_query_id=callback_id,
                 text="Unauthorized",
@@ -1286,6 +1301,8 @@ class TelegramInterfaceWorker:
         if bot_id is None:
             raise TelegramAPIError("Telegram returned an invalid bot identity.")
         self._bot_id = bot_id
+        username = str(bot.get("username") or "").strip().lstrip("@")
+        self._bot_username = username or None
 
     def _source_event_id(self, update_id: int) -> str:
         if self._bot_id is None:
@@ -1607,6 +1624,42 @@ def _command(text: str) -> tuple[str, str]:
     command = parts[0].split("@", 1)[0].lower()
     argument = parts[1].strip() if len(parts) == 2 else ""
     return command, argument
+
+
+def _is_non_private_chat(chat: Any) -> bool:
+    if not isinstance(chat, Mapping):
+        return False
+    chat_type = str(chat.get("type") or "private").strip().lower()
+    return chat_type not in {"", "private"}
+
+
+def _message_addresses_bot(
+    message: Mapping[str, Any],
+    *,
+    bot_id: int | None,
+    bot_username: str | None,
+) -> bool:
+    reply = message.get("reply_to_message")
+    if isinstance(reply, Mapping):
+        reply_sender = reply.get("from")
+        if isinstance(reply_sender, Mapping) and _positive_int(reply_sender.get("id")) == bot_id:
+            return True
+    username = str(bot_username or "").strip().lstrip("@").lower()
+    if not username:
+        return False
+    marker = f"@{username}"
+    text = str(message.get("text") or message.get("caption") or "").lower()
+    return marker in text
+
+
+def _strip_leading_bot_mention(text: str, bot_username: str | None) -> str:
+    username = str(bot_username or "").strip().lstrip("@")
+    if not username:
+        return text
+    marker = f"@{username}"
+    if not text.lower().startswith(marker.lower()):
+        return text
+    return text[len(marker) :].strip()
 
 
 def _coalescible_text(

--- a/tests/test_capability_worker_telegram.py
+++ b/tests/test_capability_worker_telegram.py
@@ -247,13 +247,23 @@ class _UnavailableAgent(_Agent):
         raise AgentAPIError("agent API is starting")
 
 
-def _message(update_id: int, *, user_id: int = 7, chat_id: int = 9, text: str) -> dict[str, Any]:
+def _message(
+    update_id: int,
+    *,
+    user_id: int = 7,
+    chat_id: int = 9,
+    chat_type: str | None = None,
+    text: str,
+) -> dict[str, Any]:
+    chat: dict[str, Any] = {"id": chat_id}
+    if chat_type is not None:
+        chat["type"] = chat_type
     return {
         "update_id": update_id,
         "message": {
             "message_id": update_id,
             "from": {"id": user_id},
-            "chat": {"id": chat_id},
+            "chat": chat,
             "text": text,
         },
     }
@@ -320,6 +330,64 @@ async def test_one_time_pairing_then_routes_only_owner_messages(tmp_path: Path) 
 
     await worker.poll_once()
     assert len(agent.starts) == 1
+
+
+@pytest.mark.asyncio
+async def test_group_chatter_is_ignored_without_unauthorized_spam(tmp_path: Path) -> None:
+    telegram = _Telegram(
+        [
+            _message(1, user_id=8, chat_id=-100, chat_type="supergroup", text="hello all"),
+            _message(2, user_id=7, chat_id=-100, chat_type="supergroup", text="not for bot"),
+        ]
+    )
+    agent = _Agent()
+    state = TelegramWorkerState(tmp_path / "worker.json")
+    state.pair(user_id=7, chat_id=9)
+    worker = TelegramInterfaceWorker(
+        telegram=telegram,
+        agent=agent,
+        state=state,
+        pairing_code=None,
+        poll_timeout_seconds=1,
+    )
+
+    assert await worker.poll_once() == 2
+
+    assert agent.starts == []
+    assert telegram.messages == []
+    assert state.next_update_id == 3
+
+
+@pytest.mark.asyncio
+async def test_paired_owner_can_address_bot_in_group(tmp_path: Path) -> None:
+    telegram = _Telegram(
+        [
+            _message(
+                1,
+                user_id=7,
+                chat_id=-100,
+                chat_type="supergroup",
+                text="@open_tulpa_bot summarize this thread",
+            )
+        ]
+    )
+    agent = _Agent()
+    state = TelegramWorkerState(tmp_path / "worker.json")
+    state.pair(user_id=7, chat_id=9)
+    worker = TelegramInterfaceWorker(
+        telegram=telegram,
+        agent=agent,
+        state=state,
+        pairing_code=None,
+        poll_timeout_seconds=1,
+    )
+
+    assert await worker.poll_once() == 1
+
+    assert agent.starts[0]["thread_id"] == state.thread_id(-100)
+    assert agent.starts[0]["text"] == "summarize this thread"
+    assert telegram.messages[-1]["chat_id"] == -100
+    assert telegram.messages[-1]["text"] == "hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ignore unrelated group/supergroup Telegram chatter without replying Unauthorized
- allow the paired owner to use the bot in groups when mentioning/replying to the bot
- keep private DM exact pairing behavior unchanged

## Verification
- uv run rtk pytest tests/test_capability_worker_telegram.py -q
- uv run rtk ruff check src/opentulpa/capability_workers/telegram_worker.py tests/test_capability_worker_telegram.py
- uv run rtk mypy src/opentulpa/capability_workers/telegram_worker.py
- uv run rtk ruff check
- uv run rtk mypy src
- uv run rtk pytest -q
- rtk git diff --check