### PR TITLE
Support uv controller entrypoint wrappers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -666,10 +666,17 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
     runtime_digest.update(b"\0")
 if runtime_digest.hexdigest() != manifest.get("runtime_tree_sha256"):
     raise SystemExit(1)
-expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
+def uses_final_interpreter(entrypoint: pathlib.Path) -> bool:
+    first = entrypoint.read_text(errors="replace").splitlines()[0]
+    interpreter = pathlib.Path(first.removeprefix("#!"))
+    return (
+        first.startswith("#!")
+        and interpreter.parent.resolve() == (root / "bin").resolve()
+        and interpreter.resolve() == (root / "bin" / "python").resolve()
+    )
 for command in commands:
     entrypoint = root / "bin" / command
-    if not entrypoint.is_file() or entrypoint.read_text(errors="replace").splitlines()[0] not in expected:
+    if not entrypoint.is_file() or not uses_final_interpreter(entrypoint):
         raise SystemExit(1)
 PY
 }
@@ -781,14 +788,21 @@ import sys
 root = pathlib.Path(sys.argv[1])
 source = pathlib.Path(sys.argv[2]).resolve()
 commands = sys.argv[3:]
-expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
+def uses_final_interpreter(script: pathlib.Path) -> bool:
+    first = script.read_text(errors="replace").splitlines()[0]
+    interpreter = pathlib.Path(first.removeprefix("#!"))
+    return (
+        first.startswith("#!")
+        and interpreter.parent.resolve() == (root / "bin").resolve()
+        and interpreter.resolve() == (root / "bin" / "python").resolve()
+    )
 distribution = importlib.metadata.distribution("opentulpa")
 entrypoints = {item.name: item for item in distribution.entry_points if item.group == "console_scripts"}
 for command in commands:
     script = root / "bin" / command
     if command not in entrypoints or not script.is_file():
         raise SystemExit(f"missing console entrypoint: {command}")
-    if script.read_text(errors="replace").splitlines()[0] not in expected:
+    if not uses_final_interpreter(script):
         raise SystemExit(f"entrypoint does not use its final interpreter: {command}")
     if not callable(entrypoints[command].load()):
         raise SystemExit(f"console entrypoint is not callable: {command}")
@@ -1023,8 +1037,13 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
     runtime_digest.update(payload + b"\0")
 if runtime_digest.hexdigest() != digest:
     raise SystemExit(1)
-expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
-if entrypoint.read_text(errors="replace").splitlines()[0] not in expected:
+first = entrypoint.read_text(errors="replace").splitlines()[0]
+interpreter = pathlib.Path(first.removeprefix("#!"))
+if (
+    not first.startswith("#!")
+    or interpreter.parent.resolve() != (root / "bin").resolve()
+    or interpreter.resolve() != (root / "bin" / "python").resolve()
+):
     raise SystemExit(1)
 source = manifest.get("source")
 oid = str(source.get("oid") if isinstance(source, dict) else "")

--- a/install.sh
+++ b/install.sh
@@ -666,10 +666,10 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
     runtime_digest.update(b"\0")
 if runtime_digest.hexdigest() != manifest.get("runtime_tree_sha256"):
     raise SystemExit(1)
-expected = f"#!{root / 'bin' / 'python'}"
+expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
 for command in commands:
     entrypoint = root / "bin" / command
-    if not entrypoint.is_file() or entrypoint.read_text(errors="replace").splitlines()[0] != expected:
+    if not entrypoint.is_file() or entrypoint.read_text(errors="replace").splitlines()[0] not in expected:
         raise SystemExit(1)
 PY
 }
@@ -781,14 +781,14 @@ import sys
 root = pathlib.Path(sys.argv[1])
 source = pathlib.Path(sys.argv[2]).resolve()
 commands = sys.argv[3:]
-expected = f"#!{root / 'bin' / 'python'}"
+expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
 distribution = importlib.metadata.distribution("opentulpa")
 entrypoints = {item.name: item for item in distribution.entry_points if item.group == "console_scripts"}
 for command in commands:
     script = root / "bin" / command
     if command not in entrypoints or not script.is_file():
         raise SystemExit(f"missing console entrypoint: {command}")
-    if script.read_text(errors="replace").splitlines()[0] != expected:
+    if script.read_text(errors="replace").splitlines()[0] not in expected:
         raise SystemExit(f"entrypoint does not use its final interpreter: {command}")
     if not callable(entrypoints[command].load()):
         raise SystemExit(f"console entrypoint is not callable: {command}")
