### PR TITLE
Allow installer data beside host state

### DIFF
--- a/src/opentulpa/host/paths.py
+++ b/src/opentulpa/host/paths.py
@@ -31,6 +31,7 @@ _PRODUCT_ENTRIES = {
 _CONTROLLER_ENTRIES = frozenset(
     {
         "bootstrap",
+        "install",
         "product",
         "source",
         "bun",

--- a/tests/test_host_cli.py
+++ b/tests/test_host_cli.py
@@ -341,6 +341,7 @@ def test_host_paths_allow_known_controller_entries_during_product_migration(
     for name in (
         "bootstrap",
         "bun",
+        "install",
         "lost+found",
         ".runtime-generations-control",
         "runtime-generations",
@@ -357,6 +358,7 @@ def test_host_paths_allow_known_controller_entries_during_product_migration(
     for name in (
         "bootstrap",
         "bun",
+        "install",
         "lost+found",
         ".runtime-generations-control",
         "runtime-generations",


### PR DESCRIPTION
## Summary
- recognize the installer-owned `install` directory as trusted controller data
- keep rejecting unknown entries, symlinks, and non-directory controller entries

## Verification
- `uv run --isolated --frozen --all-extras -- pytest -q tests/test_host_cli.py -k host_paths` (`7 passed`)
- `uv run --isolated --frozen --all-extras -- ruff check src/opentulpa/host/paths.py tests/test_host_cli.py`

Independent review was unavailable; direct fallback review confirmed this matches the existing controller-directory migration policy.