### PR TITLE
Export live source from installed launchers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -903,10 +903,19 @@ import sys
 print(shlex.quote(sys.argv[1]))
 PY
   )
+  source_root_shell=$(
+    "$PYTHON_BIN" - "$SOURCE_ROOT" <<'PY'
+import shlex
+import sys
+
+print(shlex.quote(sys.argv[1]))
+PY
+  )
   {
     printf '%s\n' '#!/bin/sh'
     printf '%s\n' "bootstrap_python=${bootstrap_python_shell}"
     printf '%s\n' "bootstrap_python_sha256=${BOOTSTRAP_PYTHON_SHA256}"
+    printf '%s\n' "source_root=${source_root_shell}"
     cat <<'DISPATCHER'
 set -eu
 
@@ -1158,6 +1167,7 @@ source_seed=$(CDPATH= cd "${generation}/source-seed" && pwd -P) || {
   exit 1
 }
 export OPENTULPA_INSTALL_ROOT="$install_root"
+export OPENTULPA_SOURCE_ROOT="$source_root"
 export OPENTULPA_SOURCE_SEED_ROOT="$source_seed"
 export OPENTULPA_SOURCE_SEED_OID="$source_oid"
 export OPENTULPA_SOURCE_SEED_SHA256="$source_seed_sha256"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -219,7 +219,8 @@ elif args[:2] == ["pip", "install"]:
             "import json, os, pathlib, sys\\n"
             "if len(sys.argv) == 3 and sys.argv[1] == '--probe':\\n"
             "    pathlib.Path(sys.argv[2]).write_text(json.dumps({{k: os.environ.get(k) for k in "
-            "['OPENTULPA_INSTALL_ROOT', 'OPENTULPA_SOURCE_SEED_ROOT', "
+            "['OPENTULPA_INSTALL_ROOT', 'OPENTULPA_SOURCE_ROOT', "
+            "'OPENTULPA_SOURCE_SEED_ROOT', "
             "'OPENTULPA_TRUSTED_WHEELHOUSE', 'OPENTULPA_INSTALL_ASSETS_ROOT', "
             "'OPENTULPA_UV_BIN', 'OPENTULPA_SOURCE_SEED_OID', "
             "'OPENTULPA_SOURCE_SEED_SHA256', 'OPENTULPA_SOURCE_SEED_TREE_OID']}}), "
@@ -357,6 +358,7 @@ def test_installer_builds_final_path_controller_and_exact_dispatcher(tmp_path: P
     environment = json.loads(probe.read_text(encoding="utf-8"))
     assert environment == {
         "OPENTULPA_INSTALL_ROOT": str(tmp_path / "install root"),
+        "OPENTULPA_SOURCE_ROOT": str(source),
         "OPENTULPA_SOURCE_SEED_ROOT": str(generation / "source-seed"),
         "OPENTULPA_TRUSTED_WHEELHOUSE": str(generation / "wheelhouse"),
         "OPENTULPA_INSTALL_ASSETS_ROOT": str(generation / "assets"),


### PR DESCRIPTION
## Summary
- export the installer-validated Git source root from generated command dispatchers
- let bare installs satisfy the v3.1 live-source startup contract
- preserve shell-safe handling for source paths containing spaces

## Verification
- `uv run --isolated --frozen --all-extras -- pytest -q tests/test_install_script.py` (`19 passed`)
- `uv run --isolated --frozen --all-extras -- ruff check tests/test_install_script.py`
- `sh -n install.sh`
- real isolated install and `opentulpa-host` launch reached healthy state through the generated dispatcher
- Telegram/prompt/secret focused suite: `73 passed`

Independent review found the missing dispatcher export as the only bare-VPS blocker; this patch addresses it.