@@ -1023,8 +1023,8 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
     runtime_digest.update(payload + b"\0")
 if runtime_digest.hexdigest() != digest:
     raise SystemExit(1)
-expected = f"#!{root / 'bin' / 'python'}"
-if entrypoint.read_text(errors="replace").splitlines()[0] != expected:
+expected = {f"#!{root / 'bin' / name}" for name in ("python", "python3")}
+if entrypoint.read_text(errors="replace").splitlines()[0] not in expected:
     raise SystemExit(1)
 source = manifest.get("source")
 oid = str(source.get("oid") if isinstance(source, dict) else "")

--- a/install.sh
+++ b/install.sh
@@ -667,10 +667,25 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
 if runtime_digest.hexdigest() != manifest.get("runtime_tree_sha256"):
     raise SystemExit(1)
 def uses_final_interpreter(entrypoint: pathlib.Path) -> bool:
-    first = entrypoint.read_text(errors="replace").splitlines()[0]
-    interpreter = pathlib.Path(first.removeprefix("#!"))
+    lines = entrypoint.read_text(errors="replace").splitlines()
+    if len(lines) >= 3 and lines[0] == "#!/bin/sh" and lines[2] == "' '''":
+        prefix = "'''exec' '"
+        suffix = "' \"$0\" \"$@\""
+        if not lines[1].startswith(prefix) or not lines[1].endswith(suffix):
+            return False
+        raw_interpreter = lines[1][len(prefix):-len(suffix)]
+        if not raw_interpreter or "'" in raw_interpreter:
+            return False
+        interpreter = pathlib.Path(raw_interpreter)
+    elif lines and lines[0].startswith("#!"):
+        interpreter = pathlib.Path(lines[0].removeprefix("#!"))
+    else:
+        return False
+    aliases = {"python", f"python{sys.version_info.major}", f"python{sys.version_info.major}.{sys.version_info.minor}"}
     return (
-        first.startswith("#!")
+        interpreter.is_absolute()
+        and ".." not in interpreter.parts
+        and interpreter.name in aliases
         and interpreter.parent.resolve() == (root / "bin").resolve()
         and interpreter.resolve() == (root / "bin" / "python").resolve()
     )
@@ -789,10 +804,25 @@ root = pathlib.Path(sys.argv[1])
 source = pathlib.Path(sys.argv[2]).resolve()
 commands = sys.argv[3:]
 def uses_final_interpreter(script: pathlib.Path) -> bool:
-    first = script.read_text(errors="replace").splitlines()[0]
-    interpreter = pathlib.Path(first.removeprefix("#!"))
+    lines = script.read_text(errors="replace").splitlines()
+    if len(lines) >= 3 and lines[0] == "#!/bin/sh" and lines[2] == "' '''":
+        prefix = "'''exec' '"
+        suffix = "' \"$0\" \"$@\""
+        if not lines[1].startswith(prefix) or not lines[1].endswith(suffix):
+            return False
+        raw_interpreter = lines[1][len(prefix):-len(suffix)]
+        if not raw_interpreter or "'" in raw_interpreter:
+            return False
+        interpreter = pathlib.Path(raw_interpreter)
+    elif lines and lines[0].startswith("#!"):
+        interpreter = pathlib.Path(lines[0].removeprefix("#!"))
+    else:
+        return False
+    aliases = {"python", f"python{sys.version_info.major}", f"python{sys.version_info.major}.{sys.version_info.minor}"}
     return (
-        first.startswith("#!")
+        interpreter.is_absolute()
+        and ".." not in interpreter.parts
+        and interpreter.name in aliases
         and interpreter.parent.resolve() == (root / "bin").resolve()
         and interpreter.resolve() == (root / "bin" / "python").resolve()
     )
