### PR TITLE
Treat exited runtime zombies as stopped

### DIFF
--- a/src/opentulpa/host/runtime.py
+++ b/src/opentulpa/host/runtime.py
@@ -2916,6 +2916,8 @@ class RuntimeSupervisor:
             raise RuntimeUnavailableError("recorded runtime process could not be inspected") from exc
         argv = tuple(value.decode("utf-8", errors="surrogateescape") for value in raw_argv.split(b"\0") if value)
         if not argv:
+            if RuntimeSupervisor._linux_process_state(proc_root) == "Z":
+                return None
             raise RuntimeUnavailableError("recorded runtime process command is unavailable")
         try:
             executable = RuntimeSupervisor._linux_process_executable(proc_root, argv)
@@ -2981,6 +2983,15 @@ class RuntimeSupervisor:
     @staticmethod
     def _linux_process_birth(proc_root: Path) -> str:
         return RuntimeSupervisor._linux_process_metadata(proc_root)[2]
+
+    @staticmethod
+    def _linux_process_state(proc_root: Path) -> str:
+        raw_stat = (proc_root / "stat").read_text(encoding="ascii")
+        close_paren = raw_stat.rfind(")")
+        fields = raw_stat[close_paren + 2 :].split() if close_paren >= 0 else []
+        if not fields or len(fields[0]) != 1:
+            raise RuntimeUnavailableError("runtime process state is invalid")
+        return fields[0]
 
     @staticmethod
     def _linux_process_metadata(proc_root: Path) -> tuple[int, int, str]:

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -822,6 +822,41 @@ def test_process_table_error_preserves_safe_pid_and_errno(
         RuntimeSupervisor._linux_process_table(proc_root)
 
 
+def test_process_inspection_treats_only_empty_zombie_command_as_exited(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc_root = tmp_path / "proc" / "42"
+    proc_root.mkdir(parents=True)
+    (proc_root / "cmdline").write_bytes(b"")
+    monkeypatch.setattr(
+        runtime_module,
+        "Path",
+        lambda value: proc_root.parent if value == "/proc" else Path(value),
+    )
+
+    monkeypatch.setattr(RuntimeSupervisor, "_pid_alive", staticmethod(lambda pid: True))
+    monkeypatch.setattr(
+        RuntimeSupervisor,
+        "_linux_process_metadata",
+        staticmethod(lambda path: (1, 42, "linux:1")),
+    )
+    monkeypatch.setattr(
+        RuntimeSupervisor,
+        "_linux_process_state",
+        staticmethod(lambda path: "Z"),
+    )
+    assert RuntimeSupervisor._inspect_process(42) is None
+
+    monkeypatch.setattr(
+        RuntimeSupervisor,
+        "_linux_process_state",
+        staticmethod(lambda path: "R"),
+    )
+    with pytest.raises(RuntimeUnavailableError, match="process command is unavailable"):
+        RuntimeSupervisor._inspect_process(42)
+
+
 @pytest.mark.asyncio
 async def test_explicit_stop_fails_closed_when_containment_preflight_fails(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- recognize an empty Linux cmdline as exited only when procfs proves zombie state
- keep every non-zombie empty-command case fail-closed
- cover the planned runtime-replacement race found during OpenTulpa v2 migration

## Verification
- 1075 passed, 3 skipped, 5 deselected
- ruff check .
- mypy src
- uv lock --check
- shell syntax checks