### PR TITLE
Fix Telegram worker startup after evolution

### DIFF
--- a/src/opentulpa/capabilities/workers.py
+++ b/src/opentulpa/capabilities/workers.py
@@ -87,7 +87,7 @@ class SubprocessWorkerHost:
     stable OCI authority, which enforces those boundaries and rollback fencing.
     """
 
-    _INHERITED_ENVIRONMENT = ("PATH", "LANG", "LC_ALL", "TMPDIR")
+    _INHERITED_ENVIRONMENT = ("PATH", "LANG", "LC_ALL", "TMPDIR", "PYTHONPATH")
 
     def __init__(
         self,

--- a/src/opentulpa/host/assets/index.html
+++ b/src/opentulpa/host/assets/index.html
@@ -73,8 +73,9 @@
               <div class="divider"><span>OPTIONAL INTERFACE</span></div>
               <div class="form-grid two">
                 <label>TELEGRAM BOT TOKEN<input id="telegram-token" type="password" autocomplete="off" placeholder="123456:bot-token"></label>
-                <label>TELEGRAM USER ID<input id="telegram-user-id" inputmode="numeric" pattern="[0-9]*" placeholder="numeric owner id"></label>
+                <label>TELEGRAM USER ID (OPTIONAL)<input id="telegram-user-id" inputmode="numeric" pattern="[0-9]*" placeholder="numeric owner id"></label>
               </div>
+              <p class="muted">Without a user ID, pair in Telegram with <code>/start</code> followed by the last 8 characters of the bot token.</p>
               <div class="actions">
                 <button id="apply-button" type="submit">VALIDATE + START</button>
                 <button id="restart-button" class="secondary hidden" type="button">RESTART RUNTIME</button>

--- a/src/opentulpa/host/cli.py
+++ b/src/opentulpa/host/cli.py
@@ -142,7 +142,7 @@ def build_host_application() -> tuple[Any, str, str, Path]:
             telegram_bot_token=SecretStr(telegram_token) if telegram_token else None,
             telegram_user_id=telegram_id if telegram_token else None,
         )
-    elif active is not None and active.telegram_bot_token is None and telegram_token and telegram_id:
+    elif active is not None and active.telegram_bot_token is None and telegram_token:
         bootstrap = HostConfigInput(
             expected_revision=active.revision,
             base_url=active.base_url,

--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -1671,9 +1671,8 @@ class RuntimeSupervisor:
             environment["OPENTULPA_TELEGRAM_PAIRING_CODE"] = (
                 config.telegram_pairing_code.get_secret_value()
             )
-        environment["OPENTULPA_TELEGRAM_OWNER_ID"] = (
-            str(config.telegram_user_id) if config.telegram_user_id is not None else ""
-        )
+        if config.telegram_user_id is not None:
+            environment["OPENTULPA_TELEGRAM_OWNER_ID"] = str(config.telegram_user_id)
         return environment
 
     def _live_source_cwd(self, source_root: Path) -> Path:

--- a/src/opentulpa/host/store.py
+++ b/src/opentulpa/host/store.py
@@ -196,10 +196,16 @@ class HostStore:
                 if active.telegram_bot_token is not None
                 else None
             )
-        if (telegram_token is None) != (value.telegram_user_id is None):
-            raise ValueError("Telegram bot token and user ID must be configured together")
+        if telegram_token is None and value.telegram_user_id is not None:
+            raise ValueError("Telegram bot token is required when a user ID is configured")
         internal_token = secrets.token_urlsafe(48)
-        pairing_code = secrets.token_urlsafe(9) if telegram_token else None
+        pairing_code = (
+            telegram_token[-8:]
+            if telegram_token and value.telegram_user_id is None
+            else secrets.token_urlsafe(9)
+            if telegram_token
+            else None
+        )
         with self._lock, closing(self._connect()) as connection:
             connection.execute("BEGIN IMMEDIATE")
             cursor = connection.execute(

--- a/start.sh
+++ b/start.sh
@@ -64,8 +64,8 @@ Options:
   --dry-run             Print commands without running them
   --api-key KEY         OpenAI-compatible model API key
   --telegram-bot-token TOKEN
-                        Telegram bot token; requires --telegram-user-id
-  --telegram-user-id ID Telegram numeric owner ID; requires --telegram-bot-token
+                        Telegram bot token; owner ID is optional
+  --telegram-user-id ID Optional numeric owner ID; otherwise pair in Telegram
   --owner-token TOKEN   Optional remote Agent API owner token
   --host HOST           Bind host (local default: 127.0.0.1)
   --port PORT           Server port (default: PORT or 8000)
@@ -708,8 +708,9 @@ configure_serve() {
 
   env_is_set "TELEGRAM_BOT_TOKEN" && bot_configured=1
   telegram_allowlist_is_set && owner_configured=1
-  [[ "${bot_configured}" == "${owner_configured}" ]] \
-    || die "Telegram requires both --telegram-bot-token and --telegram-user-id"
+  if [[ "${owner_configured}" == "1" && "${bot_configured}" != "1" ]]; then
+    die "--telegram-user-id requires --telegram-bot-token"
+  fi
 
   RUNTIME_MODE="server"
 }

--- a/tests/test_dynamic_capability_workers.py
+++ b/tests/test_dynamic_capability_workers.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -368,6 +369,46 @@ async def test_subprocess_host_starts_without_a_shell_and_stops_cleanly() -> Non
 
     await manager.stop("timer-main")
     assert manager.active("timer-main") is None
+
+
+@pytest.mark.asyncio
+async def test_subprocess_host_inherits_live_source_pythonpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "src"
+    package = source / "live_worker"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "__main__.py").write_text(
+        "import os, time\n"
+        "from pathlib import Path\n"
+        "ready = Path(os.environ['OPENTULPA_WORKER_READY_FILE'])\n"
+        "ready.write_text(str(os.getpid()), encoding='ascii')\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PYTHONPATH", str(source))
+    worker = WorkerSpec(
+        name="live_source_worker",
+        kind=WorkerKind.INTERFACE,
+        protocol="agent-interface-v1",
+        command=(sys.executable, "-m", "live_worker"),
+        healthcheck=HealthCheck(kind="ready_file"),
+        resources=ResourceLimits(startup_timeout_seconds=1),
+    )
+    manifest = CapabilityManifest(
+        name="live_source",
+        version="1.0.0",
+        workers=(worker,),
+        eval_commands=(EvalCommand(argv=("pytest", "-q")),),
+    )
+    manager = CapabilityWorkerManager(SubprocessWorkerHost(cwd=tmp_path))
+
+    active = await manager.start(instance_id="live-source-main", manifest=manifest)
+
+    assert len(active.handles) == 1
+    assert await manager.healthy("live-source-main") is True
+    await manager.stop("live-source-main")
 
 
 @pytest.mark.asyncio

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -485,6 +485,10 @@ async def test_host_passes_telegram_owner_identity_without_writing_child_state(
 
     assert environment["OPENTULPA_TELEGRAM_OWNER_ID"] == "7"
     assert not data_root.exists()
+
+    token_only = _config().model_copy(update={"telegram_user_id": None})
+    pairing_environment = runtime._child_environment(token_only, port=8123, live_source=spec)
+    assert "OPENTULPA_TELEGRAM_OWNER_ID" not in pairing_environment
     await runtime.shutdown()
 
 

--- a/tests/test_host_service.py
+++ b/tests/test_host_service.py
@@ -188,7 +188,7 @@ async def test_failed_candidate_keeps_previous_revision_and_runtime(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_telegram_is_validated_stored_as_handle_and_activated(tmp_path: Path) -> None:
+async def test_telegram_token_only_is_validated_stored_and_activated(tmp_path: Path) -> None:
     requests: list[tuple[str, str, dict[str, object] | None]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -238,11 +238,11 @@ async def test_telegram_is_validated_stored_as_handle_and_activated(tmp_path: Pa
             api_key=SecretStr("provider-secret"),
             base_url="https://models.example",
             telegram_bot_token=SecretStr("123:telegram-secret"),
-            telegram_user_id=7,
         )
     )
 
     assert view.telegram_configured is True
+    assert view.telegram_pairing_required is True
     pending = next(body for method, path, body in requests if path == "/v2/secrets/pending")
     assert pending == {
         "id": "telegram-bot-token",

--- a/tests/test_host_store.py
+++ b/tests/test_host_store.py
@@ -77,6 +77,21 @@ def test_configuration_is_encrypted_revisioned_and_atomic(tmp_path: Path) -> Non
         )
 
 
+def test_first_configuration_accepts_telegram_token_without_owner_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    config = store.stage(
+        HostConfigInput(
+            api_key=SecretStr("provider-secret"),
+            telegram_bot_token=SecretStr("123456789:abcdefghijklmnopqrstuvwxyzABCDEFGH"),
+        )
+    )
+
+    assert config.telegram_user_id is None
+    assert config.telegram_pairing_code == SecretStr("ABCDEFGH")
+    assert store.view(config).telegram_pairing_required is True
+
+
 def test_host_database_has_exactly_one_active_revision(tmp_path: Path) -> None:
     store = _store(tmp_path)
     one = store.stage(HostConfigInput(api_key=SecretStr("secret-one")))

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -151,7 +151,7 @@ def test_serve_uses_stable_host_when_public_url_is_present(tmp_path: Path) -> No
     assert "Telegram webhook secret" not in result.stdout
 
 
-def test_serve_requires_bot_token_and_owner_id_together() -> None:
+def test_serve_accepts_bot_token_without_owner_id() -> None:
     result = _run_start(
         "serve",
         "--run-only",
@@ -163,8 +163,8 @@ def test_serve_requires_bot_token_and_owner_id_together() -> None:
         env=EMPTY_REQUIRED_ENV,
     )
 
-    assert result.returncode == 1
-    assert "requires both --telegram-bot-token and --telegram-user-id" in result.stderr
+    assert result.returncode == 0
+    assert "python -m opentulpa.host" in result.stdout
 
 
 def test_serve_does_not_persist_command_line_secrets_in_dotenv(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve the trusted live-source PYTHONPATH when launching capability subprocesses
- allow token-only Telegram setup with deterministic pairing and persistent paired state
- accept token-only bootstrap through the host CLI and setup script

## Verification
- 85 focused host/worker tests passed
- 116 Telegram composition tests passed
- full suite: 1,393 passed, 4 skipped, 9 deselected; two PATH-sensitive evaluator tests rerun with the venv on PATH and passed
- Ruff checks, bash syntax, and git diff checks passed