@@ -1037,12 +1067,27 @@ for path in sorted(runtime_paths, key=lambda item: item.relative_to(root).as_pos
     runtime_digest.update(payload + b"\0")
 if runtime_digest.hexdigest() != digest:
     raise SystemExit(1)
-first = entrypoint.read_text(errors="replace").splitlines()[0]
-interpreter = pathlib.Path(first.removeprefix("#!"))
-if (
-    not first.startswith("#!")
-    or interpreter.parent.resolve() != (root / "bin").resolve()
-    or interpreter.resolve() != (root / "bin" / "python").resolve()
+lines = entrypoint.read_text(errors="replace").splitlines()
+if len(lines) >= 3 and lines[0] == "#!/bin/sh" and lines[2] == "' '''":
+    prefix = "'''exec' '"
+    suffix = "' \"$0\" \"$@\""
+    if not lines[1].startswith(prefix) or not lines[1].endswith(suffix):
+        raise SystemExit(1)
+    raw_interpreter = lines[1][len(prefix):-len(suffix)]
+    if not raw_interpreter or "'" in raw_interpreter:
+        raise SystemExit(1)
+    interpreter = pathlib.Path(raw_interpreter)
+elif lines and lines[0].startswith("#!"):
+    interpreter = pathlib.Path(lines[0].removeprefix("#!"))
+else:
+    raise SystemExit(1)
+aliases = {"python", f"python{sys.version_info.major}", f"python{sys.version_info.major}.{sys.version_info.minor}"}
+if not (
+    interpreter.is_absolute()
+    and ".." not in interpreter.parts
+    and interpreter.name in aliases
+    and interpreter.parent.resolve() == (root / "bin").resolve()
+    and interpreter.resolve() == (root / "bin" / "python").resolve()
 ):
     raise SystemExit(1)
 source = manifest.get("source")

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -139,6 +139,7 @@ destination.mkdir(parents=True, exist_ok=True)
 import os
 import pathlib
 import platform
+import shlex
 import sys
 import time
 
@@ -203,8 +204,17 @@ elif args[:2] == ["pip", "install"]:
     (dist / "entry_points.txt").write_text(entries, encoding="utf-8")
     for name in COMMANDS:
         script = generation / "bin" / name
+        interpreter = generation / "bin" / "python"
+        launcher = f"#!{{interpreter}}\\n"
+        if os.environ.get("FAKE_UV_LONG_SHEBANG") == "1":
+            launcher = (
+                "#!/bin/sh\\n'''exec' "
+                + shlex.quote(str(interpreter))
+                + ' "$0" "$@"\\n'
+                + "' '''\\n"
+            )
         script.write_text(
-            f"#!{{generation / 'bin' / 'python'}}\\n"
+            launcher +
             "import json, os, pathlib, sys\\n"
             "if len(sys.argv) == 3 and sys.argv[1] == '--probe':\\n"
             "    pathlib.Path(sys.argv[2]).write_text(json.dumps({{k: os.environ.get(k) for k in "
@@ -321,6 +331,41 @@ def test_installer_builds_final_path_controller_and_exact_dispatcher(tmp_path: P
     assert "--extra evaluation" not in logged
     assert "pip download --disable-pip-version-check --require-hashes --only-binary=:all:" in logged
     assert "uv sync" not in logged
+
+
+def test_installer_accepts_uv_long_shebang_wrapper(tmp_path: Path) -> None:
+    source = _source(tmp_path / "source")
+    tools, _ = _fake_tools(tmp_path)
+
+    result = _run_install(
+        tmp_path,
+        source,
+        tools,
+        extra_env={"FAKE_UV_LONG_SHEBANG": "1"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    generation = _current_generation(tmp_path)
+    assert (generation / "bin" / "opentulpa").read_text().startswith(
+        "#!/bin/sh\n'''exec' "
+    )
+    probe = tmp_path / "long shebang environment.json"
+    dispatched = subprocess.run(
+        [str(tmp_path / "command bin" / "opentulpa"), "--probe", str(probe)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert dispatched.returncode == 0, dispatched.stderr
+
+    reused = _run_install(
+        tmp_path,
+        source,
+        tools,
+        extra_env={"FAKE_UV_LONG_SHEBANG": "1"},
+    )
+    assert reused.returncode == 0, reused.stderr
+    assert _current_generation(tmp_path) == generation
 
 
 def test_installer_reuses_identity_and_atomically_tracks_previous(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- accept generation-local Python aliases in installed console scripts
- validate uv long-path shell wrappers at build, reuse, and launch time
- keep rejecting relative, escaping, or foreign interpreter paths

## Verification
- `uv run --isolated --frozen --all-extras -- pytest -q tests/test_install_script.py` (`18 passed`)
- `uv run --isolated --frozen --all-extras -- ruff check tests/test_install_script.py`
- `sh -n install.sh`
- real macOS install created and reused generation `bba8ebcaff5fc82b0f4a814482dba2f37753e1faa2145feb5feed324eeadd578`
- installed dispatcher successfully ran `opentulpa --help`